### PR TITLE
Support Integers with bitwidth of 11

### DIFF
--- a/bc/module.cpp
+++ b/bc/module.cpp
@@ -1781,35 +1781,20 @@ bool ModuleParseContext::parse_type(const BlockOrRecord &child)
 	}
 
 	case TypeRecord::INTEGER:
+	{
 		if (child.ops.size() < 1)
 			return false;
 
-		switch (child.ops[0])
+		if (child.ops[0] <= 64)
 		{
-		case 1:
-			type = Type::getInt1Ty(*context);
-			break;
-
-		case 8:
-			type = Type::getInt8Ty(*context);
-			break;
-
-		case 16:
-			type = Type::getInt16Ty(*context);
-			break;
-
-		case 32:
-			type = Type::getInt32Ty(*context);
-			break;
-
-		case 64:
-			type = Type::getInt64Ty(*context);
-			break;
-
-		default:
-			LOGE("Unexpected integer bitwidth %u.\n", unsigned(child.ops[0]));
+			type = Type::getIntTy(*context, child.ops[0]);
+		}
+		else
+		{
+			LOGE("Unexpected integer bit width %llu\n", child.ops[0]);
 			return false;
 		}
+	}
 		break;
 
 	case TypeRecord::STRUCT_NAMED:

--- a/bc/type.hpp
+++ b/bc/type.hpp
@@ -58,6 +58,7 @@ public:
 	static Type *getInt16Ty(LLVMContext &context);
 	static Type *getInt32Ty(LLVMContext &context);
 	static Type *getInt64Ty(LLVMContext &context);
+	static Type *getIntTy(LLVMContext &context, uint32_t width);
 	static Type *getLabelTy(LLVMContext &context);
 	static Type *getMetadataTy(LLVMContext &context);
 
@@ -76,7 +77,6 @@ public:
 protected:
 	LLVMContext &context;
 	TypeID type_id;
-	static Type *getIntTy(LLVMContext &context, uint32_t width);
 	static Type *getTy(LLVMContext &context, TypeID id);
 	unsigned address_space = 0;
 };

--- a/bc/value.cpp
+++ b/bc/value.cpp
@@ -123,41 +123,67 @@ APFloat::APFloat(Type *type_, uint64_t value_)
 
 int64_t APInt::getSExtValue() const
 {
-	switch (cast<IntegerType>(type)->getBitWidth())
+	unsigned integer_width = cast<IntegerType>(type)->getBitWidth();
+	if (integer_width <= 64)
 	{
-	case 1:
-		return (value & 1) != 0 ? -1 : 0;
-	case 8:
-		return int8_t(value);
-	case 16:
-		return int16_t(value);
-	case 32:
-		return int32_t(value);
-	case 64:
-		return int64_t(value);
-	default:
-		LOGE("Unrecognized bitwidth.\n");
-		return 0;
+		if (integer_width > 32)
+		{
+			return int64_t(value);
+		}
+		else if (integer_width > 16)
+		{
+			return int32_t(value);
+		}
+		else if (integer_width > 8)
+		{
+			return int16_t(value);
+		}
+		else if (integer_width > 1)
+		{
+			return int8_t(value);
+		}
+		else
+		{
+			return (value & 1) != 0 ? -1 : 0;
+		}
+	}
+	else
+	{
+		LOGE("Unexpected integer bit width %u\n", integer_width);
+		return false;
 	}
 }
 
 uint64_t APInt::getZExtValue() const
 {
-	switch (cast<IntegerType>(type)->getBitWidth())
+	unsigned integer_width = cast<IntegerType>(type)->getBitWidth();
+	if (integer_width <= 64)
 	{
-	case 1:
-		return value & 1;
-	case 8:
-		return uint8_t(value);
-	case 16:
-		return uint16_t(value);
-	case 32:
-		return uint32_t(value);
-	case 64:
-		return uint64_t(value);
-	default:
-		LOGE("Unrecognized bitwidth.\n");
-		return 0;
+		if (integer_width > 32)
+		{
+			return uint64_t(value);
+		}
+		else if (integer_width > 16)
+		{
+			return uint32_t(value);
+		}
+		else if (integer_width > 8)
+		{
+			return uint16_t(value);
+		}
+		else if (integer_width > 1)
+		{
+			return uint8_t(value);
+		}
+		else
+		{
+			return value & 1;
+		}
+	}
+	else
+	{
+		LOGE("Unexpected integer bit width %u\n", integer_width);
+		return false;
 	}
 }
 

