### PR TITLE
Fixup SSA variables which have their dominance broken

### DIFF
--- a/cfg_structurizer.hpp
+++ b/cfg_structurizer.hpp
@@ -130,6 +130,8 @@ private:
 	void eliminate_node_link_preds_to_succ(CFGNode *node);
 	void prune_dead_preds();
 
+	void fixup_broken_value_dominance();
+
 	UnorderedMap<uint32_t, CFGNode *> value_id_to_block;
 
 	void log_cfg(const char *tag) const;

--- a/opcodes/dxil/dxil_arithmetic.cpp
+++ b/opcodes/dxil/dxil_arithmetic.cpp
@@ -43,9 +43,9 @@ bool emit_fmad_instruction(Converter::Impl &impl, const llvm::CallInst *instruct
 		impl.glsl_std450_ext = builder.import("GLSL.std.450");
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
+	op->add_id(impl.glsl_std450_ext);
+	op->add_literal(GLSLstd450Fma);
 	op->add_ids({
-	    impl.glsl_std450_ext,
-	    GLSLstd450Fma,
 	    impl.get_id_for_value(instruction->getOperand(1)),
 	    impl.get_id_for_value(instruction->getOperand(2)),
 	    impl.get_id_for_value(instruction->getOperand(3)),
@@ -91,8 +91,9 @@ bool emit_find_high_bit_instruction(GLSLstd450 opcode, Converter::Impl &impl, co
 	// This is actually CLZ, and not FindMSB.
 	Operation *msb_op = impl.allocate(spv::OpExtInst, impl.get_type_id(instruction->getType()));
 	{
-		msb_op->add_ids(
-		    { impl.glsl_std450_ext, static_cast<spv::Id>(opcode), impl.get_id_for_value(instruction->getOperand(1)) });
+		msb_op->add_id(impl.glsl_std450_ext);
+		msb_op->add_literal(opcode);
+		msb_op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 		impl.add(msb_op);
 	}
 
@@ -121,8 +122,12 @@ bool emit_dxil_std450_binary_instruction(GLSLstd450 opcode, Converter::Impl &imp
 		impl.glsl_std450_ext = builder.import("GLSL.std.450");
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
-	op->add_ids({ impl.glsl_std450_ext, static_cast<spv::Id>(opcode), impl.get_id_for_value(instruction->getOperand(1)),
-	              impl.get_id_for_value(instruction->getOperand(2)) });
+	op->add_id(impl.glsl_std450_ext);
+	op->add_literal(opcode);
+	op->add_ids({
+		            impl.get_id_for_value(instruction->getOperand(1)),
+		            impl.get_id_for_value(instruction->getOperand(2))
+	            });
 
 	impl.add(op);
 	return true;
@@ -135,7 +140,9 @@ bool emit_dxil_std450_trinary_instruction(GLSLstd450 opcode, Converter::Impl &im
 		impl.glsl_std450_ext = builder.import("GLSL.std.450");
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
-	op->add_ids({ impl.glsl_std450_ext, static_cast<spv::Id>(opcode), impl.get_id_for_value(instruction->getOperand(1)),
+	op->add_id(impl.glsl_std450_ext);
+	op->add_literal(opcode);
+	op->add_ids({ impl.get_id_for_value(instruction->getOperand(1)),
 	              impl.get_id_for_value(instruction->getOperand(2)),
 	              impl.get_id_for_value(instruction->getOperand(3)) });
 
@@ -150,8 +157,9 @@ bool emit_dxil_std450_unary_instruction(GLSLstd450 opcode, Converter::Impl &impl
 		impl.glsl_std450_ext = builder.import("GLSL.std.450");
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
-	op->add_ids(
-	    { impl.glsl_std450_ext, static_cast<spv::Id>(opcode), impl.get_id_for_value(instruction->getOperand(1)) });
+	op->add_id(impl.glsl_std450_ext);
+	op->add_literal(opcode);
+	op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 
 	impl.add(op);
 	return true;
@@ -195,7 +203,9 @@ bool emit_saturate_instruction(Converter::Impl &impl, const llvm::CallInst *inst
 	}
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
-	op->add_ids({ impl.glsl_std450_ext, GLSLstd450NClamp, impl.get_id_for_value(instruction->getOperand(1)),
+	op->add_id(impl.glsl_std450_ext);
+	op->add_literal(GLSLstd450NClamp);
+	op->add_ids({ impl.get_id_for_value(instruction->getOperand(1)),
 	              constant_0, constant_1 });
 
 	impl.add(op);
@@ -267,7 +277,7 @@ bool emit_make_double_instruction(Converter::Impl &impl, const llvm::CallInst *i
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
 	op->add_id(impl.glsl_std450_ext);
-	op->add_id(GLSLstd450PackDouble2x32);
+	op->add_literal(GLSLstd450PackDouble2x32);
 
 	spv::Id inputs[2];
 	for (unsigned i = 0; i < 2; i++)
@@ -286,7 +296,7 @@ bool emit_split_double_instruction(Converter::Impl &impl, const llvm::CallInst *
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction, builder.makeVectorType(builder.makeUintType(32), 2));
 	op->add_id(impl.glsl_std450_ext);
-	op->add_id(GLSLstd450UnpackDouble2x32);
+	op->add_literal(GLSLstd450UnpackDouble2x32);
 	op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 	impl.add(op);
 	return true;
@@ -300,7 +310,7 @@ bool emit_legacy_f16_to_f32_instruction(Converter::Impl &impl, const llvm::CallI
 
 	Operation *unpack_op = impl.allocate(spv::OpExtInst, builder.makeVectorType(builder.makeFloatType(32), 2));
 	unpack_op->add_id(impl.glsl_std450_ext);
-	unpack_op->add_id(GLSLstd450UnpackHalf2x16);
+	unpack_op->add_literal(GLSLstd450UnpackHalf2x16);
 	unpack_op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 	impl.add(unpack_op);
 
@@ -319,7 +329,7 @@ bool emit_legacy_f32_to_f16_instruction(Converter::Impl &impl, const llvm::CallI
 
 	Operation *op = impl.allocate(spv::OpExtInst, instruction);
 	op->add_id(impl.glsl_std450_ext);
-	op->add_id(GLSLstd450PackHalf2x16);
+	op->add_literal(GLSLstd450PackHalf2x16);
 
 	spv::Id inputs[2] = { impl.get_id_for_value(instruction->getOperand(1)), builder.makeFloatConstant(0.0f) };
 	op->add_id(impl.build_vector(builder.makeFloatType(32), inputs, 2));

--- a/opcodes/dxil/dxil_resources.cpp
+++ b/opcodes/dxil/dxil_resources.cpp
@@ -347,11 +347,9 @@ bool emit_interpolate_instruction(GLSLstd450 opcode, Converter::Impl &impl, cons
 
 	// Need to deal with signed vs unsigned here.
 	Operation *op = impl.allocate(spv::OpExtInst, instruction, impl.get_type_id(meta.component_type, 1, 1));
-	op->add_ids({
-	    impl.glsl_std450_ext,
-	    static_cast<spv::Id>(opcode),
-	    ptr_id,
-	});
+	op->add_id(impl.glsl_std450_ext);
+	op->add_literal(opcode);
+	op->add_id(ptr_id);
 
 	if (aux_id)
 		op->add_id(aux_id);

--- a/reference/shaders/control-flow/dual-inner-loop-early-return.comp
+++ b/reference/shaders/control-flow/dual-inner-loop-early-return.comp
@@ -3,13 +3,14 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _8;
 
-uint _50;
+uint _52;
 
 void main()
 {
     uint _23;
     uint _25;
     uint _37;
+    uint _49;
     for (;;)
     {
         _23 = 0u;
@@ -18,7 +19,6 @@ void main()
         uint _29;
         bool ladder_phi_8;
         uint frontier_phi_7_pred_pred;
-        uint frontier_phi_7_pred_pred_1;
         for (;;)
         {
             _27 = 0u;
@@ -29,8 +29,7 @@ void main()
                 if (_29 < 10u)
                 {
                     ladder_phi_7_pred = true;
-                    frontier_phi_7_pred_pred = gl_GlobalInvocationID.y;
-                    frontier_phi_7_pred_pred_1 = 50u;
+                    frontier_phi_7_pred_pred = 50u;
                     break;
                 }
                 else
@@ -38,14 +37,14 @@ void main()
                     if (gl_GlobalInvocationID.z < 10u)
                     {
                         ladder_phi_7_pred = true;
-                        frontier_phi_7_pred_pred = gl_GlobalInvocationID.y;
-                        frontier_phi_7_pred_pred_1 = 70u;
+                        frontier_phi_7_pred_pred = 70u;
                         break;
                     }
                     else
                     {
                         uint _26 = _29 + 1u;
                         uint _28 = _27 + 1u;
+                        _49 = _26;
                         if (int(_28) < int(20u))
                         {
                             _27 = _28;
@@ -55,8 +54,7 @@ void main()
                         else
                         {
                             ladder_phi_7_pred = false;
-                            frontier_phi_7_pred_pred = _26;
-                            frontier_phi_7_pred_pred_1 = _50;
+                            frontier_phi_7_pred_pred = _52;
                             break;
                         }
                     }
@@ -71,7 +69,7 @@ void main()
             if (int(_24) < int(10u))
             {
                 _23 = _24;
-                _25 = frontier_phi_7_pred_pred;
+                _25 = _49;
                 continue;
             }
             else
@@ -82,7 +80,7 @@ void main()
         }
         if (ladder_phi_8)
         {
-            _37 = frontier_phi_7_pred_pred_1;
+            _37 = frontier_phi_7_pred_pred;
             break;
         }
         _37 = 80u;
@@ -97,7 +95,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 69
+; Bound: 71
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -107,8 +105,7 @@ OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
 OpName %44 "ladder_phi_7.pred"
 OpName %47 "ladder_phi_8"
-OpName %48 "frontier_phi_7.pred.pred"
-OpName %49 "frontier_phi_7.pred.pred"
+OpName %51 "frontier_phi_7.pred.pred"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %8 NonReadable
@@ -135,11 +132,13 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %42 = OpConstant %5 20
 %45 = OpConstantFalse %30
 %46 = OpConstantTrue %30
+%48 = OpTypePointer Function %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-%50 = OpUndef %5
-OpBranch %51
-%51 = OpLabel
+%49 = OpVariable %48 Function
+%52 = OpUndef %5
+OpBranch %53
+%53 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
@@ -147,60 +146,61 @@ OpBranch %51
 %19 = OpLoad %5 %17
 %20 = OpAccessChain %13 %12 %21
 %22 = OpLoad %5 %20
-OpBranch %52
-%52 = OpLabel
-OpLoopMerge %65 %66 None
-OpBranch %53
-%53 = OpLabel
-%23 = OpPhi %5 %15 %52 %24 %62
-%25 = OpPhi %5 %19 %52 %48 %62
-OpLoopMerge %63 %62 None
 OpBranch %54
 %54 = OpLabel
-%27 = OpPhi %5 %15 %53 %28 %57
-%29 = OpPhi %5 %25 %53 %26 %57
-%31 = OpULessThan %30 %29 %32
-OpLoopMerge %60 %57 None
-OpBranchConditional %31 %59 %55
-%59 = OpLabel
-OpBranch %60
+OpLoopMerge %67 %68 None
+OpBranch %55
 %55 = OpLabel
-%36 = OpULessThan %30 %22 %32
-OpSelectionMerge %67 None
-OpBranchConditional %36 %58 %56
-%58 = OpLabel
-OpBranch %60
+%23 = OpPhi %5 %15 %54 %24 %64
+%25 = OpPhi %5 %19 %54 %50 %64
+OpLoopMerge %65 %64 None
+OpBranch %56
 %56 = OpLabel
-OpBranch %57
-%67 = OpLabel
-OpUnreachable
+%27 = OpPhi %5 %15 %55 %28 %59
+%29 = OpPhi %5 %25 %55 %26 %59
+%31 = OpULessThan %30 %29 %32
+OpLoopMerge %62 %59 None
+OpBranchConditional %31 %61 %57
+%61 = OpLabel
+OpBranch %62
 %57 = OpLabel
+%36 = OpULessThan %30 %22 %32
+OpSelectionMerge %69 None
+OpBranchConditional %36 %60 %58
+%60 = OpLabel
+OpBranch %62
+%58 = OpLabel
+OpBranch %59
+%69 = OpLabel
+OpUnreachable
+%59 = OpLabel
 %26 = OpIAdd %5 %29 %18
 %28 = OpIAdd %5 %27 %18
 %41 = OpSLessThan %30 %28 %42
-OpBranchConditional %41 %54 %60
-%60 = OpLabel
-%44 = OpPhi %30 %45 %57 %46 %58 %46 %59
-%48 = OpPhi %5 %26 %57 %19 %58 %19 %59
-%49 = OpPhi %5 %50 %57 %35 %58 %34 %59
-OpSelectionMerge %61 None
-OpBranchConditional %44 %63 %61
-%61 = OpLabel
-OpBranch %62
+OpStore %49 %26
+OpBranchConditional %41 %56 %62
 %62 = OpLabel
+%44 = OpPhi %30 %45 %59 %46 %60 %46 %61
+%51 = OpPhi %5 %52 %59 %35 %60 %34 %61
+OpSelectionMerge %63 None
+OpBranchConditional %44 %65 %63
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%50 = OpLoad %5 %49
 %24 = OpIAdd %5 %23 %18
 %43 = OpSLessThan %30 %24 %32
-OpBranchConditional %43 %53 %63
-%63 = OpLabel
-%47 = OpPhi %30 %45 %62 %46 %60
-OpSelectionMerge %64 None
-OpBranchConditional %47 %65 %64
-%64 = OpLabel
-OpBranch %65
-%66 = OpLabel
-OpBranch %52
+OpBranchConditional %43 %55 %65
 %65 = OpLabel
-%37 = OpPhi %5 %38 %64 %49 %63
+%47 = OpPhi %30 %45 %64 %46 %62
+OpSelectionMerge %66 None
+OpBranchConditional %47 %67 %66
+%66 = OpLabel
+OpBranch %67
+%68 = OpLabel
+OpBranch %54
+%67 = OpLabel
+%37 = OpPhi %5 %38 %66 %51 %65
 %40 = OpCompositeConstruct %39 %37 %37 %37 %37
 OpImageWrite %9 %16 %40
 OpReturn

--- a/reference/shaders/control-flow/loop-break-2.comp
+++ b/reference/shaders/control-flow/loop-break-2.comp
@@ -12,6 +12,7 @@ void main()
     }
     else
     {
+        uint _39;
         uint frontier_phi_6;
         uint _25 = 0u;
         uint _26 = 0u;
@@ -28,6 +29,7 @@ void main()
             {
                 uint _22 = _30 + _25;
                 uint _27 = _26 + 1u;
+                _39 = _22;
                 if (_27 < gl_GlobalInvocationID.z)
                 {
                     _25 = _22;
@@ -36,7 +38,7 @@ void main()
                 }
                 else
                 {
-                    frontier_phi_6 = _22;
+                    frontier_phi_6 = 0u;
                     break;
                 }
             }
@@ -52,7 +54,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 48
+; Bound: 51
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -60,7 +62,7 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "main" %12
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
-OpName %38 "frontier_phi_6"
+OpName %41 "frontier_phi_6"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %12 BuiltIn GlobalInvocationId
@@ -81,44 +83,48 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %32 = OpConstant %5 30
 %33 = OpConstant %5 25
 %36 = OpConstant %5 1
+%38 = OpTypePointer Function %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %39
-%39 = OpLabel
+%39 = OpVariable %38 Function
+OpBranch %42
+%42 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
 %18 = OpIEqual %17 %16 %19
-OpSelectionMerge %46 None
-OpBranchConditional %18 %46 %40
-%40 = OpLabel
-OpBranch %41
-%41 = OpLabel
-%25 = OpPhi %5 %19 %40 %22 %43
-%26 = OpPhi %5 %19 %40 %27 %43
+OpSelectionMerge %49 None
+OpBranchConditional %18 %49 %43
+%43 = OpLabel
+OpBranch %44
+%44 = OpLabel
+%25 = OpPhi %5 %19 %43 %22 %46
+%26 = OpPhi %5 %19 %43 %27 %46
 %28 = OpShiftLeftLogical %5 %26 %15
 %29 = OpImageRead %23 %9 %26
 %30 = OpCompositeExtract %5 %29 0
 %31 = OpIEqual %17 %30 %32
-OpLoopMerge %45 %43 None
-OpBranchConditional %31 %44 %42
-%44 = OpLabel
+OpLoopMerge %48 %46 None
+OpBranchConditional %31 %47 %45
+%47 = OpLabel
 %34 = OpImageRead %23 %9 %33
 %35 = OpCompositeExtract %5 %34 0
 %21 = OpIAdd %5 %35 %25
-OpBranch %45
-%42 = OpLabel
-OpBranch %43
-%43 = OpLabel
+OpBranch %48
+%45 = OpLabel
+OpBranch %46
+%46 = OpLabel
 %22 = OpIAdd %5 %30 %25
 %27 = OpIAdd %5 %26 %36
 %37 = OpULessThan %17 %27 %16
-OpBranchConditional %37 %41 %45
-%45 = OpLabel
-%38 = OpPhi %5 %22 %43 %21 %44
-OpBranch %46
-%46 = OpLabel
-%20 = OpPhi %5 %19 %39 %38 %45
+OpStore %39 %22
+OpBranchConditional %37 %44 %48
+%48 = OpLabel
+%41 = OpPhi %5 %19 %46 %21 %47
+%40 = OpLoad %5 %39
+OpBranch %49
+%49 = OpLabel
+%20 = OpPhi %5 %19 %42 %41 %48
 %24 = OpCompositeConstruct %23 %20 %20 %20 %20
 OpImageWrite %9 %19 %24
 OpReturn

--- a/reference/shaders/control-flow/loop-break.comp
+++ b/reference/shaders/control-flow/loop-break.comp
@@ -12,6 +12,7 @@ void main()
     }
     else
     {
+        uint _36;
         uint frontier_phi_4_break_5;
         uint _24 = 0u;
         uint _26 = 0u;
@@ -28,6 +29,7 @@ void main()
             {
                 uint _25 = _30 + _24;
                 uint _27 = _26 + 1u;
+                _36 = _25;
                 if (_27 < gl_GlobalInvocationID.z)
                 {
                     _24 = _25;
@@ -36,7 +38,7 @@ void main()
                 }
                 else
                 {
-                    frontier_phi_4_break_5 = _25;
+                    frontier_phi_4_break_5 = 0u;
                     break;
                 }
             }
@@ -52,7 +54,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 45
+; Bound: 48
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -60,7 +62,7 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "main" %12
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
-OpName %35 "frontier_phi_4.break.5"
+OpName %38 "frontier_phi_4.break.5"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %12 BuiltIn GlobalInvocationId
@@ -80,41 +82,45 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %22 = OpTypeVector %5 4
 %32 = OpConstant %5 30
 %33 = OpConstant %5 1
+%35 = OpTypePointer Function %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %36
-%36 = OpLabel
+%36 = OpVariable %35 Function
+OpBranch %39
+%39 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
 %18 = OpIEqual %17 %16 %19
-OpSelectionMerge %43 None
-OpBranchConditional %18 %43 %37
-%37 = OpLabel
-OpBranch %38
-%38 = OpLabel
-%24 = OpPhi %5 %19 %37 %25 %40
-%26 = OpPhi %5 %19 %37 %27 %40
+OpSelectionMerge %46 None
+OpBranchConditional %18 %46 %40
+%40 = OpLabel
+OpBranch %41
+%41 = OpLabel
+%24 = OpPhi %5 %19 %40 %25 %43
+%26 = OpPhi %5 %19 %40 %27 %43
 %28 = OpShiftLeftLogical %5 %26 %15
 %29 = OpImageRead %22 %9 %26
 %30 = OpCompositeExtract %5 %29 0
 %31 = OpIEqual %17 %30 %32
-OpLoopMerge %42 %40 None
-OpBranchConditional %31 %41 %39
-%41 = OpLabel
-OpBranch %42
-%39 = OpLabel
-OpBranch %40
-%40 = OpLabel
+OpLoopMerge %45 %43 None
+OpBranchConditional %31 %44 %42
+%44 = OpLabel
+OpBranch %45
+%42 = OpLabel
+OpBranch %43
+%43 = OpLabel
 %25 = OpIAdd %5 %30 %24
 %27 = OpIAdd %5 %26 %33
 %34 = OpULessThan %17 %27 %16
-OpBranchConditional %34 %38 %42
-%42 = OpLabel
-%35 = OpPhi %5 %25 %40 %24 %41
-OpBranch %43
-%43 = OpLabel
-%20 = OpPhi %5 %19 %36 %35 %42
+OpStore %36 %25
+OpBranchConditional %34 %41 %45
+%45 = OpLabel
+%38 = OpPhi %5 %19 %43 %24 %44
+%37 = OpLoad %5 %36
+OpBranch %46
+%46 = OpLabel
+%20 = OpPhi %5 %19 %39 %38 %45
 %23 = OpCompositeConstruct %22 %20 %20 %20 %20
 OpImageWrite %9 %19 %23
 OpReturn

--- a/reference/shaders/control-flow/loop-return.comp
+++ b/reference/shaders/control-flow/loop-return.comp
@@ -18,6 +18,9 @@ void main()
             uint _35;
             _35 = 0u;
             uint _31;
+            uint _85;
+            uint _89;
+            uint frontier_phi_8_pred_1;
             uint frontier_phi_12;
             uint _37 = 0u;
             bool _38;
@@ -25,7 +28,6 @@ void main()
             {
                 _38 = gl_GlobalInvocationID.y == 0u;
                 uint frontier_phi_8_pred;
-                uint frontier_phi_8_pred_1;
                 if (_38)
                 {
                     frontier_phi_8_pred = _37;
@@ -35,7 +37,6 @@ void main()
                 {
                     bool ladder_phi_20;
                     uint frontier_phi_20_pred;
-                    uint frontier_phi_20_pred_1;
                     uint _47 = _37;
                     uint _48 = 0u;
                     for (;;)
@@ -44,14 +45,14 @@ void main()
                         if (imageLoad(_8, int(_50)).x == 100u)
                         {
                             ladder_phi_20 = true;
-                            frontier_phi_20_pred = _37;
-                            frontier_phi_20_pred_1 = imageLoad(_8, int(32u)).x + _47;
+                            frontier_phi_20_pred = imageLoad(_8, int(32u)).x + _47;
                             break;
                         }
                         else
                         {
                             uint _43 = imageLoad(_8, int(((_35 << 2u) * _48) >> 2u)).x + _47;
                             uint _49 = _48 + 1u;
+                            _89 = _43;
                             if (_49 < gl_GlobalInvocationID.y)
                             {
                                 _47 = _43;
@@ -61,22 +62,22 @@ void main()
                             else
                             {
                                 ladder_phi_20 = false;
-                                frontier_phi_20_pred = _43;
-                                frontier_phi_20_pred_1 = 0u;
+                                frontier_phi_20_pred = 0u;
                                 break;
                             }
                         }
                     }
                     if (ladder_phi_20)
                     {
-                        frontier_phi_12 = frontier_phi_20_pred_1;
+                        frontier_phi_12 = frontier_phi_20_pred;
                         break;
                     }
-                    frontier_phi_8_pred = frontier_phi_20_pred;
-                    frontier_phi_8_pred_1 = frontier_phi_20_pred_1;
+                    frontier_phi_8_pred = _89;
+                    frontier_phi_8_pred_1 = frontier_phi_20_pred;
                 }
                 _31 = frontier_phi_8_pred;
                 uint _36 = _35 + 1u;
+                _85 = _31;
                 if (_36 < gl_GlobalInvocationID.x)
                 {
                     _35 = _36;
@@ -85,7 +86,7 @@ void main()
                 }
                 else
                 {
-                    frontier_phi_12 = _31;
+                    frontier_phi_12 = frontier_phi_8_pred_1;
                     break;
                 }
             }
@@ -105,6 +106,9 @@ void main()
             uint _39;
             _39 = 0u;
             uint _32;
+            uint _87;
+            uint _91;
+            uint frontier_phi_10_pred_1;
             uint frontier_phi_14;
             uint _41 = 0u;
             bool _42;
@@ -112,7 +116,6 @@ void main()
             {
                 _42 = gl_GlobalInvocationID.y == 0u;
                 uint frontier_phi_10_pred;
-                uint frontier_phi_10_pred_1;
                 if (_42)
                 {
                     frontier_phi_10_pred = _41;
@@ -122,7 +125,6 @@ void main()
                 {
                     bool ladder_phi_21;
                     uint frontier_phi_21_pred;
-                    uint frontier_phi_21_pred_1;
                     uint _55 = 0u;
                     uint _57 = _41;
                     for (;;)
@@ -131,14 +133,14 @@ void main()
                         if (imageLoad(_8, int(_58)).x == 100u)
                         {
                             ladder_phi_21 = true;
-                            frontier_phi_21_pred = _41;
-                            frontier_phi_21_pred_1 = imageLoad(_8, int(32u)).x + _57;
+                            frontier_phi_21_pred = imageLoad(_8, int(32u)).x + _57;
                             break;
                         }
                         else
                         {
                             uint _45 = imageLoad(_8, int(((_39 << 2u) * _55) >> 2u)).x + _57;
                             uint _56 = _55 + 1u;
+                            _91 = _45;
                             if (_56 < gl_GlobalInvocationID.y)
                             {
                                 _55 = _56;
@@ -148,22 +150,22 @@ void main()
                             else
                             {
                                 ladder_phi_21 = false;
-                                frontier_phi_21_pred = _45;
-                                frontier_phi_21_pred_1 = 0u;
+                                frontier_phi_21_pred = 0u;
                                 break;
                             }
                         }
                     }
                     if (ladder_phi_21)
                     {
-                        frontier_phi_14 = frontier_phi_21_pred_1;
+                        frontier_phi_14 = frontier_phi_21_pred;
                         break;
                     }
-                    frontier_phi_10_pred = frontier_phi_21_pred;
-                    frontier_phi_10_pred_1 = frontier_phi_21_pred_1;
+                    frontier_phi_10_pred = _91;
+                    frontier_phi_10_pred_1 = frontier_phi_21_pred;
                 }
                 _32 = frontier_phi_10_pred;
                 uint _40 = _39 + 1u;
+                _87 = _32;
                 if (_40 < gl_GlobalInvocationID.z)
                 {
                     _39 = _40;
@@ -172,7 +174,7 @@ void main()
                 }
                 else
                 {
-                    frontier_phi_14 = _32;
+                    frontier_phi_14 = frontier_phi_10_pred_1;
                     break;
                 }
             }
@@ -189,7 +191,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 129
+; Bound: 136
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -199,18 +201,16 @@ OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
 OpName %80 "ladder_phi_20"
 OpName %83 "ladder_phi_21"
-OpName %84 "frontier_phi_21.pred"
-OpName %85 "frontier_phi_10.pred"
-OpName %86 "frontier_phi_20.pred"
-OpName %87 "frontier_phi_8.pred"
-OpName %88 "frontier_phi_21.pred"
-OpName %89 "frontier_phi_10.pred"
-OpName %90 "frontier_phi_14"
-OpName %91 "frontier_phi_3.2.ladder"
-OpName %92 "frontier_phi_20.pred"
-OpName %93 "frontier_phi_8.pred"
-OpName %94 "frontier_phi_12"
-OpName %95 "frontier_phi_3.1.ladder"
+OpName %93 "frontier_phi_10.pred"
+OpName %94 "frontier_phi_8.pred"
+OpName %95 "frontier_phi_21.pred"
+OpName %96 "frontier_phi_10.pred"
+OpName %97 "frontier_phi_14"
+OpName %98 "frontier_phi_3.2.ladder"
+OpName %99 "frontier_phi_20.pred"
+OpName %100 "frontier_phi_8.pred"
+OpName %101 "frontier_phi_12"
+OpName %102 "frontier_phi_3.1.ladder"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %12 BuiltIn GlobalInvocationId
@@ -233,10 +233,15 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %63 = OpConstant %5 32
 %81 = OpConstantFalse %23
 %82 = OpConstantTrue %23
+%84 = OpTypePointer Function %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %96
-%96 = OpLabel
+%85 = OpVariable %84 Function
+%87 = OpVariable %84 Function
+%89 = OpVariable %84 Function
+%91 = OpVariable %84 Function
+OpBranch %103
+%103 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
@@ -245,43 +250,43 @@ OpBranch %96
 %20 = OpAccessChain %13 %12 %21
 %22 = OpLoad %5 %20
 %24 = OpULessThan %23 %16 %25
-OpSelectionMerge %127 None
-OpBranchConditional %24 %112 %97
-%112 = OpLabel
+OpSelectionMerge %134 None
+OpBranchConditional %24 %119 %104
+%119 = OpLabel
 %26 = OpIEqual %23 %16 %15
-OpSelectionMerge %126 None
-OpBranchConditional %26 %126 %113
-%113 = OpLabel
-OpBranch %114
-%114 = OpLabel
-%35 = OpPhi %5 %15 %113 %36 %124
-%37 = OpPhi %5 %15 %113 %31 %124
+OpSelectionMerge %133 None
+OpBranchConditional %26 %133 %120
+%120 = OpLabel
+OpBranch %121
+%121 = OpLabel
+%35 = OpPhi %5 %15 %120 %36 %131
+%37 = OpPhi %5 %15 %120 %31 %131
 %38 = OpIEqual %23 %19 %15
-OpLoopMerge %125 %124 None
-OpBranch %115
-%115 = OpLabel
-OpSelectionMerge %123 None
-OpBranchConditional %38 %123 %116
-%116 = OpLabel
-OpBranch %117
-%117 = OpLabel
-%47 = OpPhi %5 %37 %116 %43 %119
-%48 = OpPhi %5 %15 %116 %49 %119
+OpLoopMerge %132 %131 None
+OpBranch %122
+%122 = OpLabel
+OpSelectionMerge %130 None
+OpBranchConditional %38 %130 %123
+%123 = OpLabel
+OpBranch %124
+%124 = OpLabel
+%47 = OpPhi %5 %37 %123 %43 %126
+%48 = OpPhi %5 %15 %123 %49 %126
 %50 = OpBitwiseXor %5 %48 %35
 %51 = OpShiftLeftLogical %5 %50 %21
 %52 = OpImageRead %33 %9 %50
 %53 = OpCompositeExtract %5 %52 0
 %54 = OpIEqual %23 %53 %25
-OpLoopMerge %121 %119 None
-OpBranchConditional %54 %120 %118
-%120 = OpLabel
+OpLoopMerge %128 %126 None
+OpBranchConditional %54 %127 %125
+%127 = OpLabel
 %64 = OpImageRead %33 %9 %63
 %65 = OpCompositeExtract %5 %64 0
 %29 = OpIAdd %5 %65 %47
-OpBranch %121
-%118 = OpLabel
-OpBranch %119
-%119 = OpLabel
+OpBranch %128
+%125 = OpLabel
+OpBranch %126
+%126 = OpLabel
 %66 = OpShiftLeftLogical %5 %35 %21
 %67 = OpIMul %5 %66 %48
 %68 = OpShiftRightLogical %5 %67 %21
@@ -290,65 +295,68 @@ OpBranch %119
 %43 = OpIAdd %5 %70 %47
 %49 = OpIAdd %5 %48 %18
 %71 = OpULessThan %23 %49 %19
-OpBranchConditional %71 %117 %121
-%121 = OpLabel
-%80 = OpPhi %23 %81 %119 %82 %120
-%86 = OpPhi %5 %43 %119 %37 %120
-%92 = OpPhi %5 %15 %119 %29 %120
-OpSelectionMerge %122 None
-OpBranchConditional %80 %125 %122
-%122 = OpLabel
-OpBranch %123
-%123 = OpLabel
-%87 = OpPhi %5 %37 %115 %86 %122
-%93 = OpPhi %5 %15 %115 %92 %122
-%31 = OpCopyObject %5 %87
-OpBranch %124
-%124 = OpLabel
+OpStore %89 %43
+OpBranchConditional %71 %124 %128
+%128 = OpLabel
+%80 = OpPhi %23 %81 %126 %82 %127
+%99 = OpPhi %5 %15 %126 %29 %127
+OpSelectionMerge %129 None
+OpBranchConditional %80 %132 %129
+%129 = OpLabel
+%90 = OpLoad %5 %89
+OpBranch %130
+%130 = OpLabel
+%94 = OpPhi %5 %37 %122 %90 %129
+%100 = OpPhi %5 %15 %122 %99 %129
+%31 = OpCopyObject %5 %94
+OpBranch %131
+%131 = OpLabel
 %36 = OpIAdd %5 %35 %18
 %44 = OpULessThan %23 %36 %16
-OpBranchConditional %44 %114 %125
-%125 = OpLabel
-%94 = OpPhi %5 %31 %124 %92 %121
-OpBranch %126
-%126 = OpLabel
-%95 = OpPhi %5 %15 %112 %94 %125
-OpBranch %127
-%97 = OpLabel
+OpStore %85 %31
+OpBranchConditional %44 %121 %132
+%132 = OpLabel
+%101 = OpPhi %5 %100 %131 %99 %128
+%86 = OpLoad %5 %85
+OpBranch %133
+%133 = OpLabel
+%102 = OpPhi %5 %15 %119 %101 %132
+OpBranch %134
+%104 = OpLabel
 %27 = OpIEqual %23 %22 %15
-OpSelectionMerge %111 None
-OpBranchConditional %27 %111 %98
-%98 = OpLabel
-OpBranch %99
-%99 = OpLabel
-%39 = OpPhi %5 %15 %98 %40 %109
-%41 = OpPhi %5 %15 %98 %32 %109
+OpSelectionMerge %118 None
+OpBranchConditional %27 %118 %105
+%105 = OpLabel
+OpBranch %106
+%106 = OpLabel
+%39 = OpPhi %5 %15 %105 %40 %116
+%41 = OpPhi %5 %15 %105 %32 %116
 %42 = OpIEqual %23 %19 %15
-OpLoopMerge %110 %109 None
-OpBranch %100
-%100 = OpLabel
-OpSelectionMerge %108 None
-OpBranchConditional %42 %108 %101
-%101 = OpLabel
-OpBranch %102
-%102 = OpLabel
-%55 = OpPhi %5 %15 %101 %56 %104
-%57 = OpPhi %5 %41 %101 %45 %104
+OpLoopMerge %117 %116 None
+OpBranch %107
+%107 = OpLabel
+OpSelectionMerge %115 None
+OpBranchConditional %42 %115 %108
+%108 = OpLabel
+OpBranch %109
+%109 = OpLabel
+%55 = OpPhi %5 %15 %108 %56 %111
+%57 = OpPhi %5 %41 %108 %45 %111
 %58 = OpBitwiseXor %5 %55 %39
 %59 = OpShiftLeftLogical %5 %58 %21
 %60 = OpImageRead %33 %9 %58
 %61 = OpCompositeExtract %5 %60 0
 %62 = OpIEqual %23 %61 %25
-OpLoopMerge %106 %104 None
-OpBranchConditional %62 %105 %103
-%105 = OpLabel
+OpLoopMerge %113 %111 None
+OpBranchConditional %62 %112 %110
+%112 = OpLabel
 %72 = OpImageRead %33 %9 %63
 %73 = OpCompositeExtract %5 %72 0
 %30 = OpIAdd %5 %73 %57
-OpBranch %106
-%103 = OpLabel
-OpBranch %104
-%104 = OpLabel
+OpBranch %113
+%110 = OpLabel
+OpBranch %111
+%111 = OpLabel
 %74 = OpShiftLeftLogical %5 %39 %21
 %75 = OpIMul %5 %74 %55
 %76 = OpShiftRightLogical %5 %75 %21
@@ -357,32 +365,35 @@ OpBranch %104
 %45 = OpIAdd %5 %78 %57
 %56 = OpIAdd %5 %55 %18
 %79 = OpULessThan %23 %56 %19
-OpBranchConditional %79 %102 %106
-%106 = OpLabel
-%83 = OpPhi %23 %81 %104 %82 %105
-%84 = OpPhi %5 %45 %104 %41 %105
-%88 = OpPhi %5 %15 %104 %30 %105
-OpSelectionMerge %107 None
-OpBranchConditional %83 %110 %107
-%107 = OpLabel
-OpBranch %108
-%108 = OpLabel
-%85 = OpPhi %5 %41 %100 %84 %107
-%89 = OpPhi %5 %15 %100 %88 %107
-%32 = OpCopyObject %5 %85
-OpBranch %109
-%109 = OpLabel
+OpStore %91 %45
+OpBranchConditional %79 %109 %113
+%113 = OpLabel
+%83 = OpPhi %23 %81 %111 %82 %112
+%95 = OpPhi %5 %15 %111 %30 %112
+OpSelectionMerge %114 None
+OpBranchConditional %83 %117 %114
+%114 = OpLabel
+%92 = OpLoad %5 %91
+OpBranch %115
+%115 = OpLabel
+%93 = OpPhi %5 %41 %107 %92 %114
+%96 = OpPhi %5 %15 %107 %95 %114
+%32 = OpCopyObject %5 %93
+OpBranch %116
+%116 = OpLabel
 %40 = OpIAdd %5 %39 %18
 %46 = OpULessThan %23 %40 %22
-OpBranchConditional %46 %99 %110
-%110 = OpLabel
-%90 = OpPhi %5 %32 %109 %88 %106
-OpBranch %111
-%111 = OpLabel
-%91 = OpPhi %5 %15 %97 %90 %110
-OpBranch %127
-%127 = OpLabel
-%28 = OpPhi %5 %91 %111 %95 %126
+OpStore %87 %32
+OpBranchConditional %46 %106 %117
+%117 = OpLabel
+%97 = OpPhi %5 %96 %116 %95 %113
+%88 = OpLoad %5 %87
+OpBranch %118
+%118 = OpLabel
+%98 = OpPhi %5 %15 %104 %97 %117
+OpBranch %134
+%134 = OpLabel
+%28 = OpPhi %5 %98 %118 %102 %133
 %34 = OpCompositeConstruct %33 %28 %28 %28 %28
 OpImageWrite %9 %15 %34
 OpReturn

--- a/reference/shaders/control-flow/nested-loop-break-2.comp
+++ b/reference/shaders/control-flow/nested-loop-break-2.comp
@@ -13,9 +13,11 @@ void main()
     else
     {
         uint _27;
+        uint _29;
         _27 = 0u;
+        _29 = 0u;
         uint _24;
-        uint _29 = 0u;
+        uint _53;
         bool _30;
         for (;;)
         {
@@ -42,6 +44,7 @@ void main()
                         uint _47 = _35 ^ _27;
                         uint _32 = imageLoad(_8, int(_47)).x + _34;
                         uint _36 = _35 + 1u;
+                        _53 = _32;
                         if (_36 < gl_GlobalInvocationID.z)
                         {
                             _34 = _32;
@@ -50,7 +53,7 @@ void main()
                         }
                         else
                         {
-                            frontier_phi_10 = _32;
+                            frontier_phi_10 = _29;
                             break;
                         }
                     }
@@ -81,7 +84,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 69
+; Bound: 72
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -89,8 +92,8 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "main" %12
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
-OpName %52 "frontier_phi_10"
-OpName %53 "frontier_phi_4.pred"
+OpName %55 "frontier_phi_10"
+OpName %56 "frontier_phi_4.pred"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %12 BuiltIn GlobalInvocationId
@@ -112,49 +115,51 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %38 = OpConstant %5 7
 %40 = OpConstant %5 32
 %44 = OpConstant %5 10
+%52 = OpTypePointer Function %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %54
-%54 = OpLabel
+%53 = OpVariable %52 Function
+OpBranch %57
+%57 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
 %17 = OpAccessChain %13 %12 %18
 %19 = OpLoad %5 %17
 %21 = OpIEqual %20 %16 %22
-OpSelectionMerge %67 None
-OpBranchConditional %21 %67 %55
-%55 = OpLabel
-OpBranch %56
-%56 = OpLabel
-%27 = OpPhi %5 %22 %55 %28 %65
-%29 = OpPhi %5 %22 %55 %24 %65
-%30 = OpIEqual %20 %19 %22
-OpLoopMerge %66 %65 None
-OpBranch %57
-%57 = OpLabel
-OpSelectionMerge %64 None
-OpBranchConditional %30 %64 %58
+OpSelectionMerge %70 None
+OpBranchConditional %21 %70 %58
 %58 = OpLabel
 OpBranch %59
 %59 = OpLabel
-%34 = OpPhi %5 %29 %58 %32 %61
-%35 = OpPhi %5 %22 %58 %36 %61
+%27 = OpPhi %5 %22 %58 %28 %68
+%29 = OpPhi %5 %22 %58 %24 %68
+%30 = OpIEqual %20 %19 %22
+OpLoopMerge %69 %68 None
+OpBranch %60
+%60 = OpLabel
+OpSelectionMerge %67 None
+OpBranchConditional %30 %67 %61
+%61 = OpLabel
+OpBranch %62
+%62 = OpLabel
+%34 = OpPhi %5 %29 %61 %32 %64
+%35 = OpPhi %5 %22 %61 %36 %64
 %37 = OpShiftLeftLogical %5 %35 %38
 %39 = OpIMul %5 %35 %40
 %41 = OpImageRead %25 %9 %39
 %42 = OpCompositeExtract %5 %41 0
 %43 = OpIEqual %20 %42 %44
-OpLoopMerge %63 %61 None
-OpBranchConditional %43 %62 %60
-%62 = OpLabel
+OpLoopMerge %66 %64 None
+OpBranchConditional %43 %65 %63
+%65 = OpLabel
 %45 = OpImageRead %25 %9 %18
 %46 = OpCompositeExtract %5 %45 0
 %31 = OpIAdd %5 %46 %34
-OpBranch %63
-%60 = OpLabel
-OpBranch %61
-%61 = OpLabel
+OpBranch %66
+%63 = OpLabel
+OpBranch %64
+%64 = OpLabel
 %47 = OpBitwiseXor %5 %35 %27
 %48 = OpShiftLeftLogical %5 %47 %18
 %49 = OpImageRead %25 %9 %47
@@ -162,22 +167,24 @@ OpBranch %61
 %32 = OpIAdd %5 %50 %34
 %36 = OpIAdd %5 %35 %15
 %51 = OpULessThan %20 %36 %19
-OpBranchConditional %51 %59 %63
-%63 = OpLabel
-%52 = OpPhi %5 %32 %61 %31 %62
-OpBranch %64
-%64 = OpLabel
-%53 = OpPhi %5 %29 %57 %52 %63
-%24 = OpCopyObject %5 %53
-OpBranch %65
-%65 = OpLabel
-%28 = OpIAdd %5 %27 %15
-%33 = OpIEqual %20 %28 %16
-OpBranchConditional %33 %66 %56
+OpStore %53 %32
+OpBranchConditional %51 %62 %66
 %66 = OpLabel
+%55 = OpPhi %5 %29 %64 %31 %65
+%54 = OpLoad %5 %53
 OpBranch %67
 %67 = OpLabel
-%23 = OpPhi %5 %22 %54 %24 %66
+%56 = OpPhi %5 %29 %60 %55 %66
+%24 = OpCopyObject %5 %56
+OpBranch %68
+%68 = OpLabel
+%28 = OpIAdd %5 %27 %15
+%33 = OpIEqual %20 %28 %16
+OpBranchConditional %33 %69 %59
+%69 = OpLabel
+OpBranch %70
+%70 = OpLabel
+%23 = OpPhi %5 %22 %57 %24 %69
 %26 = OpCompositeConstruct %25 %23 %23 %23 %23
 OpImageWrite %9 %22 %26
 OpReturn

--- a/reference/shaders/control-flow/nested-loop-break.comp
+++ b/reference/shaders/control-flow/nested-loop-break.comp
@@ -13,9 +13,12 @@ void main()
     else
     {
         uint _29;
+        uint _31;
         _29 = 0u;
+        _31 = 0u;
         uint _26;
-        uint _31 = 0u;
+        uint _70;
+        uint _72;
         bool _32;
         for (;;)
         {
@@ -28,10 +31,11 @@ void main()
             else
             {
                 uint _36;
+                uint _38;
                 _36 = 0u;
+                _38 = _31;
                 uint _34;
                 uint frontier_phi_12;
-                uint _38 = _31;
                 for (;;)
                 {
                     if (imageLoad(_8, int(_36 * 32u)).x == 10u)
@@ -63,6 +67,7 @@ void main()
                                     uint _64 = (_36 ^ _29) ^ _54;
                                     uint _51 = imageLoad(_8, int(_64)).x + _53;
                                     uint _55 = _54 + 1u;
+                                    _72 = _51;
                                     if (_55 < gl_GlobalInvocationID.z)
                                     {
                                         _53 = _51;
@@ -71,7 +76,7 @@ void main()
                                     }
                                     else
                                     {
-                                        frontier_phi_16 = _51;
+                                        frontier_phi_16 = _38;
                                         break;
                                     }
                                 }
@@ -80,6 +85,7 @@ void main()
                         }
                         _34 = frontier_phi_10_pred;
                         uint _37 = _36 + 1u;
+                        _70 = _34;
                         if (_37 < gl_GlobalInvocationID.y)
                         {
                             _36 = _37;
@@ -88,7 +94,7 @@ void main()
                         }
                         else
                         {
-                            frontier_phi_12 = _34;
+                            frontier_phi_12 = _31;
                             break;
                         }
                     }
@@ -119,7 +125,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 95
+; Bound: 100
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -127,10 +133,10 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "main" %12
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
-OpName %69 "frontier_phi_16"
-OpName %70 "frontier_phi_10.pred"
-OpName %71 "frontier_phi_12"
-OpName %72 "frontier_phi_4.pred"
+OpName %74 "frontier_phi_16"
+OpName %75 "frontier_phi_10.pred"
+OpName %76 "frontier_phi_12"
+OpName %77 "frontier_phi_4.pred"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %12 BuiltIn GlobalInvocationId
@@ -152,10 +158,13 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %40 = OpConstant %5 7
 %42 = OpConstant %5 32
 %46 = OpConstant %5 10
+%69 = OpTypePointer Function %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %73
-%73 = OpLabel
+%70 = OpVariable %69 Function
+%72 = OpVariable %69 Function
+OpBranch %78
+%78 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
@@ -164,60 +173,60 @@ OpBranch %73
 %20 = OpAccessChain %13 %12 %21
 %22 = OpLoad %5 %20
 %24 = OpIEqual %23 %16 %15
-OpSelectionMerge %93 None
-OpBranchConditional %24 %93 %74
-%74 = OpLabel
-OpBranch %75
-%75 = OpLabel
-%29 = OpPhi %5 %15 %74 %30 %91
-%31 = OpPhi %5 %15 %74 %26 %91
+OpSelectionMerge %98 None
+OpBranchConditional %24 %98 %79
+%79 = OpLabel
+OpBranch %80
+%80 = OpLabel
+%29 = OpPhi %5 %15 %79 %30 %96
+%31 = OpPhi %5 %15 %79 %26 %96
 %32 = OpIEqual %23 %19 %15
-OpLoopMerge %92 %91 None
-OpBranch %76
-%76 = OpLabel
-OpSelectionMerge %90 None
-OpBranchConditional %32 %90 %77
-%77 = OpLabel
-OpBranch %78
-%78 = OpLabel
-%36 = OpPhi %5 %15 %77 %37 %87
-%38 = OpPhi %5 %31 %77 %34 %87
+OpLoopMerge %97 %96 None
+OpBranch %81
+%81 = OpLabel
+OpSelectionMerge %95 None
+OpBranchConditional %32 %95 %82
+%82 = OpLabel
+OpBranch %83
+%83 = OpLabel
+%36 = OpPhi %5 %15 %82 %37 %92
+%38 = OpPhi %5 %31 %82 %34 %92
 %39 = OpShiftLeftLogical %5 %36 %40
 %41 = OpIMul %5 %36 %42
 %43 = OpImageRead %27 %9 %41
 %44 = OpCompositeExtract %5 %43 0
 %45 = OpIEqual %23 %44 %46
-OpLoopMerge %89 %87 None
-OpBranchConditional %45 %88 %79
-%88 = OpLabel
+OpLoopMerge %94 %92 None
+OpBranchConditional %45 %93 %84
+%93 = OpLabel
 %47 = OpImageRead %27 %9 %18
 %48 = OpCompositeExtract %5 %47 0
 %33 = OpIAdd %5 %48 %38
-OpBranch %89
-%79 = OpLabel
+OpBranch %94
+%84 = OpLabel
 %49 = OpIEqual %23 %22 %15
-OpSelectionMerge %86 None
-OpBranchConditional %49 %86 %80
-%80 = OpLabel
-OpBranch %81
-%81 = OpLabel
-%53 = OpPhi %5 %38 %80 %51 %83
-%54 = OpPhi %5 %15 %80 %55 %83
+OpSelectionMerge %91 None
+OpBranchConditional %49 %91 %85
+%85 = OpLabel
+OpBranch %86
+%86 = OpLabel
+%53 = OpPhi %5 %38 %85 %51 %88
+%54 = OpPhi %5 %15 %85 %55 %88
 %56 = OpShiftLeftLogical %5 %54 %40
 %57 = OpIMul %5 %54 %42
 %58 = OpImageRead %27 %9 %57
 %59 = OpCompositeExtract %5 %58 0
 %60 = OpIEqual %23 %59 %46
-OpLoopMerge %85 %83 None
-OpBranchConditional %60 %84 %82
-%84 = OpLabel
+OpLoopMerge %90 %88 None
+OpBranchConditional %60 %89 %87
+%89 = OpLabel
 %61 = OpImageRead %27 %9 %21
 %62 = OpCompositeExtract %5 %61 0
 %50 = OpIAdd %5 %62 %53
-OpBranch %85
-%82 = OpLabel
-OpBranch %83
-%83 = OpLabel
+OpBranch %90
+%87 = OpLabel
+OpBranch %88
+%88 = OpLabel
 %63 = OpBitwiseXor %5 %36 %29
 %64 = OpBitwiseXor %5 %63 %54
 %65 = OpShiftLeftLogical %5 %64 %21
@@ -226,33 +235,37 @@ OpBranch %83
 %51 = OpIAdd %5 %67 %53
 %55 = OpIAdd %5 %54 %18
 %68 = OpULessThan %23 %55 %22
-OpBranchConditional %68 %81 %85
-%85 = OpLabel
-%69 = OpPhi %5 %51 %83 %50 %84
-OpBranch %86
-%86 = OpLabel
-%70 = OpPhi %5 %38 %79 %69 %85
-%34 = OpCopyObject %5 %70
-OpBranch %87
-%87 = OpLabel
-%37 = OpIAdd %5 %36 %18
-%52 = OpULessThan %23 %37 %19
-OpBranchConditional %52 %78 %89
-%89 = OpLabel
-%71 = OpPhi %5 %34 %87 %33 %88
-OpBranch %90
+OpStore %72 %51
+OpBranchConditional %68 %86 %90
 %90 = OpLabel
-%72 = OpPhi %5 %31 %76 %71 %89
-%26 = OpCopyObject %5 %72
+%74 = OpPhi %5 %38 %88 %50 %89
+%73 = OpLoad %5 %72
 OpBranch %91
 %91 = OpLabel
+%75 = OpPhi %5 %38 %84 %74 %90
+%34 = OpCopyObject %5 %75
+OpBranch %92
+%92 = OpLabel
+%37 = OpIAdd %5 %36 %18
+%52 = OpULessThan %23 %37 %19
+OpStore %70 %34
+OpBranchConditional %52 %83 %94
+%94 = OpLabel
+%76 = OpPhi %5 %31 %92 %33 %93
+%71 = OpLoad %5 %70
+OpBranch %95
+%95 = OpLabel
+%77 = OpPhi %5 %31 %81 %76 %94
+%26 = OpCopyObject %5 %77
+OpBranch %96
+%96 = OpLabel
 %30 = OpIAdd %5 %29 %18
 %35 = OpIEqual %23 %30 %16
-OpBranchConditional %35 %92 %75
-%92 = OpLabel
-OpBranch %93
-%93 = OpLabel
-%25 = OpPhi %5 %15 %73 %26 %92
+OpBranchConditional %35 %97 %80
+%97 = OpLabel
+OpBranch %98
+%98 = OpLabel
+%25 = OpPhi %5 %15 %78 %26 %97
 %28 = OpCompositeConstruct %27 %25 %25 %25 %25
 OpImageWrite %9 %15 %28
 OpReturn

--- a/util/thread_local_allocator.hpp
+++ b/util/thread_local_allocator.hpp
@@ -73,8 +73,8 @@ static inline bool operator!=(const ThreadLocalAllocator<A> &, const ThreadLocal
 template <typename T>
 using Vector = std::vector<T, ThreadLocalAllocator<T>>;
 
-template <typename T>
-using UnorderedSet = std::unordered_set<T, std::hash<T>, std::equal_to<T>, ThreadLocalAllocator<T>>;
+template <typename T, typename Hash = std::hash<T>>
+using UnorderedSet = std::unordered_set<T, Hash, std::equal_to<T>, ThreadLocalAllocator<T>>;
 
 template <typename T>
 using Set = std::set<T, std::less<T>, ThreadLocalAllocator<T>>;
@@ -83,7 +83,7 @@ using String = std::basic_string<char, std::char_traits<char>, ThreadLocalAlloca
 using StringStream = std::basic_ostringstream<char, std::char_traits<char>, ThreadLocalAllocator<char>>;
 
 template <typename Key, typename Value, typename Hash = std::hash<Key>>
-using UnorderedMap = std::unordered_map<Key, Value, std::hash<Key>, std::equal_to<Key>, ThreadLocalAllocator<std::pair<const Key, Value>>>;
+using UnorderedMap = std::unordered_map<Key, Value, Hash, std::equal_to<Key>, ThreadLocalAllocator<std::pair<const Key, Value>>>;
 
 void begin_thread_allocator_context();
 void end_thread_allocator_context();


### PR DESCRIPTION
Rewriting the CFG can cause dominance relationships to break. Lower SSA variables to OpVariable instead when this edge case occurs.