### PR TITLE
Handle "odd" integer sizes.

### DIFF
--- a/bc/module.cpp
+++ b/bc/module.cpp
@@ -1754,36 +1754,17 @@ bool ModuleParseContext::parse_type(const BlockOrRecord &child)
 	}
 
 	case TypeRecord::INTEGER:
+	{
 		if (child.ops.size() < 1)
 			return false;
 
-		switch (child.ops[0])
-		{
-		case 1:
-			type = Type::getInt1Ty(*context);
-			break;
-
-		case 8:
-			type = Type::getInt8Ty(*context);
-			break;
-
-		case 16:
-			type = Type::getInt16Ty(*context);
-			break;
-
-		case 32:
-			type = Type::getInt32Ty(*context);
-			break;
-
-		case 64:
-			type = Type::getInt64Ty(*context);
-			break;
-
-		default:
-			LOGE("Unexpected integer bitwidth %u.\n", unsigned(child.ops[0]));
+		auto bit_width = child.ops[0];
+		if (bit_width <= 64)
+			type = Type::getIntTy(*context, unsigned(bit_width));
+		else
 			return false;
-		}
 		break;
+	}
 
 	case TypeRecord::STRUCT_NAMED:
 	case TypeRecord::STRUCT_ANON:

--- a/bc/type.hpp
+++ b/bc/type.hpp
@@ -58,6 +58,7 @@ public:
 	static Type *getInt16Ty(LLVMContext &context);
 	static Type *getInt32Ty(LLVMContext &context);
 	static Type *getInt64Ty(LLVMContext &context);
+	static Type *getIntTy(LLVMContext &context, uint32_t width);
 	static Type *getLabelTy(LLVMContext &context);
 	static Type *getMetadataTy(LLVMContext &context);
 
@@ -76,7 +77,6 @@ public:
 protected:
 	LLVMContext &context;
 	TypeID type_id;
-	static Type *getIntTy(LLVMContext &context, uint32_t width);
 	static Type *getTy(LLVMContext &context, TypeID id);
 	unsigned address_space = 0;
 };

--- a/bc/value.cpp
+++ b/bc/value.cpp
@@ -123,42 +123,22 @@ APFloat::APFloat(Type *type_, uint64_t value_)
 
 int64_t APInt::getSExtValue() const
 {
-	switch (cast<IntegerType>(type)->getBitWidth())
-	{
-	case 1:
-		return (value & 1) != 0 ? -1 : 0;
-	case 8:
-		return int8_t(value);
-	case 16:
-		return int16_t(value);
-	case 32:
-		return int32_t(value);
-	case 64:
+	auto width = cast<IntegerType>(type)->getBitWidth();
+	if (width == 64)
 		return int64_t(value);
-	default:
-		LOGE("Unrecognized bitwidth.\n");
-		return 0;
-	}
+	auto mask = (1ull << width) - 1;
+	bool sign_bit = ((value >> (width - 1)) & 1) != 0;
+	uint64_t extended = sign_bit ? ~mask : 0ull;
+	return int64_t((value & mask) | extended);
 }
 
 uint64_t APInt::getZExtValue() const
 {
-	switch (cast<IntegerType>(type)->getBitWidth())
-	{
-	case 1:
-		return value & 1;
-	case 8:
-		return uint8_t(value);
-	case 16:
-		return uint16_t(value);
-	case 32:
-		return uint32_t(value);
-	case 64:
-		return uint64_t(value);
-	default:
-		LOGE("Unrecognized bitwidth.\n");
-		return 0;
-	}
+	auto width = cast<IntegerType>(type)->getBitWidth();
+	if (width == 64)
+		return value;
+	auto mask = (1ull << width) - 1u;
+	return value & mask;
 }
 
 ConstantFP *ConstantFP::get(Type *type, uint64_t value)

