### PR TITLE
Fix missing header guard

### DIFF
--- a/scratch_pool.hpp
+++ b/scratch_pool.hpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#pragma once
+
 namespace dxil_spv
 {
 template <typename T>


### PR DESCRIPTION
Fixes error with `meson ... --unity=on ...` build.