### PR TITLE
Shader seemingly hits infinite loop in graph traversal but instead just takes incredibly long to complete.

### DIFF
--- a/node.hpp
+++ b/node.hpp
@@ -116,7 +116,7 @@ private:
 	Vector<CFGNode *> post_dominance_frontier;
 
 private:
-	bool dominates_all_reachable_exits(const CFGNode &header) const;
+	bool dominates_all_reachable_exits(std::unordered_set<const CFGNode *>& completed, const CFGNode &header) const;
 	template <typename Op>
 	void traverse_dominated_blocks_and_rewrite_branch(const CFGNode &header, CFGNode *from, CFGNode *to, const Op &op);
 	template <typename Op>


### PR DESCRIPTION
The graph traversal of dominates_all_reachable_exits was hitting the same nodes repeatedly and was seemingly in an infinite loop but was instead just taking an incredibly long time to finish. This was due to checking the same nodes each time they were encountered instead of just recording they have been checked.

[e5010e4ebf22196d.zip](https://github.com/HansKristian-Work/dxil-spirv/files/6361639/e5010e4ebf22196d.zip)
