### PR TITLE
Converting odd bit width integers to next power of two integer bit width

### DIFF
--- a/bc/module.cpp
+++ b/bc/module.cpp
@@ -1754,35 +1754,40 @@ bool ModuleParseContext::parse_type(const BlockOrRecord &child)
 	}
 
 	case TypeRecord::INTEGER:
+	{
 		if (child.ops.size() < 1)
 			return false;
 
-		switch (child.ops[0])
+		uint64_t integer_width = child.ops[0];
+		if (integer_width <= 64)
 		{
-		case 1:
-			type = Type::getInt1Ty(*context);
-			break;
-
-		case 8:
-			type = Type::getInt8Ty(*context);
-			break;
-
-		case 16:
-			type = Type::getInt16Ty(*context);
-			break;
-
-		case 32:
-			type = Type::getInt32Ty(*context);
-			break;
-
-		case 64:
-			type = Type::getInt64Ty(*context);
-			break;
-
-		default:
-			LOGE("Unexpected integer bitwidth %u.\n", unsigned(child.ops[0]));
+			if (integer_width > 32)
+			{
+				type = Type::getInt64Ty(*context);
+			}
+			else if (integer_width > 16)
+			{
+				type = Type::getInt32Ty(*context);
+			}
+			else if (integer_width > 8)
+			{
+				type = Type::getInt16Ty(*context);
+			}
+			else if (integer_width > 1)
+			{
+				type = Type::getInt8Ty(*context);
+			}
+			else
+			{
+				type = Type::getInt1Ty(*context);
+			}
+		}
+		else
+		{
+			LOGE("Unexpected integer bit width %llu\n", integer_width);
 			return false;
 		}
+	}
 		break;
 
 	case TypeRecord::STRUCT_NAMED:


### PR DESCRIPTION
The dxc compiler generates some optimized code for switch statements that make bit masks instead of switch statements. This just converts the bit width from the odd bit width to the next power of two width.