--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -2063,21 +2063,28 @@ spv::Id Converter::Impl::get_id_for_constant(const llvm::Constant *constant, uns
 	case llvm::Type::TypeID::IntegerTyID:
 	{
 		unsigned integer_width = forced_width ? forced_width : constant->getType()->getIntegerBitWidth();
-		switch (integer_width)
+		if (integer_width <= 64)
 		{
-		case 1:
-			return builder.makeBoolConstant(constant->getUniqueInteger().getZExtValue() != 0);
-
-		case 16:
-			return builder.makeUint16Constant(constant->getUniqueInteger().getZExtValue());
-
-		case 32:
-			return builder.makeUintConstant(constant->getUniqueInteger().getZExtValue());
-
-		case 64:
-			return builder.makeUint64Constant(constant->getUniqueInteger().getZExtValue());
-
-		default:
+			if (integer_width > 32)
+			{
+				return builder.makeUint64Constant(constant->getUniqueInteger().getZExtValue(), integer_width);
+			}
+			else if (integer_width > 16)
+			{
+				return builder.makeUintConstant(constant->getUniqueInteger().getZExtValue(), integer_width);
+			}
+			else if (integer_width > 1)
+			{
+				return builder.makeUint16Constant(constant->getUniqueInteger().getZExtValue(), integer_width);
+			}
+			else
+			{
+				return builder.makeBoolConstant(constant->getUniqueInteger().getZExtValue() != 0);
+			}
+		}
+		else
+		{
+			LOGE("Unexpected integer bit width %u\n", integer_width);
 			return 0;
 		}
 	}

--- a/third_party/glslang-spirv/SpvBuilder.h
+++ b/third_party/glslang-spirv/SpvBuilder.h
@@ -230,13 +230,25 @@ public:
 
     // For making new constants (will return old constant if the requested one was already made).
     Id makeBoolConstant(bool b, bool specConstant = false);
-    Id makeIntConstant(int i, bool specConstant = false)         { return makeIntConstant(makeIntType(32),  (unsigned)i, specConstant); }
-    Id makeUintConstant(unsigned u, bool specConstant = false)   { return makeIntConstant(makeUintType(32),           u, specConstant); }
-    Id makeInt64Constant(long long i, bool specConstant = false)            { return makeInt64Constant(makeIntType(64),  (unsigned long long)i, specConstant); }
-    Id makeUint64Constant(unsigned long long u, bool specConstant = false)  { return makeInt64Constant(makeUintType(64),                     u, specConstant); }
+    Id makeIntConstant(int i, unsigned width, bool specConstant = false)    { return makeIntConstant(makeIntType(width),  (unsigned)i, specConstant); }
+    Id makeIntConstant(int i, bool specConstant)                            { return makeIntConstant(i, 32, specConstant); }
+    Id makeIntConstant(int i)                                               { return makeIntConstant(i, 32, false); }
+    Id makeUintConstant(unsigned u, unsigned width, bool specConstant = false)  { return makeIntConstant(makeUintType(width), u, specConstant); }
+    Id makeUintConstant(unsigned u, bool specConstant)                          { return makeUintConstant(u, 32, specConstant); }
+    Id makeUintConstant(unsigned u)                                             { return makeUintConstant(u, 32, false); }
+    Id makeInt64Constant(long long i, unsigned width = 64, bool specConstant = false)   { return makeInt64Constant(makeIntType(width),  (unsigned long long)i, specConstant); }
+    Id makeInt64Constant(long long i, bool specConstant)                                { return makeInt64Constant(i, 64, specConstant); }
+    Id makeInt64Constant(long long i)                                                   { return makeInt64Constant(i, 64, false); }
+    Id makeUint64Constant(unsigned long long u, unsigned width = 64, bool specConstant = false) { return makeInt64Constant(makeUintType(width), u, specConstant); }
+    Id makeUint64Constant(unsigned long long u, bool specConstant)                              { return makeUint64Constant(u, 64, specConstant); }
+    Id makeUint64Constant(unsigned long long u)                                                 { return makeUint64Constant(u, 64, false); }
 #ifdef AMD_EXTENSIONS
-    Id makeInt16Constant(short i, bool specConstant = false)        { return makeIntConstant(makeIntType(16),      (unsigned)((unsigned short)i), specConstant); }
-    Id makeUint16Constant(unsigned short u, bool specConstant = false)  { return makeIntConstant(makeUintType(16), (unsigned)u, specConstant); }
+    Id makeInt16Constant(short i, unsigned width = 16, bool specConstant = false)   { return makeIntConstant(makeIntType(width), (unsigned)((unsigned short)i), specConstant); }
+    Id makeInt16Constant(short i, bool specConstant)                                { return makeInt16Constant(i, 16, specConstant); }
+    Id makeInt16Constant(short i)                                                   { return makeInt16Constant(i, 16, false); }
+    Id makeUint16Constant(unsigned short u, unsigned width = 16, bool specConstant = false) { return makeIntConstant(makeUintType(width), (unsigned)u, specConstant); }
+    Id makeUint16Constant(unsigned short u, bool specConstant)                              { return makeUint16Constant(u, 16, specConstant); }
+    Id makeUint16Constant(unsigned short u)                                                 { return makeUint16Constant(u, 16, false); }
 #endif
     Id makeFloatConstant(float f, bool specConstant = false);
     Id makeDoubleConstant(double d, bool specConstant = false);


### PR DESCRIPTION
Sample code.

; <label>:1401                                    ; preds = %1395
  %1402 = trunc i32 %1399 to i11
  %1403 = lshr i11 440, %1402
  %1404 = and i11 %1403, 1
  %1405 = icmp ne i11 %1404, 0
  br label %1406

The issue initially presented with "Unexpected integer bitwidth 11."

NOTE: I do not like this implementation. I am adding this PR to get feedback for a better approach.