--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -2063,7 +2063,8 @@ spv::Id Converter::Impl::get_id_for_constant(const llvm::Constant *constant, uns
 	case llvm::Type::TypeID::IntegerTyID:
 	{
 		unsigned integer_width = forced_width ? forced_width : constant->getType()->getIntegerBitWidth();
-		switch (integer_width)
+		int physical_width = physical_integer_bit_width(integer_width);
+		switch (physical_width)
 		{
 		case 1:
 			return builder.makeBoolConstant(constant->getUniqueInteger().getZExtValue() != 0);
@@ -2336,7 +2337,10 @@ spv::Id Converter::Impl::get_type_id(const llvm::Type *type)
 		if (type->getIntegerBitWidth() == 1)
 			return builder.makeBoolType();
 		else
-			return builder.makeIntegerType(type->getIntegerBitWidth(), false);
+		{
+			auto width = physical_integer_bit_width(type->getIntegerBitWidth());
+			return builder.makeIntegerType(width, false);
+		}
 
 	case llvm::Type::TypeID::PointerTyID:
 	{

--- a/opcodes/opcodes_llvm_builtins.hpp
+++ b/opcodes/opcodes_llvm_builtins.hpp
@@ -43,4 +43,6 @@ bool analyze_getelementptr_instruction(Converter::Impl &impl, const llvm::GetEle
 bool analyze_extractvalue_instruction(Converter::Impl &impl, const llvm::ExtractValueInst *instruction);
 
 bool emit_llvm_instruction(Converter::Impl &impl, const llvm::Instruction &instruction);
+
+unsigned physical_integer_bit_width(unsigned width);
 } // namespace dxil_spv

--- a/reference/shaders/llvm-builtin/glitched-integer-width.comp
+++ b/reference/shaders/llvm-builtin/glitched-integer-width.comp
@@ -1,0 +1,122 @@
+#version 460
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, std140) uniform _13_15
+{
+    vec4 _m0[1];
+} _15;
+
+layout(set = 0, binding = 0) uniform writeonly image2DArray _8;
+
+void main()
+{
+    uint _24;
+    bool _27;
+    for (;;)
+    {
+        _24 = floatBitsToUint(_15._m0[0u]).x + 4294967295u;
+        _27 = _24 < 11u;
+        if (_27)
+        {
+            if (bitfieldExtract((bitfieldExtract(440u, int(0u), int(11u)) >> bitfieldExtract(bitfieldExtract(_24, int(0u), int(11u)), int(0u), int(11u))) & 1u, int(0u), int(11u)) == bitfieldExtract(0u, int(0u), int(11u)))
+            {
+                imageStore(_8, ivec3(uvec3(1u)), vec4(1.0));
+                break;
+            }
+        }
+        imageStore(_8, ivec3(uvec3(1u)), vec4(0.0));
+        break;
+    }
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 54
+; Schema: 0
+OpCapability Shader
+OpCapability StorageImageWriteWithoutFormat
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main"
+OpExecutionMode %3 LocalSize 8 8 1
+OpName %3 "main"
+OpName %13 ""
+OpDecorate %8 DescriptorSet 0
+OpDecorate %8 Binding 0
+OpDecorate %8 NonReadable
+OpDecorate %12 ArrayStride 16
+OpMemberDecorate %13 0 Offset 0
+OpDecorate %13 Block
+OpDecorate %15 DescriptorSet 0
+OpDecorate %15 Binding 0
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeFloat 32
+%6 = OpTypeImage %5 2D 0 1 0 2 Unknown
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeInt 32 0
+%10 = OpConstant %9 1
+%11 = OpTypeVector %5 4
+%12 = OpTypeArray %11 %10
+%13 = OpTypeStruct %12
+%14 = OpTypePointer Uniform %13
+%15 = OpVariable %14 Uniform
+%17 = OpConstant %9 0
+%18 = OpTypePointer Uniform %11
+%21 = OpTypeVector %9 4
+%25 = OpConstant %9 4294967295
+%26 = OpTypeBool
+%28 = OpConstant %9 11
+%31 = OpConstant %9 440
+%38 = OpConstant %5 0
+%39 = OpTypeVector %9 3
+%42 = OpConstant %5 1
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %45
+%45 = OpLabel
+%16 = OpLoad %6 %8
+%19 = OpAccessChain %18 %15 %17 %17
+%20 = OpLoad %11 %19
+%22 = OpBitcast %21 %20
+%23 = OpCompositeExtract %9 %22 0
+%24 = OpIAdd %9 %23 %25
+%27 = OpULessThan %26 %24 %28
+OpLoopMerge %51 %52 None
+OpBranch %46
+%46 = OpLabel
+OpSelectionMerge %49 None
+OpBranchConditional %27 %47 %49
+%47 = OpLabel
+%29 = OpBitFieldUExtract %9 %24 %17 %28
+%32 = OpBitFieldUExtract %9 %31 %17 %28
+%33 = OpBitFieldUExtract %9 %29 %17 %28
+%30 = OpShiftRightLogical %9 %32 %33
+%34 = OpBitwiseAnd %9 %30 %10
+%36 = OpBitFieldUExtract %9 %34 %17 %28
+%37 = OpBitFieldUExtract %9 %17 %17 %28
+%35 = OpIEqual %26 %36 %37
+OpSelectionMerge %48 None
+OpBranchConditional %35 %50 %48
+%50 = OpLabel
+%43 = OpCompositeConstruct %39 %10 %10 %10
+%44 = OpCompositeConstruct %11 %42 %42 %42 %42
+OpImageWrite %16 %43 %44
+OpBranch %51
+%48 = OpLabel
+OpBranch %49
+%49 = OpLabel
+%40 = OpCompositeConstruct %39 %10 %10 %10
+%41 = OpCompositeConstruct %11 %38 %38 %38 %38
+OpImageWrite %16 %40 %41
+OpBranch %51
+%52 = OpLabel
+OpBranch %45
+%51 = OpLabel
+OpReturn
+OpFunctionEnd
+#endif

--- a/shaders/llvm-builtin/glitched-integer-width.comp
+++ b/shaders/llvm-builtin/glitched-integer-width.comp
@@ -1,0 +1,44 @@
+cbuffer buffer1 : register (b0) 
+{ 
+    uint cbSwitch;
+}; 
+
+struct struct1 
+{ 
+    float4 value1; 
+}; 
+
+cbuffer buffer2 : register (b1) 
+{ 
+    struct1 g_struct1; 
+} 
+
+RWTexture2DArray<float3> out1 : register(u0); 
+
+[numthreads(8, 8, 1)] 
+void main() 
+{ 
+    const float3 variable1 = float3(1.0f, 1.0f, 1.0f);
+    
+    bool variable3 = true; 
+    switch (cbSwitch) 
+    { 
+	case 1:
+	case 2:
+	case 3:
+	case 7:
+	case 10:
+	case 11:
+        variable3 = false; 
+        break; 
+    } 
+    
+    if (variable3) 
+    {
+        out1[variable1] = float3(0, 0, 0);
+    } 
+    else
+    {
+        out1[variable1] = float3(1, 1, 1);
+    }
+}


### PR DESCRIPTION
LLVM IR supports "weird" integer sizes, and it implies that backend
deals with masking where appropriate.

In contexts where sign matters, we need to extend the input to physical
bitwidth from logical bitwidth.

For now, this is probably not exhaustive, but handle trunc/zext/sext and
some arithmetic opcodes which are sign sensitive.

Obsoletes #41.