### PR TITLE
Fix for when GEP refers to a forward reference for the third operand.

### DIFF
--- a/bc/module.cpp
+++ b/bc/module.cpp
@@ -1496,15 +1496,15 @@ bool ModuleParseContext::parse_record(const BlockOrRecord &entry)
 
 		bool inbounds = entry.ops[0] != 0;
 		auto *type = get_type(entry.ops[1]);
-		unsigned count = entry.ops.size() - 2;
+		unsigned count = entry.ops.size();
 		Vector<Value *> args;
 		args.reserve(count);
-		for (unsigned i = 0; i < count; i++)
+		for (unsigned i = 2; i < count;)
 		{
-			auto *value = get_value(entry.ops[i + 2]);
-			if (!value)
+			auto value = get_value_and_type(entry.ops, i);
+			if (!value.first)
 				return false;
-			args.push_back(value);
+			args.push_back(value.first);
 		}
 
 		type = resolve_gep_element_type(type, args);


### PR DESCRIPTION
Sample of the code causing the issue.

```
; <label>:344                                     ; preds = %356
  %345 = shl nsw i32 %373, 3
  %346 = and i32 %345, 24
  %347 = lshr i32 %211, %346
  %348 = and i32 %347, 255
  %349 = uitofp i32 %348 to float
  %350 = fmul fast float %349, 0x3F70101020000000
  %351 = fmul fast float %350, %350
  %352 = fmul fast float %351, %316
  %353 = getelementptr inbounds [4 x float], [4 x float]* %14, i32 0, i32 %373
  %354 = load float, float* %353, align 4, !tbaa !26
  %355 = fmul fast float %354, %316
  br label %389
```

Line %353 refers to %373 which is a forward reference at this point. The get_value code just simply prints an error whereas other instructions properly using the following op as the type.