### PR TITLE
Implement descriptor QA checks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_subdirectory(external EXCLUDE_FROM_ALL)
 
 add_library(spirv-module STATIC
         ir.hpp ir.cpp
+        descriptor_qa.cpp descriptor_qa.hpp
         spirv_module.hpp spirv_module.cpp)
 set_target_properties(spirv-module PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(spirv-module PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/descriptor_qa.cpp
+++ b/descriptor_qa.cpp
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2021 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "descriptor_qa.hpp"
+#include "spirv_module.hpp"
+#include "SpvBuilder.h"
+#include "logging.hpp"
+
+namespace dxil_spv
+{
+static spv::Id build_descriptor_qa_heap_buffer_type(spv::Builder &builder)
+{
+	Vector<spv::Id> member_types;
+	// DescriptorHeapQAData {
+	//  uint descriptor_count;
+	//  uint heap_id;
+	//  uvec2 cookies_descriptor_info[];
+	// }
+	spv::Id u32_type = builder.makeUintType(32);
+	spv::Id uvec2_type = builder.makeVectorType(u32_type, 2);
+	spv::Id uvec2_arr_type = builder.makeRuntimeArray(uvec2_type);
+	builder.addDecoration(uvec2_arr_type, spv::DecorationArrayStride, 8);
+
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(uvec2_arr_type);
+
+	spv::Id id = builder.makeStructType(member_types, "DescriptorHeapQAData");
+
+	const auto set_info = [&](DescriptorQAHeapMembers member, int offset, const char *name) {
+		builder.addMemberDecoration(id, int(member), spv::DecorationOffset, offset);
+		builder.addMemberName(id, int(member), name);
+	};
+
+	set_info(DescriptorQAHeapMembers::DescriptorCount, 0, "descriptor_count");
+	set_info(DescriptorQAHeapMembers::HeapIndex, 4, "heap_index");
+	set_info(DescriptorQAHeapMembers::CookiesDescriptorInfo, 8, "cookies_descriptor_info");
+
+	builder.addDecoration(id, spv::DecorationBlock);
+	return id;
+}
+
+static spv::Id build_descriptor_global_buffer_type(spv::Builder &builder)
+{
+	Vector<spv::Id> member_types;
+	// DescriptorHeapQAGlobalData {
+	//  uvec2 failed_shader_hash;
+	//  uint failed_offset;
+	//  uint failed_heap;
+	//  uint failed_cookie;
+	//  uint fault_atomic;
+	//  uint failed_instruction;
+	//  uint failed_descriptor_type_mask;
+	//  uint actual_descriptor_type_mask;
+	//  uint fault_type;
+	//  uint live_status_table[];
+	// }
+	spv::Id u32_type = builder.makeUintType(32);
+	spv::Id uvec2_type = builder.makeVectorType(u32_type, 2);
+	spv::Id u32_arr_type = builder.makeRuntimeArray(u32_type);
+	builder.addDecoration(u32_arr_type, spv::DecorationArrayStride, 4);
+
+	member_types.push_back(uvec2_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_type);
+	member_types.push_back(u32_arr_type);
+
+	spv::Id id = builder.makeStructType(member_types, "DescriptorHeapGlobalQAData");
+
+	const auto set_info = [&](DescriptorQAGlobalMembers member, int offset, const char *name) {
+		builder.addMemberDecoration(id, int(member), spv::DecorationOffset, offset);
+		builder.addMemberName(id, int(member), name);
+	};
+
+	set_info(DescriptorQAGlobalMembers::FailedShaderHash, 0, "failed_shader_hash");
+	set_info(DescriptorQAGlobalMembers::FailedOffset, 8, "failed_offset");
+	set_info(DescriptorQAGlobalMembers::FailedHeap, 12, "failed_heap");
+	set_info(DescriptorQAGlobalMembers::FailedCookie, 16, "failed_cookie");
+	set_info(DescriptorQAGlobalMembers::FaultAtomic, 20, "fault_atomic");
+	set_info(DescriptorQAGlobalMembers::FailedInstruction, 24, "failed_instruction");
+	set_info(DescriptorQAGlobalMembers::FailedDescriptorTypeMask, 28, "failed_descriptor_type_mask");
+	set_info(DescriptorQAGlobalMembers::ActualDescriptorTypeMask, 32, "actual_descriptor_type_mask");
+	set_info(DescriptorQAGlobalMembers::FaultType, 36, "fault_type");
+	set_info(DescriptorQAGlobalMembers::LiveStatusTable, 40, "live_status_table");
+
+	builder.addDecoration(id, spv::DecorationBlock);
+
+	return id;
+}
+
+static spv::Id build_ssbo_load(spv::Builder &builder, spv::Id value_type, spv::Id ssbo_id, uint32_t member)
+{
+	spv::Id ptr_id = builder.makePointer(spv::StorageClassStorageBuffer, value_type);
+	auto chain = std::make_unique<spv::Instruction>(builder.getUniqueId(), ptr_id, spv::OpAccessChain);
+	chain->addIdOperand(ssbo_id);
+	chain->addIdOperand(builder.makeUintConstant(member));
+
+	auto load = std::make_unique<spv::Instruction>(builder.getUniqueId(), value_type, spv::OpLoad);
+	load->addIdOperand(chain->getResultId());
+	spv::Id result_id = load->getResultId();
+
+	builder.getBuildPoint()->addInstruction(std::move(chain));
+	builder.getBuildPoint()->addInstruction(std::move(load));
+	return result_id;
+}
+
+static void build_ssbo_store(spv::Builder &builder, spv::Id value_type, spv::Id ssbo_id, uint32_t member, spv::Id value_id)
+{
+	spv::Id ptr_id = builder.makePointer(spv::StorageClassStorageBuffer, value_type);
+	auto chain = std::make_unique<spv::Instruction>(builder.getUniqueId(), ptr_id, spv::OpAccessChain);
+	chain->addIdOperand(ssbo_id);
+	chain->addIdOperand(builder.makeUintConstant(member));
+
+	auto store = std::make_unique<spv::Instruction>(spv::OpStore);
+	store->addIdOperand(chain->getResultId());
+	store->addIdOperand(value_id);
+
+	builder.getBuildPoint()->addInstruction(std::move(chain));
+	builder.getBuildPoint()->addInstruction(std::move(store));
+}
+
+static spv::Id build_ssbo_load_array(spv::Builder &builder, spv::Id value_type, spv::Id ssbo_id, uint32_t member,
+                                     spv::Id offset)
+{
+	spv::Id ptr_id = builder.makePointer(spv::StorageClassStorageBuffer, value_type);
+	auto chain = std::make_unique<spv::Instruction>(builder.getUniqueId(), ptr_id, spv::OpAccessChain);
+	chain->addIdOperand(ssbo_id);
+	chain->addIdOperand(builder.makeUintConstant(member));
+	chain->addIdOperand(offset);
+
+	auto load = std::make_unique<spv::Instruction>(builder.getUniqueId(), value_type, spv::OpLoad);
+	load->addIdOperand(chain->getResultId());
+	spv::Id result_id = load->getResultId();
+
+	builder.getBuildPoint()->addInstruction(std::move(chain));
+	builder.getBuildPoint()->addInstruction(std::move(load));
+	return result_id;
+}
+
+static void build_cookie_descriptor_info_split(spv::Builder &builder, spv::Id composite_id,
+                                               spv::Id &cookie_id,
+                                               spv::Id &cookie_shifted_id,
+                                               spv::Id &cookie_masked_id,
+                                               spv::Id &descriptor_info_id)
+{
+	spv::Id u32_type = builder.makeUintType(32);
+
+	auto cookie = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpCompositeExtract);
+	cookie->addIdOperand(composite_id);
+	cookie->addImmediateOperand(0);
+
+	auto info = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpCompositeExtract);
+	info->addIdOperand(composite_id);
+	info->addImmediateOperand(1);
+
+	auto shifted = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpShiftRightLogical);
+	shifted->addIdOperand(cookie->getResultId());
+	shifted->addIdOperand(builder.makeUintConstant(5));
+
+	auto masked = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpBitwiseAnd);
+	masked->addIdOperand(cookie->getResultId());
+	masked->addIdOperand(builder.makeUintConstant(31));
+
+	cookie_id = cookie->getResultId();
+	descriptor_info_id = info->getResultId();
+	cookie_shifted_id = shifted->getResultId();
+	cookie_masked_id = masked->getResultId();
+	builder.getBuildPoint()->addInstruction(std::move(cookie));
+	builder.getBuildPoint()->addInstruction(std::move(shifted));
+	builder.getBuildPoint()->addInstruction(std::move(masked));
+	builder.getBuildPoint()->addInstruction(std::move(info));
+}
+
+static spv::Id build_live_check(spv::Builder &builder, spv::Id status_id, spv::Id bit_id)
+{
+	spv::Id u32_type = builder.makeUintType(32);
+
+	auto shift_up = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpShiftLeftLogical);
+	shift_up->addIdOperand(builder.makeUintConstant(1));
+	shift_up->addIdOperand(bit_id);
+
+	auto mask = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpBitwiseAnd);
+	mask->addIdOperand(status_id);
+	mask->addIdOperand(shift_up->getResultId());
+
+	auto cond = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeBoolType(), spv::OpINotEqual);
+	cond->addIdOperand(mask->getResultId());
+	cond->addIdOperand(builder.makeUintConstant(0));
+	spv::Id res = cond->getResultId();
+
+	builder.getBuildPoint()->addInstruction(std::move(shift_up));
+	builder.getBuildPoint()->addInstruction(std::move(mask));
+	builder.getBuildPoint()->addInstruction(std::move(cond));
+	return res;
+}
+
+static spv::Id build_binary_op(spv::Builder &builder, spv::Id type, spv::Op opcode, spv::Id a, spv::Id b)
+{
+	auto op = std::make_unique<spv::Instruction>(builder.getUniqueId(), type, opcode);
+	op->addIdOperand(a);
+	op->addIdOperand(b);
+	spv::Id ret = op->getResultId();
+	builder.getBuildPoint()->addInstruction(std::move(op));
+	return ret;
+}
+
+static void build_ssbo_barrier(spv::Builder &builder)
+{
+	auto barrier = std::make_unique<spv::Instruction>(spv::OpMemoryBarrier);
+	barrier->addIdOperand(builder.makeUintConstant(spv::ScopeDevice));
+	barrier->addIdOperand(builder.makeUintConstant(spv::MemorySemanticsUniformMemoryMask |
+	                                               spv::MemorySemanticsAcquireReleaseMask));
+	builder.getBuildPoint()->addInstruction(std::move(barrier));
+}
+
+static void build_descriptor_qa_fault_report(SPIRVModule &module, spv::Id &func_id, spv::Id &buffer_id)
+{
+	auto &builder = module.get_builder();
+	spv::Id global_buffer_type_id = build_descriptor_global_buffer_type(builder);
+	spv::Id descriptor_qa_global_buffer_id = module.create_variable(spv::StorageClassStorageBuffer,
+	                                                                global_buffer_type_id, "QAGlobalData");
+	buffer_id = descriptor_qa_global_buffer_id;
+
+	builder.addDecoration(descriptor_qa_global_buffer_id, spv::DecorationDescriptorSet,
+	                      module.get_descriptor_qa_info().global_desc_set);
+	builder.addDecoration(descriptor_qa_global_buffer_id, spv::DecorationBinding,
+	                      module.get_descriptor_qa_info().global_binding);
+
+	auto *current_build_point = builder.getBuildPoint();
+
+	spv::Block *entry = nullptr;
+
+	Vector<spv::Id> param_types(7, builder.makeUintType(32));
+	auto *func = builder.makeFunctionEntry(spv::NoPrecision, builder.makeVoidType(),
+	                                       "descriptor_qa_report_fault", param_types, {}, &entry);
+
+	func_id = func->getId();
+
+	spv::Id fault_type_id = func->getParamId(0);
+	spv::Id heap_offset_id = func->getParamId(1);
+	spv::Id cookie_id = func->getParamId(2);
+	spv::Id heap_id = func->getParamId(3);
+	spv::Id descriptor_type_id = func->getParamId(4);
+	spv::Id actual_descriptor_type_id = func->getParamId(5);
+	spv::Id instruction_id = func->getParamId(6);
+	builder.addName(fault_type_id, "fault_type");
+	builder.addName(heap_offset_id, "heap_offset");
+	builder.addName(cookie_id, "cookie");
+	builder.addName(heap_id, "heap_index");
+	builder.addName(descriptor_type_id, "descriptor_type");
+	builder.addName(actual_descriptor_type_id, "actual_descriptor_type");
+	builder.addName(instruction_id, "instruction");
+
+	spv::Id u32_type = builder.makeUintType(32);
+	spv::Id u32_ptr_type = builder.makePointer(spv::StorageClassStorageBuffer, u32_type);
+
+	auto chain = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_ptr_type, spv::OpAccessChain);
+	chain->addIdOperand(descriptor_qa_global_buffer_id);
+	chain->addIdOperand(builder.makeUintConstant(uint32_t(DescriptorQAGlobalMembers::FaultAtomic)));
+
+	auto exchange = std::make_unique<spv::Instruction>(builder.getUniqueId(), u32_type, spv::OpAtomicExchange);
+	exchange->addIdOperand(chain->getResultId());
+	exchange->addIdOperand(builder.makeUintConstant(spv::ScopeDevice));
+	exchange->addIdOperand(builder.makeUintConstant(0));
+	exchange->addIdOperand(builder.makeUintConstant(1));
+
+	auto check = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeBoolType(), spv::OpIEqual);
+	check->addIdOperand(exchange->getResultId());
+	check->addIdOperand(builder.makeUintConstant(0));
+	spv::Id check_id = check->getResultId();
+
+	auto *true_block = new spv::Block(builder.getUniqueId(), *func);
+	auto *false_block = new spv::Block(builder.getUniqueId(), *func);
+
+	builder.setBuildPoint(entry);
+	entry->addInstruction(std::move(chain));
+	entry->addInstruction(std::move(exchange));
+	entry->addInstruction(std::move(check));
+	builder.createSelectionMerge(false_block, 0);
+	builder.createConditionalBranch(check_id, true_block, false_block);
+	builder.setBuildPoint(true_block);
+	{
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FailedCookie), cookie_id);
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FailedOffset), heap_offset_id);
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FailedHeap), heap_id);
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FailedDescriptorTypeMask), descriptor_type_id);
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::ActualDescriptorTypeMask), actual_descriptor_type_id);
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FailedInstruction), instruction_id);
+
+		spv::Id uvec2_type = builder.makeVectorType(u32_type, 2);
+
+		Vector<spv::Id> comps;
+		comps.push_back(builder.makeUintConstant(uint32_t(module.get_descriptor_qa_info().shader_hash)));
+		comps.push_back(builder.makeUintConstant(uint32_t(module.get_descriptor_qa_info().shader_hash >> 32u)));
+		spv::Id hash_id = builder.makeCompositeConstant(uvec2_type, comps);
+		build_ssbo_store(builder, uvec2_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FailedShaderHash), hash_id);
+
+		// Device memory barrier here so that if host observed fault_type != 0,
+		// we're certain that the other values are correct as well.
+		build_ssbo_barrier(builder);
+
+		build_ssbo_store(builder, u32_type, descriptor_qa_global_buffer_id,
+		                 uint32_t(DescriptorQAGlobalMembers::FaultType), fault_type_id);
+
+		builder.createBranch(false_block);
+	}
+	builder.setBuildPoint(false_block);
+	builder.makeReturn(false);
+	builder.setBuildPoint(current_build_point);
+}
+
+spv::Id build_descriptor_qa_check_function(SPIRVModule &module)
+{
+	auto &builder = module.get_builder();
+	spv::Id fault_func_id, global_buffer_id;
+	build_descriptor_qa_fault_report(module, fault_func_id, global_buffer_id);
+
+	spv::Id heap_buffer_type_id = build_descriptor_qa_heap_buffer_type(builder);
+	spv::Id descriptor_qa_heap_buffer_id = module.create_variable(spv::StorageClassStorageBuffer,
+	                                                              heap_buffer_type_id, "QAHeapData");
+	builder.addDecoration(descriptor_qa_heap_buffer_id, spv::DecorationDescriptorSet,
+	                      module.get_descriptor_qa_info().heap_desc_set);
+	builder.addDecoration(descriptor_qa_heap_buffer_id, spv::DecorationBinding,
+	                      module.get_descriptor_qa_info().heap_binding);
+	builder.addDecoration(descriptor_qa_heap_buffer_id, spv::DecorationNonWritable);
+
+	auto heap_buffer_id = descriptor_qa_heap_buffer_id;
+
+	auto *current_build_point = builder.getBuildPoint();
+	spv::Block *entry = nullptr;
+
+	Vector<spv::Id> param_types(3, builder.makeUintType(32));
+	auto *func = builder.makeFunctionEntry(spv::NoPrecision, builder.makeUintType(32),
+	                                       "descriptor_qa_check",
+	                                       param_types, {}, &entry);
+	builder.setBuildPoint(entry);
+
+	spv::Id offset_id = func->getParamId(0);
+	spv::Id descriptor_type_id = func->getParamId(1);
+	spv::Id instruction_id = func->getParamId(2);
+
+	builder.addName(offset_id, "heap_offset");
+	builder.addName(descriptor_type_id, "descriptor_type_mask");
+	builder.addName(instruction_id, "instruction");
+
+	spv::Id descriptor_count_id = build_ssbo_load(builder, builder.makeUintType(32), heap_buffer_id,
+	                                              uint32_t(DescriptorQAHeapMembers::DescriptorCount));
+
+	spv::Id fallback_offset_id = descriptor_count_id;
+
+	spv::Id heap_id = build_ssbo_load(builder, builder.makeUintType(32), heap_buffer_id,
+	                                  uint32_t(DescriptorQAHeapMembers::HeapIndex));
+	spv::Id cookie_descriptor_info = build_ssbo_load_array(builder, builder.makeVectorType(builder.makeUintType(32), 2),
+	                                                       heap_buffer_id,
+	                                                       uint32_t(DescriptorQAHeapMembers::CookiesDescriptorInfo),
+	                                                       offset_id);
+	spv::Id cookie_id;
+	spv::Id cookie_shifted_id;
+	spv::Id cookie_mask_id;
+	spv::Id descriptor_info_id;
+	build_cookie_descriptor_info_split(builder, cookie_descriptor_info, cookie_id,
+	                                   cookie_shifted_id, cookie_mask_id, descriptor_info_id);
+
+	spv::Id live_status_id = build_ssbo_load_array(builder, builder.makeUintType(32),
+	                                               global_buffer_id,
+	                                               uint32_t(DescriptorQAGlobalMembers::LiveStatusTable),
+	                                               cookie_shifted_id);
+	spv::Id live_status_cond_id = build_live_check(builder, live_status_id, cookie_mask_id);
+
+	spv::Id type_cond_id = build_binary_op(builder, builder.makeUintType(32), spv::OpBitwiseAnd, descriptor_info_id, descriptor_type_id);
+	type_cond_id = build_binary_op(builder, builder.makeBoolType(), spv::OpIEqual,
+	                               type_cond_id, descriptor_type_id);
+
+	spv::Id out_of_range_id = build_binary_op(builder, builder.makeBoolType(), spv::OpUGreaterThanEqual,
+	                                          offset_id, descriptor_count_id);
+
+	// First check: descriptor index is in range of heap.
+	auto range_check = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeUintType(32), spv::OpSelect);
+	range_check->addIdOperand(out_of_range_id);
+	range_check->addIdOperand(builder.makeUintConstant(DESCRIPTOR_QA_FAULT_INDEX_OUT_OF_RANGE_BIT));
+	range_check->addIdOperand(builder.makeUintConstant(0u));
+
+	// Second: Check if type matches.
+	auto type_check = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeUintType(32), spv::OpSelect);
+	type_check->addIdOperand(type_cond_id);
+	type_check->addIdOperand(builder.makeUintConstant(0u));
+	type_check->addIdOperand(builder.makeUintConstant(DESCRIPTOR_QA_FAULT_INVALID_TYPE_BIT));
+
+	// Third: Check if cookie is alive.
+	auto alive_check = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeUintType(32), spv::OpSelect);
+	alive_check->addIdOperand(live_status_cond_id);
+	alive_check->addIdOperand(builder.makeUintConstant(0u));
+	alive_check->addIdOperand(builder.makeUintConstant(DESCRIPTOR_QA_FAULT_RESOURCE_DESTROYED_BIT));
+
+	auto merge_check0 = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeUintType(32), spv::OpBitwiseOr);
+	auto merge_check1 = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeUintType(32), spv::OpBitwiseOr);
+	merge_check0->addIdOperand(range_check->getResultId());
+	merge_check0->addIdOperand(type_check->getResultId());
+	merge_check1->addIdOperand(merge_check0->getResultId());
+	merge_check1->addIdOperand(alive_check->getResultId());
+
+	auto fault_cond = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeBoolType(), spv::OpINotEqual);
+	fault_cond->addIdOperand(merge_check1->getResultId());
+	fault_cond->addIdOperand(builder.makeUintConstant(0u));
+
+	spv::Id fault_type_id = merge_check1->getResultId();
+	spv::Id fault_cond_id = fault_cond->getResultId();
+
+	builder.getBuildPoint()->addInstruction(std::move(range_check));
+	builder.getBuildPoint()->addInstruction(std::move(type_check));
+	builder.getBuildPoint()->addInstruction(std::move(alive_check));
+	builder.getBuildPoint()->addInstruction(std::move(merge_check0));
+	builder.getBuildPoint()->addInstruction(std::move(merge_check1));
+	builder.getBuildPoint()->addInstruction(std::move(fault_cond));
+
+	auto *fault_block = new spv::Block(builder.getUniqueId(), *func);
+	auto *correct_block = new spv::Block(builder.getUniqueId(), *func);
+	builder.createSelectionMerge(correct_block, 0);
+	builder.createConditionalBranch(fault_cond_id, fault_block, correct_block);
+	{
+		builder.setBuildPoint(fault_block);
+		auto call = std::make_unique<spv::Instruction>(builder.getUniqueId(), builder.makeVoidType(), spv::OpFunctionCall);
+		call->addIdOperand(fault_func_id);
+		call->addIdOperand(fault_type_id);
+		call->addIdOperand(offset_id);
+		call->addIdOperand(cookie_id);
+		call->addIdOperand(heap_id);
+		call->addIdOperand(descriptor_type_id);
+		call->addIdOperand(descriptor_info_id);
+		call->addIdOperand(instruction_id);
+		builder.getBuildPoint()->addInstruction(std::move(call));
+		builder.makeReturn(false, fallback_offset_id);
+	}
+	builder.setBuildPoint(correct_block);
+	builder.makeReturn(false, offset_id);
+
+	builder.setBuildPoint(current_build_point);
+	return func->getId();
+}
+}

--- a/descriptor_qa.hpp
+++ b/descriptor_qa.hpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Hans-Kristian Arntzen for Valve Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "spirv.hpp"
+
+namespace dxil_spv
+{
+static constexpr uint32_t Version = 1;
+
+struct DescriptorQAInfo
+{
+	uint32_t version = 0;
+	uint32_t global_desc_set = 0;
+	uint32_t global_binding = 0;
+	uint32_t heap_desc_set = 0;
+	uint32_t heap_binding = 0;
+	uint64_t shader_hash = 0;
+};
+
+enum DescriptorQATypeFlagBits
+{
+	DESCRIPTOR_QA_TYPE_NONE_BIT = 0,
+	DESCRIPTOR_QA_TYPE_SAMPLED_IMAGE_BIT = 1 << 0,
+	DESCRIPTOR_QA_TYPE_STORAGE_IMAGE_BIT = 1 << 1,
+	DESCRIPTOR_QA_TYPE_UNIFORM_BUFFER_BIT = 1 << 2,
+	DESCRIPTOR_QA_TYPE_STORAGE_BUFFER_BIT = 1 << 3,
+	DESCRIPTOR_QA_TYPE_UNIFORM_TEXEL_BUFFER_BIT = 1 << 4,
+	DESCRIPTOR_QA_TYPE_STORAGE_TEXEL_BUFFER_BIT = 1 << 5,
+	DESCRIPTOR_QA_TYPE_RT_ACCELERATION_STRUCTURE_BIT = 1 << 6,
+	DESCRIPTOR_QA_TYPE_SAMPLER_BIT = 1 << 7,
+	DESCRIPTOR_QA_TYPE_RAW_VA_BIT = 1 << 8
+};
+using DescriptorQATypeFlags = uint32_t;
+
+enum class DescriptorQAGlobalMembers
+{
+	FailedShaderHash = 0,
+	FailedOffset,
+	FailedHeap,
+	FailedCookie,
+	FaultAtomic,
+	FailedInstruction,
+	FailedDescriptorTypeMask,
+	ActualDescriptorTypeMask,
+	FaultType,
+	LiveStatusTable
+};
+
+enum DescriptorQAFaultTypeBits
+{
+	DESCRIPTOR_QA_FAULT_INDEX_OUT_OF_RANGE_BIT = 1 << 0,
+	DESCRIPTOR_QA_FAULT_INVALID_TYPE_BIT = 1 << 1,
+	DESCRIPTOR_QA_FAULT_RESOURCE_DESTROYED_BIT = 1 << 2
+};
+
+enum class DescriptorQAHeapMembers
+{
+	DescriptorCount = 0,
+	HeapIndex,
+	CookiesDescriptorInfo
+};
+
+class SPIRVModule;
+spv::Id build_descriptor_qa_check_function(SPIRVModule &module);
+}

--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -4241,14 +4241,7 @@ bool Converter::Impl::composite_is_accessed(const llvm::Value *composite) const
 
 bool Converter::Impl::analyze_instructions()
 {
-	// Some things need to happen here. We try to figure out if a UAV is readonly or writeonly.
-	// If readonly typed UAV, we emit an image format which corresponds to r32f, r32i or r32ui as to not
-	// require StorageReadWithoutFormat capability. TODO: With FL 12, this might not be enough, but should be
-	// good enough for time being.
-	if (!analyze_instructions(get_entry_point_function(entry_point_meta)))
-		return false;
-
-	return true;
+	return analyze_instructions(get_entry_point_function(entry_point_meta));
 }
 
 ConvertedFunction Converter::Impl::convert_entry_point()

--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -4249,6 +4249,7 @@ ConvertedFunction Converter::Impl::convert_entry_point()
 	result.node_pool = std::make_unique<CFGNodePool>();
 	auto &pool = *result.node_pool;
 
+	spirv_module.set_descriptor_qa_info(options.descriptor_qa);
 	spirv_module.emit_entry_point(get_execution_model(module, entry_point_meta), "main", options.physical_storage_buffer);
 
 	if (!emit_resources_global_mapping())
@@ -4517,6 +4518,19 @@ void Converter::Impl::set_option(const OptionBase &cap)
 		break;
 	}
 
+	case Option::DescriptorQA:
+	{
+		auto &qa = static_cast<const OptionDescriptorQA &>(cap);
+		options.descriptor_qa_enabled = qa.enabled;
+		options.descriptor_qa.version = qa.version;
+		options.descriptor_qa.shader_hash = qa.shader_hash;
+		options.descriptor_qa.global_desc_set = qa.global_desc_set;
+		options.descriptor_qa.global_binding = qa.global_binding;
+		options.descriptor_qa.heap_desc_set = qa.heap_desc_set;
+		options.descriptor_qa.heap_binding = qa.heap_binding;
+		break;
+	}
+
 	default:
 		break;
 	}
@@ -4561,6 +4575,7 @@ bool Converter::recognizes_option(Option cap)
 	case Option::BindlessTypedBufferOffsets:
 	case Option::BindlessOffsetBufferLayout:
 	case Option::StorageInputOutput16:
+	case Option::DescriptorQA:
 		return true;
 
 	default:

--- a/dxil_converter.hpp
+++ b/dxil_converter.hpp
@@ -205,6 +205,7 @@ enum class Option : uint32_t
 	BindlessTypedBufferOffsets = 12,
 	BindlessOffsetBufferLayout = 13,
 	StorageInputOutput16 = 14,
+	DescriptorQA = 15
 };
 
 enum class ResourceClass : uint32_t
@@ -359,6 +360,24 @@ struct OptionStorageInputOutput16 : OptionBase
 	}
 
 	bool supported = true;
+};
+
+struct OptionDescriptorQA : OptionBase
+{
+	OptionDescriptorQA()
+		: OptionBase(Option::DescriptorQA)
+	{
+	}
+
+	enum { DefaultVersion = 1 };
+
+	bool enabled = false;
+	uint32_t version = DefaultVersion;
+	uint32_t global_desc_set = 0;
+	uint32_t global_binding = 0;
+	uint32_t heap_desc_set = 0;
+	uint32_t heap_binding = 0;
+	uint64_t shader_hash = 0;
 };
 
 struct DescriptorTableEntry

--- a/dxil_spirv_c.cpp
+++ b/dxil_spirv_c.cpp
@@ -758,6 +758,21 @@ dxil_spv_result dxil_spv_converter_add_option(dxil_spv_converter converter, cons
 		break;
 	}
 
+	case DXIL_SPV_OPTION_DESCRIPTOR_QA:
+	{
+		OptionDescriptorQA helper;
+		auto *qa = reinterpret_cast<const dxil_spv_option_descriptor_qa *>(option);
+		helper.enabled = qa->enabled == DXIL_SPV_TRUE;
+		helper.shader_hash = qa->shader_hash;
+		helper.global_desc_set = qa->global_desc_set;
+		helper.global_binding = qa->global_binding;
+		helper.heap_desc_set = qa->heap_desc_set;
+		helper.heap_binding = qa->heap_binding;
+		helper.version = qa->version;
+		converter->options.emplace_back(duplicate(helper));
+		break;
+	}
+
 	default:
 		return DXIL_SPV_ERROR_UNSUPPORTED_FEATURE;
 	}

--- a/dxil_spirv_c.h
+++ b/dxil_spirv_c.h
@@ -28,8 +28,10 @@ extern "C" {
 #endif
 
 #define DXIL_SPV_API_VERSION_MAJOR 2
-#define DXIL_SPV_API_VERSION_MINOR 4
+#define DXIL_SPV_API_VERSION_MINOR 5
 #define DXIL_SPV_API_VERSION_PATCH 0
+
+#define DXIL_SPV_DESCRIPTOR_QA_INTERFACE_VERSION 1
 
 #if !defined(DXIL_SPV_PUBLIC_API)
 #if defined(DXIL_SPV_EXPORT_SYMBOLS)
@@ -273,6 +275,7 @@ typedef enum dxil_spv_option
 	DXIL_SPV_OPTION_BINDLESS_TYPED_BUFFER_OFFSETS = 12,
 	DXIL_SPV_OPTION_BINDLESS_OFFSET_BUFFER_LAYOUT = 13,
 	DXIL_SPV_OPTION_STORAGE_INPUT_OUTPUT_16BIT = 14,
+	DXIL_SPV_OPTION_DESCRIPTOR_QA = 15,
 	DXIL_SPV_OPTION_INT_MAX = 0x7fffffff
 } dxil_spv_option;
 
@@ -379,6 +382,18 @@ typedef struct dxil_spv_option_storage_input_output_16bit
 	dxil_spv_option_base base;
 	dxil_spv_bool supported;
 } dxil_spv_option_storage_input_output_16bit;
+
+typedef struct dxil_spv_option_descriptor_qa
+{
+	dxil_spv_option_base base;
+	dxil_spv_bool enabled;
+	unsigned version;
+	unsigned global_desc_set;
+	unsigned global_binding;
+	unsigned heap_desc_set;
+	unsigned heap_binding;
+	unsigned long long shader_hash;
+} dxil_spv_option_descriptor_qa;
 
 /* Gets the ABI version used to build this library. Used to detect API/ABI mismatches. */
 DXIL_SPV_PUBLIC_API void dxil_spv_get_version(unsigned *major, unsigned *minor, unsigned *patch);

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ dxil_spirv_src = [
   # spirv-module
   'ir.cpp',
   'spirv_module.cpp',
+  'descriptor_qa.cpp',
 
   # dxil-converter
   'memory_stream.cpp',

--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -102,7 +102,7 @@ struct Converter::Impl
 		DXIL_SPV_OVERRIDE_NEW_DELETE
 	};
 	Vector<std::unique_ptr<BlockMeta>> metas;
-	UnorderedMap<llvm::BasicBlock *, BlockMeta *> bb_map;
+	UnorderedMap<const llvm::BasicBlock *, BlockMeta *> bb_map;
 	UnorderedMap<const llvm::Value *, spv::Id> value_map;
 	UnorderedMap<spv::Id, spv::Id> phi_incoming_rewrite;
 
@@ -379,6 +379,7 @@ struct Converter::Impl
 
 		DescriptorQAInfo descriptor_qa;
 		bool descriptor_qa_enabled = false;
+		bool descriptor_qa_sink_handles = true;
 	} options;
 
 	struct BindlessInfo
@@ -434,5 +435,11 @@ struct Converter::Impl
 		bool has_side_effects = false;
 		bool discards = false;
 	} shader_analysis;
+
+	// For descriptor QA, we need to rewrite how resource handles are emitted.
+	UnorderedMap<const llvm::CallInst *, const llvm::BasicBlock *> resource_handle_to_block;
+	UnorderedSet<const llvm::CallInst *> resource_handles_needing_sink;
+	UnorderedSet<const llvm::CallInst *> resource_handle_is_conservative;
+	UnorderedMap<const llvm::BasicBlock *, Vector<const llvm::Instruction *>> bb_to_sinks;
 };
 } // namespace dxil_spv

--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -427,5 +427,12 @@ struct Converter::Impl
 
 	DXIL::ComponentType get_effective_input_output_type(DXIL::ComponentType type);
 	spv::Id get_effective_input_output_type_id(DXIL::ComponentType type);
+
+	struct
+	{
+		// Only relevant for fragment shaders.
+		bool has_side_effects = false;
+		bool discards = false;
+	} shader_analysis;
 };
 } // namespace dxil_spv

--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -23,6 +23,7 @@
 #include "cfg_structurizer.hpp"
 #include "dxil_converter.hpp"
 #include "scratch_pool.hpp"
+#include "descriptor_qa.hpp"
 
 #include "GLSL.std.450.h"
 
@@ -234,6 +235,7 @@ struct Converter::Impl
 	unsigned root_descriptor_count = 0;
 	unsigned root_constant_num_words = 0;
 	unsigned patch_location_offset = 0;
+	unsigned descriptor_qa_counter = 0;
 
 	struct PhysicalPointerMeta
 	{
@@ -374,6 +376,9 @@ struct Converter::Impl
 			unsigned typed_offset = 0;
 			unsigned stride = 1;
 		} offset_buffer_layout;
+
+		DescriptorQAInfo descriptor_qa;
+		bool descriptor_qa_enabled = false;
 	} options;
 
 	struct BindlessInfo

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -329,6 +329,7 @@ bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instr
 			node.has_read = true;
 			node.has_written = true;
 			node.has_atomic = true;
+			impl.shader_analysis.has_side_effects = true;
 		}
 		break;
 	}
@@ -343,6 +344,7 @@ bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instr
 			auto &node = impl.uav_access_tracking[itr->second];
 			node.has_written = true;
 			update_access_tracking_from_type(node, instruction->getOperand(4)->getType());
+			impl.shader_analysis.has_side_effects = true;
 		}
 		break;
 	}
@@ -350,6 +352,7 @@ bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instr
 	case DXIL::Op::BufferUpdateCounter:
 	{
 		impl.llvm_values_using_update_counter.insert(instruction->getOperand(1));
+		impl.shader_analysis.has_side_effects = true;
 		break;
 	}
 
@@ -405,6 +408,10 @@ bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instr
 		impl.llvm_hit_attribute_output_type = type;
 		break;
 	}
+
+	case DXIL::Op::Discard:
+		impl.shader_analysis.discards = true;
+		break;
 
 	default:
 		break;

--- a/opcodes/opcodes_dxil_builtins.hpp
+++ b/opcodes/opcodes_dxil_builtins.hpp
@@ -25,5 +25,5 @@ namespace dxil_spv
 using DXILOperationBuilder = bool (*)(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 
-bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instruction, const llvm::BasicBlock *bb);
 } // namespace dxil_spv

--- a/reference/shaders/descriptor_qa/acceleration-structure.bindless.descriptor-qa.rgen
+++ b/reference/shaders/descriptor_qa/acceleration-structure.bindless.descriptor-qa.rgen
@@ -1,0 +1,352 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+struct _15
+{
+    vec4 _m0;
+};
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT _12[];
+layout(location = 0) rayPayloadEXT _15 _17;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _54 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_54 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _90 = QAHeapData.descriptor_count;
+    uint _92 = QAHeapData.heap_index;
+    uvec2 _94 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _102 = QAGlobalData.live_status_table[_94.x >> 5u];
+    uint _113 = (uint(heap_offset >= _90) | (((_94.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_102 & (1u << (_94.x & 31u))) != 0u) ? 0u : 4u);
+    if (_113 != 0u)
+    {
+        descriptor_qa_report_fault(_113, heap_offset, _94.x, _92, descriptor_type_mask, _94.y, instruction);
+        return _90;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    _17._m0 = vec4(1.0, 2.0, 3.0, 4.0);
+    uint _35 = descriptor_qa_check((registers._m0 + 100u) + 10u, 64u, 1u);
+    traceRayEXT(_12[_35], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    uint _130 = descriptor_qa_check(registers._m0 + 3u, 64u, 2u);
+    traceRayEXT(_12[_130], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    uint _142 = descriptor_qa_check((registers._m0 + 100u) + uint(int(_17._m0.w)), 64u, 3u);
+    traceRayEXT(_12[nonuniformEXT(_142)], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.4
+; Generator: Unknown(30017); 21022
+; Bound: 148
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint RayGenerationNV %3 "main" %8 %12 %17 %40 %82
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %15 ""
+OpName %38 "DescriptorHeapGlobalQAData"
+OpMemberName %38 0 "failed_shader_hash"
+OpMemberName %38 1 "failed_offset"
+OpMemberName %38 2 "failed_heap"
+OpMemberName %38 3 "failed_cookie"
+OpMemberName %38 4 "fault_atomic"
+OpMemberName %38 5 "failed_instruction"
+OpMemberName %38 6 "failed_descriptor_type_mask"
+OpMemberName %38 7 "actual_descriptor_type_mask"
+OpMemberName %38 8 "fault_type"
+OpMemberName %38 9 "live_status_table"
+OpName %40 "QAGlobalData"
+OpName %49 "descriptor_qa_report_fault"
+OpName %42 "fault_type"
+OpName %43 "heap_offset"
+OpName %44 "cookie"
+OpName %45 "heap_index"
+OpName %46 "descriptor_type"
+OpName %47 "actual_descriptor_type"
+OpName %48 "instruction"
+OpName %80 "DescriptorHeapQAData"
+OpMemberName %80 0 "descriptor_count"
+OpMemberName %80 1 "heap_index"
+OpMemberName %80 2 "cookies_descriptor_info"
+OpName %82 "QAHeapData"
+OpName %87 "descriptor_qa_check"
+OpName %84 "heap_offset"
+OpName %85 "descriptor_type_mask"
+OpName %86 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %12 DescriptorSet 0
+OpDecorate %12 Binding 0
+OpDecorate %37 ArrayStride 4
+OpMemberDecorate %38 0 Offset 0
+OpMemberDecorate %38 1 Offset 8
+OpMemberDecorate %38 2 Offset 12
+OpMemberDecorate %38 3 Offset 16
+OpMemberDecorate %38 4 Offset 20
+OpMemberDecorate %38 5 Offset 24
+OpMemberDecorate %38 6 Offset 28
+OpMemberDecorate %38 7 Offset 32
+OpMemberDecorate %38 8 Offset 36
+OpMemberDecorate %38 9 Offset 40
+OpDecorate %38 Block
+OpDecorate %40 DescriptorSet 10
+OpDecorate %40 Binding 10
+OpDecorate %79 ArrayStride 8
+OpMemberDecorate %80 0 Offset 0
+OpMemberDecorate %80 1 Offset 4
+OpMemberDecorate %80 2 Offset 8
+OpDecorate %80 Block
+OpDecorate %82 DescriptorSet 10
+OpDecorate %82 Binding 11
+OpDecorate %82 NonWritable
+OpDecorate %142 NonUniform
+OpDecorate %143 NonUniform
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeAccelerationStructureKHR
+%10 = OpTypeRuntimeArray %9
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeFloat 32
+%14 = OpTypeVector %13 4
+%15 = OpTypeStruct %14
+%16 = OpTypePointer RayPayloadNV %15
+%17 = OpVariable %16 RayPayloadNV
+%18 = OpTypePointer RayPayloadNV %14
+%20 = OpConstant %5 0
+%21 = OpConstant %13 1
+%22 = OpConstant %13 2
+%23 = OpConstant %13 3
+%24 = OpConstant %13 4
+%25 = OpConstantComposite %14 %21 %22 %23 %24
+%26 = OpTypePointer UniformConstant %9
+%28 = OpTypePointer PushConstant %5
+%32 = OpConstant %5 100
+%34 = OpConstant %5 10
+%36 = OpTypeVector %5 2
+%37 = OpTypeRuntimeArray %5
+%38 = OpTypeStruct %36 %5 %5 %5 %5 %5 %5 %5 %5 %37
+%39 = OpTypePointer StorageBuffer %38
+%40 = OpVariable %39 StorageBuffer
+%41 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%51 = OpTypePointer StorageBuffer %5
+%53 = OpConstant %5 4
+%55 = OpConstant %5 1
+%56 = OpTypeBool
+%61 = OpConstant %5 3
+%64 = OpConstant %5 2
+%66 = OpConstant %5 6
+%68 = OpConstant %5 7
+%70 = OpConstant %5 5
+%71 = OpConstant %5 3735928559
+%72 = OpConstantComposite %36 %71 %20
+%73 = OpTypePointer StorageBuffer %36
+%75 = OpConstant %5 72
+%77 = OpConstant %5 8
+%79 = OpTypeRuntimeArray %36
+%80 = OpTypeStruct %5 %5 %79
+%81 = OpTypePointer StorageBuffer %80
+%82 = OpVariable %81 StorageBuffer
+%83 = OpTypeFunction %5 %5 %5 %5
+%99 = OpConstant %5 31
+%101 = OpConstant %5 9
+%120 = OpConstant %5 64
+%122 = OpConstant %13 0
+%123 = OpTypeVector %13 3
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %146
+%146 = OpLabel
+%19 = OpInBoundsAccessChain %18 %17 %20
+OpStore %19 %25
+%29 = OpAccessChain %28 %8 %20
+%30 = OpLoad %5 %29
+%31 = OpIAdd %5 %30 %32
+%33 = OpIAdd %5 %31 %34
+%35 = OpFunctionCall %5 %87 %33 %120 %55
+%27 = OpAccessChain %26 %12 %35
+%121 = OpLoad %9 %27
+%124 = OpCompositeConstruct %123 %21 %22 %23
+%125 = OpCompositeConstruct %123 %122 %122 %21
+OpTraceRayKHR %121 %20 %20 %20 %20 %20 %124 %21 %125 %24 %17
+%127 = OpAccessChain %28 %8 %20
+%128 = OpLoad %5 %127
+%129 = OpIAdd %5 %128 %61
+%130 = OpFunctionCall %5 %87 %129 %120 %64
+%126 = OpAccessChain %26 %12 %130
+%131 = OpLoad %9 %126
+%132 = OpCompositeConstruct %123 %21 %22 %23
+%133 = OpCompositeConstruct %123 %122 %122 %21
+OpTraceRayKHR %131 %20 %20 %20 %20 %20 %132 %21 %133 %24 %17
+%134 = OpLoad %14 %19
+%135 = OpCompositeExtract %13 %134 3
+%136 = OpConvertFToS %5 %135
+%138 = OpAccessChain %28 %8 %20
+%139 = OpLoad %5 %138
+%140 = OpIAdd %5 %139 %32
+%141 = OpIAdd %5 %140 %136
+%142 = OpFunctionCall %5 %87 %141 %120 %61
+%137 = OpAccessChain %26 %12 %142
+%143 = OpLoad %9 %137
+%144 = OpCompositeConstruct %123 %21 %22 %23
+%145 = OpCompositeConstruct %123 %122 %122 %21
+OpTraceRayKHR %143 %20 %20 %20 %20 %20 %144 %21 %145 %24 %17
+OpReturn
+OpFunctionEnd
+%49 = OpFunction %1 None %41
+%42 = OpFunctionParameter %5
+%43 = OpFunctionParameter %5
+%44 = OpFunctionParameter %5
+%45 = OpFunctionParameter %5
+%46 = OpFunctionParameter %5
+%47 = OpFunctionParameter %5
+%48 = OpFunctionParameter %5
+%50 = OpLabel
+%52 = OpAccessChain %51 %40 %53
+%54 = OpAtomicExchange %5 %52 %55 %20 %55
+%57 = OpIEqual %56 %54 %20
+OpSelectionMerge %59 None
+OpBranchConditional %57 %58 %59
+%58 = OpLabel
+%60 = OpAccessChain %51 %40 %61
+OpStore %60 %44
+%62 = OpAccessChain %51 %40 %55
+OpStore %62 %43
+%63 = OpAccessChain %51 %40 %64
+OpStore %63 %45
+%65 = OpAccessChain %51 %40 %66
+OpStore %65 %46
+%67 = OpAccessChain %51 %40 %68
+OpStore %67 %47
+%69 = OpAccessChain %51 %40 %70
+OpStore %69 %48
+%74 = OpAccessChain %73 %40 %20
+OpStore %74 %72
+OpMemoryBarrier %55 %75
+%76 = OpAccessChain %51 %40 %77
+OpStore %76 %42
+OpBranch %59
+%59 = OpLabel
+OpReturn
+OpFunctionEnd
+%87 = OpFunction %5 None %83
+%84 = OpFunctionParameter %5
+%85 = OpFunctionParameter %5
+%86 = OpFunctionParameter %5
+%88 = OpLabel
+%89 = OpAccessChain %51 %82 %20
+%90 = OpLoad %5 %89
+%91 = OpAccessChain %51 %82 %55
+%92 = OpLoad %5 %91
+%93 = OpAccessChain %73 %82 %64 %84
+%94 = OpLoad %36 %93
+%95 = OpCompositeExtract %5 %94 0
+%97 = OpShiftRightLogical %5 %95 %70
+%98 = OpBitwiseAnd %5 %95 %99
+%96 = OpCompositeExtract %5 %94 1
+%100 = OpAccessChain %51 %40 %101 %97
+%102 = OpLoad %5 %100
+%103 = OpShiftLeftLogical %5 %55 %98
+%104 = OpBitwiseAnd %5 %102 %103
+%105 = OpINotEqual %56 %104 %20
+%106 = OpBitwiseAnd %5 %96 %85
+%107 = OpIEqual %56 %106 %85
+%108 = OpUGreaterThanEqual %56 %84 %90
+%109 = OpSelect %5 %108 %55 %20
+%110 = OpSelect %5 %107 %20 %64
+%111 = OpSelect %5 %105 %20 %53
+%112 = OpBitwiseOr %5 %109 %110
+%113 = OpBitwiseOr %5 %112 %111
+%114 = OpINotEqual %56 %113 %20
+OpSelectionMerge %116 None
+OpBranchConditional %114 %115 %116
+%115 = OpLabel
+%117 = OpFunctionCall %1 %49 %113 %84 %95 %92 %85 %96 %86
+OpReturnValue %90
+%116 = OpLabel
+OpReturnValue %84
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/acceleration-structure.bindless.descriptor-qa.rgen
+++ b/reference/shaders/descriptor_qa/acceleration-structure.bindless.descriptor-qa.rgen
@@ -46,7 +46,7 @@ layout(location = 0) rayPayloadEXT _15 _17;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _54 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _54 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_54 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -286,7 +286,7 @@ OpFunctionEnd
 %48 = OpFunctionParameter %5
 %50 = OpLabel
 %52 = OpAccessChain %51 %40 %53
-%54 = OpAtomicExchange %5 %52 %55 %20 %55
+%54 = OpAtomicIAdd %5 %52 %55 %20 %55
 %57 = OpIEqual %56 %54 %20
 OpSelectionMerge %59 None
 OpBranchConditional %57 %58 %59

--- a/reference/shaders/descriptor_qa/acceleration-structure.bindless.ssbo-rtas.local-root-signature.descriptor-qa.rgen
+++ b/reference/shaders/descriptor_qa/acceleration-structure.bindless.ssbo-rtas.local-root-signature.descriptor-qa.rgen
@@ -1,0 +1,420 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_KHR_shader_subgroup_ballot : require
+
+struct _23
+{
+    vec4 _m0;
+};
+
+layout(shaderRecordEXT, std430) buffer SBTBlock
+{
+    uint _m0[5];
+    uint _m1[6];
+    uvec2 _m2;
+    uvec2 _m3;
+    uvec2 _m4;
+    uvec2 _m5;
+    uvec2 _m6;
+    uvec2 _m7;
+    uvec2 _m8;
+    uvec2 _m9;
+    uvec2 _m10;
+} SBT;
+
+layout(set = 0, binding = 0, std430) restrict readonly buffer RTASHeap
+{
+    uvec2 _m0[];
+} _20;
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(location = 0) rayPayloadEXT _23 _25;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _59 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_59 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _93 = QAHeapData.descriptor_count;
+    uint _95 = QAHeapData.heap_index;
+    uvec2 _97 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _105 = QAGlobalData.live_status_table[_97.x >> 5u];
+    uint _116 = (uint(heap_offset >= _93) | (((_97.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_105 & (1u << (_97.x & 31u))) != 0u) ? 0u : 4u);
+    if (_116 != 0u)
+    {
+        descriptor_qa_report_fault(_116, heap_offset, _97.x, _95, descriptor_type_mask, _97.y, instruction);
+        return _93;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    _25._m0 = vec4(1.0, 2.0, 3.0, 4.0);
+    uint _41 = descriptor_qa_check((registers._m0 + 100u) + 10u, 320u, 1u);
+    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst(_41)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    uint _136 = descriptor_qa_check(registers._m0 + 3u, 320u, 2u);
+    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst(_136)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    uint _150 = descriptor_qa_check((registers._m0 + 100u) + uint(int(_25._m0.w)), 320u, 3u);
+    traceRayEXT(accelerationStructureEXT(_20._m0[_150]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    uint _163 = descriptor_qa_check(((SBT._m7.x >> 6u) + 10u) + 200u, 320u, 4u);
+    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst(_163)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.4
+; Generator: Unknown(30017); 21022
+; Bound: 172
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability GroupNonUniformBallot
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint RayGenerationNV %3 "main" %8 %16 %20 %25 %45 %85
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %14 "SBTBlock"
+OpName %16 "SBT"
+OpName %18 "RTASHeap"
+OpName %23 ""
+OpName %43 "DescriptorHeapGlobalQAData"
+OpMemberName %43 0 "failed_shader_hash"
+OpMemberName %43 1 "failed_offset"
+OpMemberName %43 2 "failed_heap"
+OpMemberName %43 3 "failed_cookie"
+OpMemberName %43 4 "fault_atomic"
+OpMemberName %43 5 "failed_instruction"
+OpMemberName %43 6 "failed_descriptor_type_mask"
+OpMemberName %43 7 "actual_descriptor_type_mask"
+OpMemberName %43 8 "fault_type"
+OpMemberName %43 9 "live_status_table"
+OpName %45 "QAGlobalData"
+OpName %54 "descriptor_qa_report_fault"
+OpName %47 "fault_type"
+OpName %48 "heap_offset"
+OpName %49 "cookie"
+OpName %50 "heap_index"
+OpName %51 "descriptor_type"
+OpName %52 "actual_descriptor_type"
+OpName %53 "instruction"
+OpName %83 "DescriptorHeapQAData"
+OpMemberName %83 0 "descriptor_count"
+OpMemberName %83 1 "heap_index"
+OpMemberName %83 2 "cookies_descriptor_info"
+OpName %85 "QAHeapData"
+OpName %90 "descriptor_qa_check"
+OpName %87 "heap_offset"
+OpName %88 "descriptor_type_mask"
+OpName %89 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %10 ArrayStride 4
+OpDecorate %12 ArrayStride 4
+OpDecorate %14 Block
+OpMemberDecorate %14 0 Offset 0
+OpMemberDecorate %14 1 Offset 20
+OpMemberDecorate %14 2 Offset 48
+OpMemberDecorate %14 3 Offset 56
+OpMemberDecorate %14 4 Offset 64
+OpMemberDecorate %14 5 Offset 72
+OpMemberDecorate %14 6 Offset 80
+OpMemberDecorate %14 7 Offset 88
+OpMemberDecorate %14 8 Offset 96
+OpMemberDecorate %14 9 Offset 104
+OpMemberDecorate %14 10 Offset 112
+OpDecorate %17 ArrayStride 8
+OpMemberDecorate %18 0 Offset 0
+OpDecorate %18 Block
+OpDecorate %20 DescriptorSet 0
+OpDecorate %20 Binding 0
+OpDecorate %20 NonWritable
+OpDecorate %20 Restrict
+OpDecorate %42 ArrayStride 4
+OpMemberDecorate %43 0 Offset 0
+OpMemberDecorate %43 1 Offset 8
+OpMemberDecorate %43 2 Offset 12
+OpMemberDecorate %43 3 Offset 16
+OpMemberDecorate %43 4 Offset 20
+OpMemberDecorate %43 5 Offset 24
+OpMemberDecorate %43 6 Offset 28
+OpMemberDecorate %43 7 Offset 32
+OpMemberDecorate %43 8 Offset 36
+OpMemberDecorate %43 9 Offset 40
+OpDecorate %43 Block
+OpDecorate %45 DescriptorSet 10
+OpDecorate %45 Binding 10
+OpDecorate %82 ArrayStride 8
+OpMemberDecorate %83 0 Offset 0
+OpMemberDecorate %83 1 Offset 4
+OpMemberDecorate %83 2 Offset 8
+OpDecorate %83 Block
+OpDecorate %85 DescriptorSet 10
+OpDecorate %85 Binding 11
+OpDecorate %85 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpConstant %5 5
+%10 = OpTypeArray %5 %9
+%11 = OpConstant %5 6
+%12 = OpTypeArray %5 %11
+%13 = OpTypeVector %5 2
+%14 = OpTypeStruct %10 %12 %13 %13 %13 %13 %13 %13 %13 %13 %13
+%15 = OpTypePointer ShaderRecordBufferNV %14
+%16 = OpVariable %15 ShaderRecordBufferNV
+%17 = OpTypeRuntimeArray %13
+%18 = OpTypeStruct %17
+%19 = OpTypePointer StorageBuffer %18
+%20 = OpVariable %19 StorageBuffer
+%21 = OpTypeFloat 32
+%22 = OpTypeVector %21 4
+%23 = OpTypeStruct %22
+%24 = OpTypePointer RayPayloadNV %23
+%25 = OpVariable %24 RayPayloadNV
+%26 = OpTypePointer RayPayloadNV %22
+%28 = OpConstant %5 0
+%29 = OpConstant %21 1
+%30 = OpConstant %21 2
+%31 = OpConstant %21 3
+%32 = OpConstant %21 4
+%33 = OpConstantComposite %22 %29 %30 %31 %32
+%34 = OpTypePointer PushConstant %5
+%38 = OpConstant %5 100
+%40 = OpConstant %5 10
+%42 = OpTypeRuntimeArray %5
+%43 = OpTypeStruct %13 %5 %5 %5 %5 %5 %5 %5 %5 %42
+%44 = OpTypePointer StorageBuffer %43
+%45 = OpVariable %44 StorageBuffer
+%46 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%56 = OpTypePointer StorageBuffer %5
+%58 = OpConstant %5 4
+%60 = OpConstant %5 1
+%61 = OpTypeBool
+%66 = OpConstant %5 3
+%69 = OpConstant %5 2
+%72 = OpConstant %5 7
+%74 = OpConstant %5 3735928559
+%75 = OpConstantComposite %13 %74 %28
+%76 = OpTypePointer StorageBuffer %13
+%78 = OpConstant %5 72
+%80 = OpConstant %5 8
+%82 = OpTypeRuntimeArray %13
+%83 = OpTypeStruct %5 %5 %82
+%84 = OpTypePointer StorageBuffer %83
+%85 = OpVariable %84 StorageBuffer
+%86 = OpTypeFunction %5 %5 %5 %5
+%102 = OpConstant %5 31
+%104 = OpConstant %5 9
+%123 = OpConstant %5 320
+%127 = OpTypeAccelerationStructureKHR
+%129 = OpConstant %21 0
+%130 = OpTypeVector %21 3
+%156 = OpTypePointer ShaderRecordBufferNV %5
+%162 = OpConstant %5 200
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %170
+%170 = OpLabel
+%27 = OpInBoundsAccessChain %26 %25 %28
+OpStore %27 %33
+%35 = OpAccessChain %34 %8 %28
+%36 = OpLoad %5 %35
+%37 = OpIAdd %5 %36 %38
+%39 = OpIAdd %5 %37 %40
+%41 = OpFunctionCall %5 %90 %39 %123 %60
+%124 = OpGroupNonUniformBroadcastFirst %5 %66 %41
+%125 = OpAccessChain %76 %20 %28 %124
+%126 = OpLoad %13 %125
+%128 = OpConvertUToAccelerationStructureKHR %127 %126
+%131 = OpCompositeConstruct %130 %29 %30 %31
+%132 = OpCompositeConstruct %130 %129 %129 %29
+OpTraceRayKHR %128 %28 %28 %28 %28 %28 %131 %29 %132 %32 %25
+%133 = OpAccessChain %34 %8 %28
+%134 = OpLoad %5 %133
+%135 = OpIAdd %5 %134 %66
+%136 = OpFunctionCall %5 %90 %135 %123 %69
+%137 = OpGroupNonUniformBroadcastFirst %5 %66 %136
+%138 = OpAccessChain %76 %20 %28 %137
+%139 = OpLoad %13 %138
+%140 = OpConvertUToAccelerationStructureKHR %127 %139
+%141 = OpCompositeConstruct %130 %29 %30 %31
+%142 = OpCompositeConstruct %130 %129 %129 %29
+OpTraceRayKHR %140 %28 %28 %28 %28 %28 %141 %29 %142 %32 %25
+%143 = OpLoad %22 %27
+%144 = OpCompositeExtract %21 %143 3
+%145 = OpConvertFToS %5 %144
+%146 = OpAccessChain %34 %8 %28
+%147 = OpLoad %5 %146
+%148 = OpIAdd %5 %147 %38
+%149 = OpIAdd %5 %148 %145
+%150 = OpFunctionCall %5 %90 %149 %123 %66
+%151 = OpAccessChain %76 %20 %28 %150
+%152 = OpLoad %13 %151
+%153 = OpConvertUToAccelerationStructureKHR %127 %152
+%154 = OpCompositeConstruct %130 %29 %30 %31
+%155 = OpCompositeConstruct %130 %129 %129 %29
+OpTraceRayKHR %153 %28 %28 %28 %28 %28 %154 %29 %155 %32 %25
+%157 = OpAccessChain %156 %16 %72 %28
+%158 = OpLoad %5 %157
+%159 = OpShiftRightLogical %5 %158 %11
+%160 = OpIAdd %5 %159 %40
+%161 = OpIAdd %5 %160 %162
+%163 = OpFunctionCall %5 %90 %161 %123 %58
+%164 = OpGroupNonUniformBroadcastFirst %5 %66 %163
+%165 = OpAccessChain %76 %20 %28 %164
+%166 = OpLoad %13 %165
+%167 = OpConvertUToAccelerationStructureKHR %127 %166
+%168 = OpCompositeConstruct %130 %29 %30 %31
+%169 = OpCompositeConstruct %130 %129 %129 %29
+OpTraceRayKHR %167 %28 %28 %28 %28 %28 %168 %29 %169 %32 %25
+OpReturn
+OpFunctionEnd
+%54 = OpFunction %1 None %46
+%47 = OpFunctionParameter %5
+%48 = OpFunctionParameter %5
+%49 = OpFunctionParameter %5
+%50 = OpFunctionParameter %5
+%51 = OpFunctionParameter %5
+%52 = OpFunctionParameter %5
+%53 = OpFunctionParameter %5
+%55 = OpLabel
+%57 = OpAccessChain %56 %45 %58
+%59 = OpAtomicExchange %5 %57 %60 %28 %60
+%62 = OpIEqual %61 %59 %28
+OpSelectionMerge %64 None
+OpBranchConditional %62 %63 %64
+%63 = OpLabel
+%65 = OpAccessChain %56 %45 %66
+OpStore %65 %49
+%67 = OpAccessChain %56 %45 %60
+OpStore %67 %48
+%68 = OpAccessChain %56 %45 %69
+OpStore %68 %50
+%70 = OpAccessChain %56 %45 %11
+OpStore %70 %51
+%71 = OpAccessChain %56 %45 %72
+OpStore %71 %52
+%73 = OpAccessChain %56 %45 %9
+OpStore %73 %53
+%77 = OpAccessChain %76 %45 %28
+OpStore %77 %75
+OpMemoryBarrier %60 %78
+%79 = OpAccessChain %56 %45 %80
+OpStore %79 %47
+OpBranch %64
+%64 = OpLabel
+OpReturn
+OpFunctionEnd
+%90 = OpFunction %5 None %86
+%87 = OpFunctionParameter %5
+%88 = OpFunctionParameter %5
+%89 = OpFunctionParameter %5
+%91 = OpLabel
+%92 = OpAccessChain %56 %85 %28
+%93 = OpLoad %5 %92
+%94 = OpAccessChain %56 %85 %60
+%95 = OpLoad %5 %94
+%96 = OpAccessChain %76 %85 %69 %87
+%97 = OpLoad %13 %96
+%98 = OpCompositeExtract %5 %97 0
+%100 = OpShiftRightLogical %5 %98 %9
+%101 = OpBitwiseAnd %5 %98 %102
+%99 = OpCompositeExtract %5 %97 1
+%103 = OpAccessChain %56 %45 %104 %100
+%105 = OpLoad %5 %103
+%106 = OpShiftLeftLogical %5 %60 %101
+%107 = OpBitwiseAnd %5 %105 %106
+%108 = OpINotEqual %61 %107 %28
+%109 = OpBitwiseAnd %5 %99 %88
+%110 = OpIEqual %61 %109 %88
+%111 = OpUGreaterThanEqual %61 %87 %93
+%112 = OpSelect %5 %111 %60 %28
+%113 = OpSelect %5 %110 %28 %69
+%114 = OpSelect %5 %108 %28 %58
+%115 = OpBitwiseOr %5 %112 %113
+%116 = OpBitwiseOr %5 %115 %114
+%117 = OpINotEqual %61 %116 %28
+OpSelectionMerge %119 None
+OpBranchConditional %117 %118 %119
+%118 = OpLabel
+%120 = OpFunctionCall %1 %54 %116 %87 %98 %95 %88 %99 %89
+OpReturnValue %93
+%119 = OpLabel
+OpReturnValue %87
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/acceleration-structure.bindless.ssbo-rtas.local-root-signature.descriptor-qa.rgen
+++ b/reference/shaders/descriptor_qa/acceleration-structure.bindless.ssbo-rtas.local-root-signature.descriptor-qa.rgen
@@ -66,7 +66,7 @@ layout(location = 0) rayPayloadEXT _23 _25;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _59 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _59 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_59 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -354,7 +354,7 @@ OpFunctionEnd
 %53 = OpFunctionParameter %5
 %55 = OpLabel
 %57 = OpAccessChain %56 %45 %58
-%59 = OpAtomicExchange %5 %57 %60 %28 %60
+%59 = OpAtomicIAdd %5 %57 %60 %28 %60
 %62 = OpIEqual %61 %59 %28
 OpSelectionMerge %64 None
 OpBranchConditional %62 %63 %64

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
@@ -1,0 +1,821 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer AtomicCounter;
+layout(buffer_reference, std430) buffer AtomicCounter
+{
+    uint _m0;
+};
+
+layout(set = 7, binding = 0, std430) readonly buffer AtomicCounters
+{
+    AtomicCounter counters[];
+} _34;
+
+layout(set = 5, binding = 0, std430) readonly buffer BindlessCBV
+{
+    vec4 _m0[4096];
+} _48[];
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 1, binding = 0) uniform samplerBuffer _17[];
+layout(set = 1, binding = 0) uniform usamplerBuffer _21[];
+layout(set = 1, binding = 0) uniform usamplerBuffer _24[];
+layout(set = 4, binding = 0, r32ui) uniform writeonly uimageBuffer _28[];
+layout(set = 4, binding = 0, r32ui) uniform writeonly uimageBuffer _37[];
+layout(set = 3, binding = 0) uniform writeonly image2D _41[];
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _76 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_76 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _111 = QAHeapData.descriptor_count;
+    uint _113 = QAHeapData.heap_index;
+    uvec2 _115 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _123 = QAGlobalData.live_status_table[_115.x >> 5u];
+    uint _134 = (uint(heap_offset >= _111) | (((_115.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_123 & (1u << (_115.x & 31u))) != 0u) ? 0u : 4u);
+    if (_134 != 0u)
+    {
+        descriptor_qa_report_fault(_134, heap_offset, _115.x, _113, descriptor_type_mask, _115.y, instruction);
+        return _111;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _57 = descriptor_qa_check(registers._m3 + 6u, 2u, 1u);
+    uint _147 = descriptor_qa_check(registers._m4 + 3u, 32u, 2u);
+    uint _153 = descriptor_qa_check(registers._m4, 32u, 3u);
+    uint _159 = descriptor_qa_check(registers._m4, 256u, 4u);
+    AtomicCounter _161 = _34.counters[_159];
+    uint _167 = descriptor_qa_check(registers._m1 + 9u, 16u, 5u);
+    uint _174 = descriptor_qa_check(registers._m1 + 6u, 16u, 6u);
+    uint _181 = descriptor_qa_check(registers._m1 + 3u, 16u, 7u);
+    uint _187 = descriptor_qa_check(registers._m0, 1u, 8u);
+    uint _193 = descriptor_qa_check(registers._m5, 8u, 9u);
+    float _205;
+    if (gl_GlobalInvocationID.x > 2u)
+    {
+        _205 = _48[_193]._m0[0u].x;
+    }
+    else
+    {
+        _205 = 0.0;
+    }
+    float _219;
+    if (gl_GlobalInvocationID.x > 3u)
+    {
+        uint _213 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 8u, 10u);
+        _219 = _48[_213]._m0[0u].x + _205;
+    }
+    else
+    {
+        _219 = _205;
+    }
+    float _225;
+    if (gl_GlobalInvocationID.x > 4u)
+    {
+        _225 = texelFetch(_13[_187], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), int(0u)).x + _219;
+    }
+    else
+    {
+        _225 = _219;
+    }
+    float _240;
+    if (gl_GlobalInvocationID.x > 5u)
+    {
+        uint _233 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 11u);
+        _240 = texelFetch(_13[_233], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _225;
+    }
+    else
+    {
+        _240 = _225;
+    }
+    float _245;
+    if (gl_GlobalInvocationID.x > 6u)
+    {
+        _245 = texelFetch(_17[_181], int(gl_GlobalInvocationID.x)).x + _240;
+    }
+    else
+    {
+        _245 = _240;
+    }
+    float _259;
+    if (gl_GlobalInvocationID.x > 7u)
+    {
+        uint _253 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 12u);
+        _259 = texelFetch(_17[_253], int(gl_GlobalInvocationID.x)).x + _245;
+    }
+    else
+    {
+        _259 = _245;
+    }
+    float _266;
+    if (gl_GlobalInvocationID.x > 8u)
+    {
+        _266 = uintBitsToFloat(texelFetch(_21[_174], int(gl_GlobalInvocationID.x)).x) + _259;
+    }
+    else
+    {
+        _266 = _259;
+    }
+    float _281;
+    if (gl_GlobalInvocationID.x > 9u)
+    {
+        uint _274 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 16u, 13u);
+        _281 = uintBitsToFloat(texelFetch(_21[_274], int(gl_GlobalInvocationID.x)).x) + _266;
+    }
+    else
+    {
+        _281 = _266;
+    }
+    float _288;
+    if (gl_GlobalInvocationID.x > 10u)
+    {
+        _288 = uintBitsToFloat(texelFetch(_24[_167], int(gl_GlobalInvocationID.x)).x) + _281;
+    }
+    else
+    {
+        _288 = _281;
+    }
+    float _304;
+    if (gl_GlobalInvocationID.x > 11u)
+    {
+        uint _296 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 16u, 14u);
+        _304 = uintBitsToFloat(texelFetch(_24[_296], int(gl_GlobalInvocationID.x >> 2u)).x) + _288;
+    }
+    else
+    {
+        _304 = _288;
+    }
+    if (gl_GlobalInvocationID.x > 1u)
+    {
+        imageStore(_28[_153], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+    }
+    if (gl_GlobalInvocationID.x > 30u)
+    {
+        uint _316 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 32u, 15u);
+        imageStore(_28[_316], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+    }
+    if (gl_GlobalInvocationID.x > 40u)
+    {
+        imageStore(_37[_147], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+    }
+    if (gl_GlobalInvocationID.x > 50u)
+    {
+        uint _336 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 32u, 16u);
+        imageStore(_37[_336], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+    }
+    if (gl_GlobalInvocationID.x > 80u)
+    {
+        imageStore(_41[_57], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_304));
+    }
+    if (gl_GlobalInvocationID.x > 90u)
+    {
+        uint _351 = descriptor_qa_check(registers._m3 + ((gl_GlobalInvocationID.x & 1u) + 7u), 2u, 17u);
+        imageStore(_41[_351], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_304));
+    }
+    uint _358 = atomicAdd(_161._m0, 1u);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 393
+; Schema: 0
+OpCapability Shader
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability SampledBuffer
+OpCapability ImageBuffer
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RuntimeDescriptorArray
+OpCapability UniformTexelBufferArrayDynamicIndexing
+OpCapability StorageTexelBufferArrayDynamicIndexing
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint GLCompute %3 "main" %196
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %29 "AtomicCounter"
+OpName %32 "AtomicCounters"
+OpMemberName %32 0 "counters"
+OpName %45 "BindlessCBV"
+OpName %60 "DescriptorHeapGlobalQAData"
+OpMemberName %60 0 "failed_shader_hash"
+OpMemberName %60 1 "failed_offset"
+OpMemberName %60 2 "failed_heap"
+OpMemberName %60 3 "failed_cookie"
+OpMemberName %60 4 "fault_atomic"
+OpMemberName %60 5 "failed_instruction"
+OpMemberName %60 6 "failed_descriptor_type_mask"
+OpMemberName %60 7 "actual_descriptor_type_mask"
+OpMemberName %60 8 "fault_type"
+OpMemberName %60 9 "live_status_table"
+OpName %62 "QAGlobalData"
+OpName %71 "descriptor_qa_report_fault"
+OpName %64 "fault_type"
+OpName %65 "heap_offset"
+OpName %66 "cookie"
+OpName %67 "heap_index"
+OpName %68 "descriptor_type"
+OpName %69 "actual_descriptor_type"
+OpName %70 "instruction"
+OpName %101 "DescriptorHeapQAData"
+OpMemberName %101 0 "descriptor_count"
+OpMemberName %101 1 "heap_index"
+OpMemberName %101 2 "cookies_descriptor_info"
+OpName %103 "QAHeapData"
+OpName %108 "descriptor_qa_check"
+OpName %105 "heap_offset"
+OpName %106 "descriptor_type_mask"
+OpName %107 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 1
+OpDecorate %17 Binding 0
+OpDecorate %21 DescriptorSet 1
+OpDecorate %21 Binding 0
+OpDecorate %24 DescriptorSet 1
+OpDecorate %24 Binding 0
+OpDecorate %28 DescriptorSet 4
+OpDecorate %28 Binding 0
+OpDecorate %28 NonReadable
+OpDecorate %29 Block
+OpMemberDecorate %29 0 Offset 0
+OpDecorate %31 ArrayStride 8
+OpDecorate %32 Block
+OpMemberDecorate %32 0 Offset 0
+OpMemberDecorate %32 0 NonWritable
+OpDecorate %34 DescriptorSet 7
+OpDecorate %34 Binding 0
+OpDecorate %34 AliasedPointer
+OpDecorate %37 DescriptorSet 4
+OpDecorate %37 Binding 0
+OpDecorate %37 NonReadable
+OpDecorate %41 DescriptorSet 3
+OpDecorate %41 Binding 0
+OpDecorate %41 NonReadable
+OpDecorate %44 ArrayStride 16
+OpDecorate %45 Block
+OpMemberDecorate %45 0 NonWritable
+OpMemberDecorate %45 0 Offset 0
+OpDecorate %48 DescriptorSet 5
+OpDecorate %48 Binding 0
+OpDecorate %59 ArrayStride 4
+OpMemberDecorate %60 0 Offset 0
+OpMemberDecorate %60 1 Offset 8
+OpMemberDecorate %60 2 Offset 12
+OpMemberDecorate %60 3 Offset 16
+OpMemberDecorate %60 4 Offset 20
+OpMemberDecorate %60 5 Offset 24
+OpMemberDecorate %60 6 Offset 28
+OpMemberDecorate %60 7 Offset 32
+OpMemberDecorate %60 8 Offset 36
+OpMemberDecorate %60 9 Offset 40
+OpDecorate %60 Block
+OpDecorate %62 DescriptorSet 10
+OpDecorate %62 Binding 10
+OpDecorate %100 ArrayStride 8
+OpMemberDecorate %101 0 Offset 0
+OpMemberDecorate %101 1 Offset 4
+OpMemberDecorate %101 2 Offset 8
+OpDecorate %101 Block
+OpDecorate %103 DescriptorSet 10
+OpDecorate %103 Binding 11
+OpDecorate %103 NonWritable
+OpDecorate %196 BuiltIn GlobalInvocationId
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeImage %9 Buffer 0 0 0 1 Unknown
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeImage %5 Buffer 0 0 0 1 Unknown
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypePointer UniformConstant %19
+%21 = OpVariable %20 UniformConstant
+%22 = OpTypeRuntimeArray %18
+%23 = OpTypePointer UniformConstant %22
+%24 = OpVariable %23 UniformConstant
+%25 = OpTypeImage %5 Buffer 0 0 0 2 R32ui
+%26 = OpTypeRuntimeArray %25
+%27 = OpTypePointer UniformConstant %26
+%28 = OpVariable %27 UniformConstant
+%29 = OpTypeStruct %5
+%30 = OpTypePointer PhysicalStorageBuffer %29
+%31 = OpTypeRuntimeArray %30
+%32 = OpTypeStruct %31
+%33 = OpTypePointer StorageBuffer %32
+%34 = OpVariable %33 StorageBuffer
+%35 = OpTypeRuntimeArray %25
+%36 = OpTypePointer UniformConstant %35
+%37 = OpVariable %36 UniformConstant
+%38 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%39 = OpTypeRuntimeArray %38
+%40 = OpTypePointer UniformConstant %39
+%41 = OpVariable %40 UniformConstant
+%42 = OpTypeVector %9 4
+%43 = OpConstant %5 4096
+%44 = OpTypeArray %42 %43
+%45 = OpTypeStruct %44
+%46 = OpTypeRuntimeArray %45
+%47 = OpTypePointer StorageBuffer %46
+%48 = OpVariable %47 StorageBuffer
+%49 = OpTypePointer UniformConstant %38
+%51 = OpTypePointer PushConstant %5
+%53 = OpConstant %5 3
+%56 = OpConstant %5 6
+%58 = OpTypeVector %5 2
+%59 = OpTypeRuntimeArray %5
+%60 = OpTypeStruct %58 %5 %5 %5 %5 %5 %5 %5 %5 %59
+%61 = OpTypePointer StorageBuffer %60
+%62 = OpVariable %61 StorageBuffer
+%63 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%73 = OpTypePointer StorageBuffer %5
+%75 = OpConstant %5 4
+%77 = OpConstant %5 1
+%78 = OpConstant %5 0
+%79 = OpTypeBool
+%86 = OpConstant %5 2
+%89 = OpConstant %5 7
+%91 = OpConstant %5 5
+%92 = OpConstant %5 3735928559
+%93 = OpConstantComposite %58 %92 %78
+%94 = OpTypePointer StorageBuffer %58
+%96 = OpConstant %5 72
+%98 = OpConstant %5 8
+%100 = OpTypeRuntimeArray %58
+%101 = OpTypeStruct %5 %5 %100
+%102 = OpTypePointer StorageBuffer %101
+%103 = OpVariable %102 StorageBuffer
+%104 = OpTypeFunction %5 %5 %5 %5
+%120 = OpConstant %5 31
+%122 = OpConstant %5 9
+%142 = OpTypePointer UniformConstant %25
+%148 = OpConstant %5 32
+%155 = OpTypePointer StorageBuffer %30
+%160 = OpConstant %5 256
+%162 = OpTypePointer UniformConstant %18
+%168 = OpConstant %5 16
+%176 = OpTypePointer UniformConstant %14
+%183 = OpTypePointer UniformConstant %10
+%189 = OpTypePointer StorageBuffer %45
+%194 = OpTypeVector %5 3
+%195 = OpTypePointer Input %194
+%196 = OpVariable %195 Input
+%197 = OpTypePointer Input %5
+%201 = OpTypePointer StorageBuffer %42
+%206 = OpConstant %9 0
+%214 = OpConstant %5 10
+%234 = OpConstant %5 11
+%254 = OpConstant %5 12
+%261 = OpTypeVector %5 4
+%275 = OpConstant %5 13
+%297 = OpConstant %5 14
+%309 = OpConstant %5 30
+%317 = OpConstant %5 15
+%322 = OpConstant %5 40
+%327 = OpConstant %5 50
+%340 = OpConstant %5 80
+%344 = OpConstant %5 90
+%352 = OpConstant %5 17
+%356 = OpTypePointer PhysicalStorageBuffer %5
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %359
+%359 = OpLabel
+%52 = OpAccessChain %51 %8 %53
+%54 = OpLoad %5 %52
+%55 = OpIAdd %5 %54 %56
+%57 = OpFunctionCall %5 %108 %55 %86 %77
+%50 = OpAccessChain %49 %41 %57
+%141 = OpLoad %38 %50
+%144 = OpAccessChain %51 %8 %75
+%145 = OpLoad %5 %144
+%146 = OpIAdd %5 %145 %53
+%147 = OpFunctionCall %5 %108 %146 %148 %86
+%143 = OpAccessChain %142 %37 %147
+%149 = OpLoad %25 %143
+%151 = OpAccessChain %51 %8 %75
+%152 = OpLoad %5 %151
+%153 = OpFunctionCall %5 %108 %152 %148 %53
+%150 = OpAccessChain %142 %28 %153
+%154 = OpLoad %25 %150
+%157 = OpAccessChain %51 %8 %75
+%158 = OpLoad %5 %157
+%159 = OpFunctionCall %5 %108 %158 %160 %75
+%156 = OpAccessChain %155 %34 %78 %159
+%161 = OpLoad %30 %156
+%164 = OpAccessChain %51 %8 %77
+%165 = OpLoad %5 %164
+%166 = OpIAdd %5 %165 %122
+%167 = OpFunctionCall %5 %108 %166 %168 %91
+%163 = OpAccessChain %162 %24 %167
+%169 = OpLoad %18 %163
+%171 = OpAccessChain %51 %8 %77
+%172 = OpLoad %5 %171
+%173 = OpIAdd %5 %172 %56
+%174 = OpFunctionCall %5 %108 %173 %168 %56
+%170 = OpAccessChain %162 %21 %174
+%175 = OpLoad %18 %170
+%178 = OpAccessChain %51 %8 %77
+%179 = OpLoad %5 %178
+%180 = OpIAdd %5 %179 %53
+%181 = OpFunctionCall %5 %108 %180 %168 %89
+%177 = OpAccessChain %176 %17 %181
+%182 = OpLoad %14 %177
+%185 = OpAccessChain %51 %8 %78
+%186 = OpLoad %5 %185
+%187 = OpFunctionCall %5 %108 %186 %77 %98
+%184 = OpAccessChain %183 %13 %187
+%188 = OpLoad %10 %184
+%191 = OpAccessChain %51 %8 %91
+%192 = OpLoad %5 %191
+%193 = OpFunctionCall %5 %108 %192 %98 %122
+%190 = OpAccessChain %189 %48 %193
+%198 = OpAccessChain %197 %196 %78
+%199 = OpLoad %5 %198
+%200 = OpUGreaterThan %79 %199 %86
+OpSelectionMerge %361 None
+OpBranchConditional %200 %360 %361
+%360 = OpLabel
+%202 = OpAccessChain %201 %190 %78 %78
+%203 = OpLoad %42 %202
+%204 = OpCompositeExtract %9 %203 0
+OpBranch %361
+%361 = OpLabel
+%205 = OpPhi %9 %206 %359 %204 %360
+%207 = OpUGreaterThan %79 %199 %53
+OpSelectionMerge %363 None
+OpBranchConditional %207 %362 %363
+%362 = OpLabel
+%208 = OpIAdd %5 %199 %77
+%210 = OpAccessChain %51 %8 %91
+%211 = OpLoad %5 %210
+%212 = OpIAdd %5 %211 %208
+%213 = OpFunctionCall %5 %108 %212 %98 %214
+%209 = OpAccessChain %189 %48 %213
+%215 = OpAccessChain %201 %209 %78 %78
+%216 = OpLoad %42 %215
+%217 = OpCompositeExtract %9 %216 0
+%218 = OpFAdd %9 %217 %205
+OpBranch %363
+%363 = OpLabel
+%219 = OpPhi %9 %205 %361 %218 %362
+%220 = OpUGreaterThan %79 %199 %75
+OpSelectionMerge %365 None
+OpBranchConditional %220 %364 %365
+%364 = OpLabel
+%222 = OpCompositeConstruct %58 %199 %78
+%221 = OpImageFetch %42 %188 %222 Lod %78
+%223 = OpCompositeExtract %9 %221 0
+%224 = OpFAdd %9 %223 %219
+OpBranch %365
+%365 = OpLabel
+%225 = OpPhi %9 %219 %363 %224 %364
+%226 = OpUGreaterThan %79 %199 %91
+OpSelectionMerge %367 None
+OpBranchConditional %226 %366 %367
+%366 = OpLabel
+%227 = OpBitwiseAnd %5 %199 %77
+%228 = OpIAdd %5 %227 %77
+%230 = OpAccessChain %51 %8 %78
+%231 = OpLoad %5 %230
+%232 = OpIAdd %5 %231 %228
+%233 = OpFunctionCall %5 %108 %232 %77 %234
+%229 = OpAccessChain %183 %13 %233
+%235 = OpLoad %10 %229
+%237 = OpCompositeConstruct %58 %78 %199
+%236 = OpImageFetch %42 %235 %237 Lod %78
+%238 = OpCompositeExtract %9 %236 0
+%239 = OpFAdd %9 %238 %225
+OpBranch %367
+%367 = OpLabel
+%240 = OpPhi %9 %225 %365 %239 %366
+%241 = OpUGreaterThan %79 %199 %56
+OpSelectionMerge %369 None
+OpBranchConditional %241 %368 %369
+%368 = OpLabel
+%242 = OpImageFetch %42 %182 %199
+%243 = OpCompositeExtract %9 %242 0
+%244 = OpFAdd %9 %243 %240
+OpBranch %369
+%369 = OpLabel
+%245 = OpPhi %9 %240 %367 %244 %368
+%246 = OpUGreaterThan %79 %199 %89
+OpSelectionMerge %371 None
+OpBranchConditional %246 %370 %371
+%370 = OpLabel
+%247 = OpBitwiseAnd %5 %199 %77
+%248 = OpIAdd %5 %247 %75
+%250 = OpAccessChain %51 %8 %77
+%251 = OpLoad %5 %250
+%252 = OpIAdd %5 %251 %248
+%253 = OpFunctionCall %5 %108 %252 %168 %254
+%249 = OpAccessChain %176 %17 %253
+%255 = OpLoad %14 %249
+%256 = OpImageFetch %42 %255 %199
+%257 = OpCompositeExtract %9 %256 0
+%258 = OpFAdd %9 %257 %245
+OpBranch %371
+%371 = OpLabel
+%259 = OpPhi %9 %245 %369 %258 %370
+%260 = OpUGreaterThan %79 %199 %98
+OpSelectionMerge %373 None
+OpBranchConditional %260 %372 %373
+%372 = OpLabel
+%262 = OpImageFetch %261 %175 %199
+%263 = OpCompositeExtract %5 %262 0
+%264 = OpBitcast %9 %263
+%265 = OpFAdd %9 %264 %259
+OpBranch %373
+%373 = OpLabel
+%266 = OpPhi %9 %259 %371 %265 %372
+%267 = OpUGreaterThan %79 %199 %122
+OpSelectionMerge %375 None
+OpBranchConditional %267 %374 %375
+%374 = OpLabel
+%268 = OpBitwiseAnd %5 %199 %77
+%269 = OpIAdd %5 %268 %89
+%271 = OpAccessChain %51 %8 %77
+%272 = OpLoad %5 %271
+%273 = OpIAdd %5 %272 %269
+%274 = OpFunctionCall %5 %108 %273 %168 %275
+%270 = OpAccessChain %162 %21 %274
+%276 = OpLoad %18 %270
+%277 = OpImageFetch %261 %276 %199
+%278 = OpCompositeExtract %5 %277 0
+%279 = OpBitcast %9 %278
+%280 = OpFAdd %9 %279 %266
+OpBranch %375
+%375 = OpLabel
+%281 = OpPhi %9 %266 %373 %280 %374
+%282 = OpUGreaterThan %79 %199 %214
+OpSelectionMerge %377 None
+OpBranchConditional %282 %376 %377
+%376 = OpLabel
+%283 = OpShiftLeftLogical %5 %199 %86
+%284 = OpImageFetch %261 %169 %199
+%285 = OpCompositeExtract %5 %284 0
+%286 = OpBitcast %9 %285
+%287 = OpFAdd %9 %286 %281
+OpBranch %377
+%377 = OpLabel
+%288 = OpPhi %9 %281 %375 %287 %376
+%289 = OpUGreaterThan %79 %199 %234
+OpSelectionMerge %379 None
+OpBranchConditional %289 %378 %379
+%378 = OpLabel
+%290 = OpBitwiseAnd %5 %199 %77
+%291 = OpIAdd %5 %290 %214
+%293 = OpAccessChain %51 %8 %77
+%294 = OpLoad %5 %293
+%295 = OpIAdd %5 %294 %291
+%296 = OpFunctionCall %5 %108 %295 %168 %297
+%292 = OpAccessChain %162 %24 %296
+%298 = OpLoad %18 %292
+%299 = OpShiftRightLogical %5 %199 %86
+%300 = OpImageFetch %261 %298 %299
+%301 = OpCompositeExtract %5 %300 0
+%302 = OpBitcast %9 %301
+%303 = OpFAdd %9 %302 %288
+OpBranch %379
+%379 = OpLabel
+%304 = OpPhi %9 %288 %377 %303 %378
+%305 = OpUGreaterThan %79 %199 %77
+OpSelectionMerge %381 None
+OpBranchConditional %305 %380 %381
+%380 = OpLabel
+%306 = OpBitcast %5 %304
+%307 = OpCompositeConstruct %261 %306 %306 %306 %306
+OpImageWrite %154 %199 %307
+OpBranch %381
+%381 = OpLabel
+%308 = OpUGreaterThan %79 %199 %309
+OpSelectionMerge %383 None
+OpBranchConditional %308 %382 %383
+%382 = OpLabel
+%310 = OpBitwiseAnd %5 %199 %77
+%311 = OpIAdd %5 %310 %77
+%313 = OpAccessChain %51 %8 %75
+%314 = OpLoad %5 %313
+%315 = OpIAdd %5 %314 %311
+%316 = OpFunctionCall %5 %108 %315 %148 %317
+%312 = OpAccessChain %142 %28 %316
+%318 = OpLoad %25 %312
+%319 = OpBitcast %5 %304
+%320 = OpCompositeConstruct %261 %319 %319 %319 %319
+OpImageWrite %318 %199 %320
+OpBranch %383
+%383 = OpLabel
+%321 = OpUGreaterThan %79 %199 %322
+OpSelectionMerge %385 None
+OpBranchConditional %321 %384 %385
+%384 = OpLabel
+%323 = OpBitcast %5 %304
+%324 = OpShiftLeftLogical %5 %199 %86
+%325 = OpCompositeConstruct %261 %323 %323 %323 %323
+OpImageWrite %149 %199 %325
+OpBranch %385
+%385 = OpLabel
+%326 = OpUGreaterThan %79 %199 %327
+OpSelectionMerge %387 None
+OpBranchConditional %326 %386 %387
+%386 = OpLabel
+%328 = OpBitwiseAnd %5 %199 %77
+%329 = OpBitcast %5 %304
+%330 = OpShiftLeftLogical %5 %199 %86
+%331 = OpIAdd %5 %328 %75
+%333 = OpAccessChain %51 %8 %75
+%334 = OpLoad %5 %333
+%335 = OpIAdd %5 %334 %331
+%336 = OpFunctionCall %5 %108 %335 %148 %168
+%332 = OpAccessChain %142 %37 %336
+%337 = OpLoad %25 %332
+%338 = OpCompositeConstruct %261 %329 %329 %329 %329
+OpImageWrite %337 %199 %338
+OpBranch %387
+%387 = OpLabel
+%339 = OpUGreaterThan %79 %199 %340
+OpSelectionMerge %389 None
+OpBranchConditional %339 %388 %389
+%388 = OpLabel
+%341 = OpCompositeConstruct %58 %199 %78
+%342 = OpCompositeConstruct %42 %304 %304 %304 %304
+OpImageWrite %141 %341 %342
+OpBranch %389
+%389 = OpLabel
+%343 = OpUGreaterThan %79 %199 %344
+OpSelectionMerge %391 None
+OpBranchConditional %343 %390 %391
+%390 = OpLabel
+%345 = OpBitwiseAnd %5 %199 %77
+%346 = OpIAdd %5 %345 %89
+%348 = OpAccessChain %51 %8 %53
+%349 = OpLoad %5 %348
+%350 = OpIAdd %5 %349 %346
+%351 = OpFunctionCall %5 %108 %350 %86 %352
+%347 = OpAccessChain %49 %41 %351
+%353 = OpLoad %38 %347
+%354 = OpCompositeConstruct %58 %78 %199
+%355 = OpCompositeConstruct %42 %304 %304 %304 %304
+OpImageWrite %353 %354 %355
+OpBranch %391
+%391 = OpLabel
+%357 = OpAccessChain %356 %161 %78
+%358 = OpAtomicIAdd %5 %357 %77 %78 %77
+OpReturn
+OpFunctionEnd
+%71 = OpFunction %1 None %63
+%64 = OpFunctionParameter %5
+%65 = OpFunctionParameter %5
+%66 = OpFunctionParameter %5
+%67 = OpFunctionParameter %5
+%68 = OpFunctionParameter %5
+%69 = OpFunctionParameter %5
+%70 = OpFunctionParameter %5
+%72 = OpLabel
+%74 = OpAccessChain %73 %62 %75
+%76 = OpAtomicExchange %5 %74 %77 %78 %77
+%80 = OpIEqual %79 %76 %78
+OpSelectionMerge %82 None
+OpBranchConditional %80 %81 %82
+%81 = OpLabel
+%83 = OpAccessChain %73 %62 %53
+OpStore %83 %66
+%84 = OpAccessChain %73 %62 %77
+OpStore %84 %65
+%85 = OpAccessChain %73 %62 %86
+OpStore %85 %67
+%87 = OpAccessChain %73 %62 %56
+OpStore %87 %68
+%88 = OpAccessChain %73 %62 %89
+OpStore %88 %69
+%90 = OpAccessChain %73 %62 %91
+OpStore %90 %70
+%95 = OpAccessChain %94 %62 %78
+OpStore %95 %93
+OpMemoryBarrier %77 %96
+%97 = OpAccessChain %73 %62 %98
+OpStore %97 %64
+OpBranch %82
+%82 = OpLabel
+OpReturn
+OpFunctionEnd
+%108 = OpFunction %5 None %104
+%105 = OpFunctionParameter %5
+%106 = OpFunctionParameter %5
+%107 = OpFunctionParameter %5
+%109 = OpLabel
+%110 = OpAccessChain %73 %103 %78
+%111 = OpLoad %5 %110
+%112 = OpAccessChain %73 %103 %77
+%113 = OpLoad %5 %112
+%114 = OpAccessChain %94 %103 %86 %105
+%115 = OpLoad %58 %114
+%116 = OpCompositeExtract %5 %115 0
+%118 = OpShiftRightLogical %5 %116 %91
+%119 = OpBitwiseAnd %5 %116 %120
+%117 = OpCompositeExtract %5 %115 1
+%121 = OpAccessChain %73 %62 %122 %118
+%123 = OpLoad %5 %121
+%124 = OpShiftLeftLogical %5 %77 %119
+%125 = OpBitwiseAnd %5 %123 %124
+%126 = OpINotEqual %79 %125 %78
+%127 = OpBitwiseAnd %5 %117 %106
+%128 = OpIEqual %79 %127 %106
+%129 = OpUGreaterThanEqual %79 %105 %111
+%130 = OpSelect %5 %129 %77 %78
+%131 = OpSelect %5 %128 %78 %86
+%132 = OpSelect %5 %126 %78 %75
+%133 = OpBitwiseOr %5 %130 %131
+%134 = OpBitwiseOr %5 %133 %132
+%135 = OpINotEqual %79 %134 %78
+OpSelectionMerge %137 None
+OpBranchConditional %135 %136 %137
+%136 = OpLabel
+%138 = OpFunctionCall %1 %71 %134 %105 %116 %113 %106 %117 %107
+OpReturnValue %111
+%137 = OpLabel
+OpReturnValue %105
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
@@ -63,7 +63,7 @@ layout(set = 3, binding = 0) uniform writeonly image2D _41[];
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _76 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _76 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_76 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -755,7 +755,7 @@ OpFunctionEnd
 %70 = OpFunctionParameter %5
 %72 = OpLabel
 %74 = OpAccessChain %73 %62 %75
-%76 = OpAtomicExchange %5 %74 %77 %78 %77
+%76 = OpAtomicIAdd %5 %74 %77 %78 %77
 %80 = OpIEqual %79 %76 %78
 OpSelectionMerge %82 None
 OpBranchConditional %80 %81 %82

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
@@ -63,8 +63,8 @@ layout(set = 3, binding = 0) uniform writeonly image2D _41[];
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _76 = atomicAdd(QAGlobalData.fault_atomic, 1u);
-    if (_76 == 0u)
+    uint _84 = atomicAdd(QAGlobalData.fault_atomic, 1u);
+    if (_84 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
         QAGlobalData.failed_offset = heap_offset;
@@ -80,154 +80,155 @@ void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, 
 
 uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
 {
-    uint _111 = QAHeapData.descriptor_count;
-    uint _113 = QAHeapData.heap_index;
-    uvec2 _115 = QAHeapData.cookies_descriptor_info[heap_offset];
-    uint _123 = QAGlobalData.live_status_table[_115.x >> 5u];
-    uint _134 = (uint(heap_offset >= _111) | (((_115.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_123 & (1u << (_115.x & 31u))) != 0u) ? 0u : 4u);
-    if (_134 != 0u)
+    uint _117 = QAHeapData.descriptor_count;
+    uint _119 = QAHeapData.heap_index;
+    uvec2 _121 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _129 = QAGlobalData.live_status_table[_121.x >> 5u];
+    uint _140 = (uint(heap_offset >= _117) | (((_121.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_129 & (1u << (_121.x & 31u))) != 0u) ? 0u : 4u);
+    if (_140 != 0u)
     {
-        descriptor_qa_report_fault(_134, heap_offset, _115.x, _113, descriptor_type_mask, _115.y, instruction);
-        return _111;
+        descriptor_qa_report_fault(_140, heap_offset, _121.x, _119, descriptor_type_mask, _121.y, instruction);
+        return _117;
     }
     return heap_offset;
 }
 
 void main()
 {
-    uint _57 = descriptor_qa_check(registers._m3 + 6u, 2u, 1u);
-    uint _147 = descriptor_qa_check(registers._m4 + 3u, 32u, 2u);
-    uint _153 = descriptor_qa_check(registers._m4, 32u, 3u);
-    uint _159 = descriptor_qa_check(registers._m4, 256u, 4u);
-    AtomicCounter _161 = _34.counters[_159];
-    uint _167 = descriptor_qa_check(registers._m1 + 9u, 16u, 5u);
-    uint _174 = descriptor_qa_check(registers._m1 + 6u, 16u, 6u);
-    uint _181 = descriptor_qa_check(registers._m1 + 3u, 16u, 7u);
-    uint _187 = descriptor_qa_check(registers._m0, 1u, 8u);
-    uint _193 = descriptor_qa_check(registers._m5, 8u, 9u);
-    float _205;
+    float _151;
     if (gl_GlobalInvocationID.x > 2u)
     {
-        _205 = _48[_193]._m0[0u].x;
+        uint _65 = descriptor_qa_check(registers._m5, 8u, 1u);
+        _151 = _48[_65]._m0[0u].x;
     }
     else
     {
-        _205 = 0.0;
+        _151 = 0.0;
     }
-    float _219;
+    float _164;
     if (gl_GlobalInvocationID.x > 3u)
     {
-        uint _213 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 8u, 10u);
-        _219 = _48[_213]._m0[0u].x + _205;
+        uint _159 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 8u, 2u);
+        _164 = _48[_159]._m0[0u].x + _151;
     }
     else
     {
-        _219 = _205;
+        _164 = _151;
     }
-    float _225;
+    float _176;
     if (gl_GlobalInvocationID.x > 4u)
     {
-        _225 = texelFetch(_13[_187], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), int(0u)).x + _219;
+        uint _170 = descriptor_qa_check(registers._m0, 1u, 3u);
+        _176 = texelFetch(_13[_170], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), int(0u)).x + _164;
     }
     else
     {
-        _225 = _219;
+        _176 = _164;
     }
-    float _240;
+    float _190;
     if (gl_GlobalInvocationID.x > 5u)
     {
-        uint _233 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 11u);
-        _240 = texelFetch(_13[_233], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _225;
+        uint _184 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 4u);
+        _190 = texelFetch(_13[_184], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _176;
     }
     else
     {
-        _240 = _225;
+        _190 = _176;
     }
-    float _245;
+    float _203;
     if (gl_GlobalInvocationID.x > 6u)
     {
-        _245 = texelFetch(_17[_181], int(gl_GlobalInvocationID.x)).x + _240;
+        uint _197 = descriptor_qa_check(registers._m1 + 3u, 16u, 5u);
+        _203 = texelFetch(_17[_197], int(gl_GlobalInvocationID.x)).x + _190;
     }
     else
     {
-        _245 = _240;
+        _203 = _190;
     }
-    float _259;
+    float _216;
     if (gl_GlobalInvocationID.x > 7u)
     {
-        uint _253 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 12u);
-        _259 = texelFetch(_17[_253], int(gl_GlobalInvocationID.x)).x + _245;
+        uint _211 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 6u);
+        _216 = texelFetch(_17[_211], int(gl_GlobalInvocationID.x)).x + _203;
     }
     else
     {
-        _259 = _245;
+        _216 = _203;
     }
-    float _266;
+    float _230;
     if (gl_GlobalInvocationID.x > 8u)
     {
-        _266 = uintBitsToFloat(texelFetch(_21[_174], int(gl_GlobalInvocationID.x)).x) + _259;
+        uint _223 = descriptor_qa_check(registers._m1 + 6u, 16u, 7u);
+        _230 = uintBitsToFloat(texelFetch(_21[_223], int(gl_GlobalInvocationID.x)).x) + _216;
     }
     else
     {
-        _266 = _259;
+        _230 = _216;
     }
-    float _281;
+    float _244;
     if (gl_GlobalInvocationID.x > 9u)
     {
-        uint _274 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 16u, 13u);
-        _281 = uintBitsToFloat(texelFetch(_21[_274], int(gl_GlobalInvocationID.x)).x) + _266;
+        uint _238 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 16u, 8u);
+        _244 = uintBitsToFloat(texelFetch(_21[_238], int(gl_GlobalInvocationID.x)).x) + _230;
     }
     else
     {
-        _281 = _266;
+        _244 = _230;
     }
-    float _288;
+    float _258;
     if (gl_GlobalInvocationID.x > 10u)
     {
-        _288 = uintBitsToFloat(texelFetch(_24[_167], int(gl_GlobalInvocationID.x)).x) + _281;
+        uint _251 = descriptor_qa_check(registers._m1 + 9u, 16u, 9u);
+        _258 = uintBitsToFloat(texelFetch(_24[_251], int(gl_GlobalInvocationID.x)).x) + _244;
     }
     else
     {
-        _288 = _281;
+        _258 = _244;
     }
-    float _304;
+    float _274;
     if (gl_GlobalInvocationID.x > 11u)
     {
-        uint _296 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 16u, 14u);
-        _304 = uintBitsToFloat(texelFetch(_24[_296], int(gl_GlobalInvocationID.x >> 2u)).x) + _288;
+        uint _267 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 16u, 10u);
+        _274 = uintBitsToFloat(texelFetch(_24[_267], int(gl_GlobalInvocationID.x >> 2u)).x) + _258;
     }
     else
     {
-        _304 = _288;
+        _274 = _258;
     }
     if (gl_GlobalInvocationID.x > 1u)
     {
-        imageStore(_28[_153], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+        uint _280 = descriptor_qa_check(registers._m4, 32u, 11u);
+        uint _287 = descriptor_qa_check(registers._m4, 256u, 12u);
+        imageStore(_28[_280], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_274)));
     }
     if (gl_GlobalInvocationID.x > 30u)
     {
-        uint _316 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 32u, 15u);
-        imageStore(_28[_316], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+        uint _301 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 32u, 13u);
+        imageStore(_28[_301], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_274)));
     }
     if (gl_GlobalInvocationID.x > 40u)
     {
-        imageStore(_37[_147], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+        uint _312 = descriptor_qa_check(registers._m4 + 3u, 32u, 14u);
+        imageStore(_37[_312], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_274)));
     }
     if (gl_GlobalInvocationID.x > 50u)
     {
-        uint _336 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 32u, 16u);
-        imageStore(_37[_336], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_304)));
+        uint _328 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 32u, 15u);
+        imageStore(_37[_328], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_274)));
     }
     if (gl_GlobalInvocationID.x > 80u)
     {
-        imageStore(_41[_57], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_304));
+        uint _339 = descriptor_qa_check(registers._m3 + 6u, 2u, 16u);
+        imageStore(_41[_339], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_274));
     }
     if (gl_GlobalInvocationID.x > 90u)
     {
         uint _351 = descriptor_qa_check(registers._m3 + ((gl_GlobalInvocationID.x & 1u) + 7u), 2u, 17u);
-        imageStore(_41[_351], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_304));
+        imageStore(_41[_351], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_274));
     }
-    uint _358 = atomicAdd(_161._m0, 1u);
+    uint _359 = descriptor_qa_check(registers._m4, 32u, 18u);
+    uint _365 = descriptor_qa_check(registers._m4, 256u, 19u);
+    uint _370 = atomicAdd(_34.counters[_365]._m0, 1u);
 }
 
 
@@ -236,7 +237,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 393
+; Bound: 405
 ; Schema: 0
 OpCapability Shader
 OpCapability SampledImageArrayDynamicIndexing
@@ -252,7 +253,7 @@ OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel PhysicalStorageBuffer64 GLSL450
-OpEntryPoint GLCompute %3 "main" %196
+OpEntryPoint GLCompute %3 "main" %51
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
 OpName %6 "RootConstants"
@@ -261,35 +262,35 @@ OpName %29 "AtomicCounter"
 OpName %32 "AtomicCounters"
 OpMemberName %32 0 "counters"
 OpName %45 "BindlessCBV"
-OpName %60 "DescriptorHeapGlobalQAData"
-OpMemberName %60 0 "failed_shader_hash"
-OpMemberName %60 1 "failed_offset"
-OpMemberName %60 2 "failed_heap"
-OpMemberName %60 3 "failed_cookie"
-OpMemberName %60 4 "fault_atomic"
-OpMemberName %60 5 "failed_instruction"
-OpMemberName %60 6 "failed_descriptor_type_mask"
-OpMemberName %60 7 "actual_descriptor_type_mask"
-OpMemberName %60 8 "fault_type"
-OpMemberName %60 9 "live_status_table"
-OpName %62 "QAGlobalData"
-OpName %71 "descriptor_qa_report_fault"
-OpName %64 "fault_type"
-OpName %65 "heap_offset"
-OpName %66 "cookie"
-OpName %67 "heap_index"
-OpName %68 "descriptor_type"
-OpName %69 "actual_descriptor_type"
-OpName %70 "instruction"
-OpName %101 "DescriptorHeapQAData"
-OpMemberName %101 0 "descriptor_count"
-OpMemberName %101 1 "heap_index"
-OpMemberName %101 2 "cookies_descriptor_info"
-OpName %103 "QAHeapData"
-OpName %108 "descriptor_qa_check"
-OpName %105 "heap_offset"
-OpName %106 "descriptor_type_mask"
-OpName %107 "instruction"
+OpName %68 "DescriptorHeapGlobalQAData"
+OpMemberName %68 0 "failed_shader_hash"
+OpMemberName %68 1 "failed_offset"
+OpMemberName %68 2 "failed_heap"
+OpMemberName %68 3 "failed_cookie"
+OpMemberName %68 4 "fault_atomic"
+OpMemberName %68 5 "failed_instruction"
+OpMemberName %68 6 "failed_descriptor_type_mask"
+OpMemberName %68 7 "actual_descriptor_type_mask"
+OpMemberName %68 8 "fault_type"
+OpMemberName %68 9 "live_status_table"
+OpName %70 "QAGlobalData"
+OpName %79 "descriptor_qa_report_fault"
+OpName %72 "fault_type"
+OpName %73 "heap_offset"
+OpName %74 "cookie"
+OpName %75 "heap_index"
+OpName %76 "descriptor_type"
+OpName %77 "actual_descriptor_type"
+OpName %78 "instruction"
+OpName %107 "DescriptorHeapQAData"
+OpMemberName %107 0 "descriptor_count"
+OpMemberName %107 1 "heap_index"
+OpMemberName %107 2 "cookies_descriptor_info"
+OpName %109 "QAHeapData"
+OpName %114 "descriptor_qa_check"
+OpName %111 "heap_offset"
+OpName %112 "descriptor_type_mask"
+OpName %113 "instruction"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 4
@@ -331,29 +332,29 @@ OpMemberDecorate %45 0 NonWritable
 OpMemberDecorate %45 0 Offset 0
 OpDecorate %48 DescriptorSet 5
 OpDecorate %48 Binding 0
-OpDecorate %59 ArrayStride 4
-OpMemberDecorate %60 0 Offset 0
-OpMemberDecorate %60 1 Offset 8
-OpMemberDecorate %60 2 Offset 12
-OpMemberDecorate %60 3 Offset 16
-OpMemberDecorate %60 4 Offset 20
-OpMemberDecorate %60 5 Offset 24
-OpMemberDecorate %60 6 Offset 28
-OpMemberDecorate %60 7 Offset 32
-OpMemberDecorate %60 8 Offset 36
-OpMemberDecorate %60 9 Offset 40
-OpDecorate %60 Block
-OpDecorate %62 DescriptorSet 10
-OpDecorate %62 Binding 10
-OpDecorate %100 ArrayStride 8
-OpMemberDecorate %101 0 Offset 0
-OpMemberDecorate %101 1 Offset 4
-OpMemberDecorate %101 2 Offset 8
-OpDecorate %101 Block
-OpDecorate %103 DescriptorSet 10
-OpDecorate %103 Binding 11
-OpDecorate %103 NonWritable
-OpDecorate %196 BuiltIn GlobalInvocationId
+OpDecorate %51 BuiltIn GlobalInvocationId
+OpDecorate %67 ArrayStride 4
+OpMemberDecorate %68 0 Offset 0
+OpMemberDecorate %68 1 Offset 8
+OpMemberDecorate %68 2 Offset 12
+OpMemberDecorate %68 3 Offset 16
+OpMemberDecorate %68 4 Offset 20
+OpMemberDecorate %68 5 Offset 24
+OpMemberDecorate %68 6 Offset 28
+OpMemberDecorate %68 7 Offset 32
+OpMemberDecorate %68 8 Offset 36
+OpMemberDecorate %68 9 Offset 40
+OpDecorate %68 Block
+OpDecorate %70 DescriptorSet 10
+OpDecorate %70 Binding 10
+OpDecorate %106 ArrayStride 8
+OpMemberDecorate %107 0 Offset 0
+OpMemberDecorate %107 1 Offset 4
+OpMemberDecorate %107 2 Offset 8
+OpDecorate %107 Block
+OpDecorate %109 DescriptorSet 10
+OpDecorate %109 Binding 11
+OpDecorate %109 NonWritable
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -400,422 +401,434 @@ OpDecorate %196 BuiltIn GlobalInvocationId
 %46 = OpTypeRuntimeArray %45
 %47 = OpTypePointer StorageBuffer %46
 %48 = OpVariable %47 StorageBuffer
-%49 = OpTypePointer UniformConstant %38
-%51 = OpTypePointer PushConstant %5
-%53 = OpConstant %5 3
-%56 = OpConstant %5 6
-%58 = OpTypeVector %5 2
-%59 = OpTypeRuntimeArray %5
-%60 = OpTypeStruct %58 %5 %5 %5 %5 %5 %5 %5 %5 %59
-%61 = OpTypePointer StorageBuffer %60
-%62 = OpVariable %61 StorageBuffer
-%63 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
-%73 = OpTypePointer StorageBuffer %5
-%75 = OpConstant %5 4
-%77 = OpConstant %5 1
-%78 = OpConstant %5 0
-%79 = OpTypeBool
-%86 = OpConstant %5 2
-%89 = OpConstant %5 7
-%91 = OpConstant %5 5
-%92 = OpConstant %5 3735928559
-%93 = OpConstantComposite %58 %92 %78
-%94 = OpTypePointer StorageBuffer %58
-%96 = OpConstant %5 72
-%98 = OpConstant %5 8
-%100 = OpTypeRuntimeArray %58
-%101 = OpTypeStruct %5 %5 %100
-%102 = OpTypePointer StorageBuffer %101
-%103 = OpVariable %102 StorageBuffer
-%104 = OpTypeFunction %5 %5 %5 %5
-%120 = OpConstant %5 31
-%122 = OpConstant %5 9
-%142 = OpTypePointer UniformConstant %25
-%148 = OpConstant %5 32
-%155 = OpTypePointer StorageBuffer %30
-%160 = OpConstant %5 256
-%162 = OpTypePointer UniformConstant %18
-%168 = OpConstant %5 16
-%176 = OpTypePointer UniformConstant %14
-%183 = OpTypePointer UniformConstant %10
-%189 = OpTypePointer StorageBuffer %45
-%194 = OpTypeVector %5 3
-%195 = OpTypePointer Input %194
-%196 = OpVariable %195 Input
-%197 = OpTypePointer Input %5
-%201 = OpTypePointer StorageBuffer %42
-%206 = OpConstant %9 0
-%214 = OpConstant %5 10
-%234 = OpConstant %5 11
-%254 = OpConstant %5 12
-%261 = OpTypeVector %5 4
-%275 = OpConstant %5 13
-%297 = OpConstant %5 14
-%309 = OpConstant %5 30
-%317 = OpConstant %5 15
-%322 = OpConstant %5 40
-%327 = OpConstant %5 50
-%340 = OpConstant %5 80
+%49 = OpTypeVector %5 3
+%50 = OpTypePointer Input %49
+%51 = OpVariable %50 Input
+%52 = OpTypePointer Input %5
+%54 = OpConstant %5 0
+%56 = OpTypeBool
+%58 = OpConstant %5 2
+%59 = OpTypePointer StorageBuffer %45
+%61 = OpTypePointer PushConstant %5
+%63 = OpConstant %5 5
+%66 = OpTypeVector %5 2
+%67 = OpTypeRuntimeArray %5
+%68 = OpTypeStruct %66 %5 %5 %5 %5 %5 %5 %5 %5 %67
+%69 = OpTypePointer StorageBuffer %68
+%70 = OpVariable %69 StorageBuffer
+%71 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%81 = OpTypePointer StorageBuffer %5
+%83 = OpConstant %5 4
+%85 = OpConstant %5 1
+%90 = OpConstant %5 3
+%94 = OpConstant %5 6
+%96 = OpConstant %5 7
+%98 = OpConstant %5 3735928559
+%99 = OpConstantComposite %66 %98 %54
+%100 = OpTypePointer StorageBuffer %66
+%102 = OpConstant %5 72
+%104 = OpConstant %5 8
+%106 = OpTypeRuntimeArray %66
+%107 = OpTypeStruct %5 %5 %106
+%108 = OpTypePointer StorageBuffer %107
+%109 = OpVariable %108 StorageBuffer
+%110 = OpTypeFunction %5 %5 %5 %5
+%126 = OpConstant %5 31
+%128 = OpConstant %5 9
+%147 = OpTypePointer StorageBuffer %42
+%152 = OpConstant %9 0
+%166 = OpTypePointer UniformConstant %10
+%192 = OpTypePointer UniformConstant %14
+%198 = OpConstant %5 16
+%218 = OpTypePointer UniformConstant %18
+%225 = OpTypeVector %5 4
+%246 = OpConstant %5 10
+%260 = OpConstant %5 11
+%276 = OpTypePointer UniformConstant %25
+%281 = OpConstant %5 32
+%283 = OpTypePointer StorageBuffer %30
+%288 = OpConstant %5 256
+%289 = OpConstant %5 12
+%294 = OpConstant %5 30
+%302 = OpConstant %5 13
+%307 = OpConstant %5 40
+%313 = OpConstant %5 14
+%319 = OpConstant %5 50
+%329 = OpConstant %5 15
+%333 = OpConstant %5 80
+%334 = OpTypePointer UniformConstant %38
 %344 = OpConstant %5 90
 %352 = OpConstant %5 17
-%356 = OpTypePointer PhysicalStorageBuffer %5
+%360 = OpConstant %5 18
+%366 = OpConstant %5 19
+%368 = OpTypePointer PhysicalStorageBuffer %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %359
-%359 = OpLabel
-%52 = OpAccessChain %51 %8 %53
-%54 = OpLoad %5 %52
-%55 = OpIAdd %5 %54 %56
-%57 = OpFunctionCall %5 %108 %55 %86 %77
-%50 = OpAccessChain %49 %41 %57
-%141 = OpLoad %38 %50
-%144 = OpAccessChain %51 %8 %75
-%145 = OpLoad %5 %144
-%146 = OpIAdd %5 %145 %53
-%147 = OpFunctionCall %5 %108 %146 %148 %86
-%143 = OpAccessChain %142 %37 %147
-%149 = OpLoad %25 %143
-%151 = OpAccessChain %51 %8 %75
-%152 = OpLoad %5 %151
-%153 = OpFunctionCall %5 %108 %152 %148 %53
-%150 = OpAccessChain %142 %28 %153
-%154 = OpLoad %25 %150
-%157 = OpAccessChain %51 %8 %75
-%158 = OpLoad %5 %157
-%159 = OpFunctionCall %5 %108 %158 %160 %75
-%156 = OpAccessChain %155 %34 %78 %159
-%161 = OpLoad %30 %156
-%164 = OpAccessChain %51 %8 %77
-%165 = OpLoad %5 %164
-%166 = OpIAdd %5 %165 %122
-%167 = OpFunctionCall %5 %108 %166 %168 %91
-%163 = OpAccessChain %162 %24 %167
-%169 = OpLoad %18 %163
-%171 = OpAccessChain %51 %8 %77
-%172 = OpLoad %5 %171
-%173 = OpIAdd %5 %172 %56
-%174 = OpFunctionCall %5 %108 %173 %168 %56
-%170 = OpAccessChain %162 %21 %174
-%175 = OpLoad %18 %170
-%178 = OpAccessChain %51 %8 %77
-%179 = OpLoad %5 %178
-%180 = OpIAdd %5 %179 %53
-%181 = OpFunctionCall %5 %108 %180 %168 %89
-%177 = OpAccessChain %176 %17 %181
-%182 = OpLoad %14 %177
-%185 = OpAccessChain %51 %8 %78
-%186 = OpLoad %5 %185
-%187 = OpFunctionCall %5 %108 %186 %77 %98
-%184 = OpAccessChain %183 %13 %187
-%188 = OpLoad %10 %184
-%191 = OpAccessChain %51 %8 %91
-%192 = OpLoad %5 %191
-%193 = OpFunctionCall %5 %108 %192 %98 %122
-%190 = OpAccessChain %189 %48 %193
-%198 = OpAccessChain %197 %196 %78
-%199 = OpLoad %5 %198
-%200 = OpUGreaterThan %79 %199 %86
-OpSelectionMerge %361 None
-OpBranchConditional %200 %360 %361
-%360 = OpLabel
-%202 = OpAccessChain %201 %190 %78 %78
-%203 = OpLoad %42 %202
-%204 = OpCompositeExtract %9 %203 0
-OpBranch %361
-%361 = OpLabel
-%205 = OpPhi %9 %206 %359 %204 %360
-%207 = OpUGreaterThan %79 %199 %53
-OpSelectionMerge %363 None
-OpBranchConditional %207 %362 %363
-%362 = OpLabel
-%208 = OpIAdd %5 %199 %77
-%210 = OpAccessChain %51 %8 %91
-%211 = OpLoad %5 %210
-%212 = OpIAdd %5 %211 %208
-%213 = OpFunctionCall %5 %108 %212 %98 %214
-%209 = OpAccessChain %189 %48 %213
-%215 = OpAccessChain %201 %209 %78 %78
-%216 = OpLoad %42 %215
-%217 = OpCompositeExtract %9 %216 0
-%218 = OpFAdd %9 %217 %205
-OpBranch %363
-%363 = OpLabel
-%219 = OpPhi %9 %205 %361 %218 %362
-%220 = OpUGreaterThan %79 %199 %75
-OpSelectionMerge %365 None
-OpBranchConditional %220 %364 %365
-%364 = OpLabel
-%222 = OpCompositeConstruct %58 %199 %78
-%221 = OpImageFetch %42 %188 %222 Lod %78
-%223 = OpCompositeExtract %9 %221 0
-%224 = OpFAdd %9 %223 %219
-OpBranch %365
-%365 = OpLabel
-%225 = OpPhi %9 %219 %363 %224 %364
-%226 = OpUGreaterThan %79 %199 %91
-OpSelectionMerge %367 None
-OpBranchConditional %226 %366 %367
-%366 = OpLabel
-%227 = OpBitwiseAnd %5 %199 %77
-%228 = OpIAdd %5 %227 %77
-%230 = OpAccessChain %51 %8 %78
-%231 = OpLoad %5 %230
-%232 = OpIAdd %5 %231 %228
-%233 = OpFunctionCall %5 %108 %232 %77 %234
-%229 = OpAccessChain %183 %13 %233
-%235 = OpLoad %10 %229
-%237 = OpCompositeConstruct %58 %78 %199
-%236 = OpImageFetch %42 %235 %237 Lod %78
-%238 = OpCompositeExtract %9 %236 0
-%239 = OpFAdd %9 %238 %225
-OpBranch %367
-%367 = OpLabel
-%240 = OpPhi %9 %225 %365 %239 %366
-%241 = OpUGreaterThan %79 %199 %56
-OpSelectionMerge %369 None
-OpBranchConditional %241 %368 %369
-%368 = OpLabel
-%242 = OpImageFetch %42 %182 %199
-%243 = OpCompositeExtract %9 %242 0
-%244 = OpFAdd %9 %243 %240
-OpBranch %369
-%369 = OpLabel
-%245 = OpPhi %9 %240 %367 %244 %368
-%246 = OpUGreaterThan %79 %199 %89
-OpSelectionMerge %371 None
-OpBranchConditional %246 %370 %371
-%370 = OpLabel
-%247 = OpBitwiseAnd %5 %199 %77
-%248 = OpIAdd %5 %247 %75
-%250 = OpAccessChain %51 %8 %77
-%251 = OpLoad %5 %250
-%252 = OpIAdd %5 %251 %248
-%253 = OpFunctionCall %5 %108 %252 %168 %254
-%249 = OpAccessChain %176 %17 %253
-%255 = OpLoad %14 %249
-%256 = OpImageFetch %42 %255 %199
-%257 = OpCompositeExtract %9 %256 0
-%258 = OpFAdd %9 %257 %245
 OpBranch %371
 %371 = OpLabel
-%259 = OpPhi %9 %245 %369 %258 %370
-%260 = OpUGreaterThan %79 %199 %98
+%53 = OpAccessChain %52 %51 %54
+%55 = OpLoad %5 %53
+%57 = OpUGreaterThan %56 %55 %58
 OpSelectionMerge %373 None
-OpBranchConditional %260 %372 %373
+OpBranchConditional %57 %372 %373
 %372 = OpLabel
-%262 = OpImageFetch %261 %175 %199
-%263 = OpCompositeExtract %5 %262 0
-%264 = OpBitcast %9 %263
-%265 = OpFAdd %9 %264 %259
+%62 = OpAccessChain %61 %8 %63
+%64 = OpLoad %5 %62
+%65 = OpFunctionCall %5 %114 %64 %104 %85
+%60 = OpAccessChain %59 %48 %65
+%148 = OpAccessChain %147 %60 %54 %54
+%149 = OpLoad %42 %148
+%150 = OpCompositeExtract %9 %149 0
 OpBranch %373
 %373 = OpLabel
-%266 = OpPhi %9 %259 %371 %265 %372
-%267 = OpUGreaterThan %79 %199 %122
+%151 = OpPhi %9 %152 %371 %150 %372
+%153 = OpUGreaterThan %56 %55 %90
 OpSelectionMerge %375 None
-OpBranchConditional %267 %374 %375
+OpBranchConditional %153 %374 %375
 %374 = OpLabel
-%268 = OpBitwiseAnd %5 %199 %77
-%269 = OpIAdd %5 %268 %89
-%271 = OpAccessChain %51 %8 %77
-%272 = OpLoad %5 %271
-%273 = OpIAdd %5 %272 %269
-%274 = OpFunctionCall %5 %108 %273 %168 %275
-%270 = OpAccessChain %162 %21 %274
-%276 = OpLoad %18 %270
-%277 = OpImageFetch %261 %276 %199
-%278 = OpCompositeExtract %5 %277 0
-%279 = OpBitcast %9 %278
-%280 = OpFAdd %9 %279 %266
+%154 = OpIAdd %5 %55 %85
+%156 = OpAccessChain %61 %8 %63
+%157 = OpLoad %5 %156
+%158 = OpIAdd %5 %157 %154
+%159 = OpFunctionCall %5 %114 %158 %104 %58
+%155 = OpAccessChain %59 %48 %159
+%160 = OpAccessChain %147 %155 %54 %54
+%161 = OpLoad %42 %160
+%162 = OpCompositeExtract %9 %161 0
+%163 = OpFAdd %9 %162 %151
 OpBranch %375
 %375 = OpLabel
-%281 = OpPhi %9 %266 %373 %280 %374
-%282 = OpUGreaterThan %79 %199 %214
+%164 = OpPhi %9 %151 %373 %163 %374
+%165 = OpUGreaterThan %56 %55 %83
 OpSelectionMerge %377 None
-OpBranchConditional %282 %376 %377
+OpBranchConditional %165 %376 %377
 %376 = OpLabel
-%283 = OpShiftLeftLogical %5 %199 %86
-%284 = OpImageFetch %261 %169 %199
-%285 = OpCompositeExtract %5 %284 0
-%286 = OpBitcast %9 %285
-%287 = OpFAdd %9 %286 %281
+%168 = OpAccessChain %61 %8 %54
+%169 = OpLoad %5 %168
+%170 = OpFunctionCall %5 %114 %169 %85 %90
+%167 = OpAccessChain %166 %13 %170
+%171 = OpLoad %10 %167
+%173 = OpCompositeConstruct %66 %55 %54
+%172 = OpImageFetch %42 %171 %173 Lod %54
+%174 = OpCompositeExtract %9 %172 0
+%175 = OpFAdd %9 %174 %164
 OpBranch %377
 %377 = OpLabel
-%288 = OpPhi %9 %281 %375 %287 %376
-%289 = OpUGreaterThan %79 %199 %234
+%176 = OpPhi %9 %164 %375 %175 %376
+%177 = OpUGreaterThan %56 %55 %63
 OpSelectionMerge %379 None
-OpBranchConditional %289 %378 %379
+OpBranchConditional %177 %378 %379
 %378 = OpLabel
-%290 = OpBitwiseAnd %5 %199 %77
-%291 = OpIAdd %5 %290 %214
-%293 = OpAccessChain %51 %8 %77
-%294 = OpLoad %5 %293
-%295 = OpIAdd %5 %294 %291
-%296 = OpFunctionCall %5 %108 %295 %168 %297
-%292 = OpAccessChain %162 %24 %296
-%298 = OpLoad %18 %292
-%299 = OpShiftRightLogical %5 %199 %86
-%300 = OpImageFetch %261 %298 %299
-%301 = OpCompositeExtract %5 %300 0
-%302 = OpBitcast %9 %301
-%303 = OpFAdd %9 %302 %288
+%178 = OpBitwiseAnd %5 %55 %85
+%179 = OpIAdd %5 %178 %85
+%181 = OpAccessChain %61 %8 %54
+%182 = OpLoad %5 %181
+%183 = OpIAdd %5 %182 %179
+%184 = OpFunctionCall %5 %114 %183 %85 %83
+%180 = OpAccessChain %166 %13 %184
+%185 = OpLoad %10 %180
+%187 = OpCompositeConstruct %66 %54 %55
+%186 = OpImageFetch %42 %185 %187 Lod %54
+%188 = OpCompositeExtract %9 %186 0
+%189 = OpFAdd %9 %188 %176
 OpBranch %379
 %379 = OpLabel
-%304 = OpPhi %9 %288 %377 %303 %378
-%305 = OpUGreaterThan %79 %199 %77
+%190 = OpPhi %9 %176 %377 %189 %378
+%191 = OpUGreaterThan %56 %55 %94
 OpSelectionMerge %381 None
-OpBranchConditional %305 %380 %381
+OpBranchConditional %191 %380 %381
 %380 = OpLabel
-%306 = OpBitcast %5 %304
-%307 = OpCompositeConstruct %261 %306 %306 %306 %306
-OpImageWrite %154 %199 %307
+%194 = OpAccessChain %61 %8 %85
+%195 = OpLoad %5 %194
+%196 = OpIAdd %5 %195 %90
+%197 = OpFunctionCall %5 %114 %196 %198 %63
+%193 = OpAccessChain %192 %17 %197
+%199 = OpLoad %14 %193
+%200 = OpImageFetch %42 %199 %55
+%201 = OpCompositeExtract %9 %200 0
+%202 = OpFAdd %9 %201 %190
 OpBranch %381
 %381 = OpLabel
-%308 = OpUGreaterThan %79 %199 %309
+%203 = OpPhi %9 %190 %379 %202 %380
+%204 = OpUGreaterThan %56 %55 %96
 OpSelectionMerge %383 None
-OpBranchConditional %308 %382 %383
+OpBranchConditional %204 %382 %383
 %382 = OpLabel
-%310 = OpBitwiseAnd %5 %199 %77
-%311 = OpIAdd %5 %310 %77
-%313 = OpAccessChain %51 %8 %75
-%314 = OpLoad %5 %313
-%315 = OpIAdd %5 %314 %311
-%316 = OpFunctionCall %5 %108 %315 %148 %317
-%312 = OpAccessChain %142 %28 %316
-%318 = OpLoad %25 %312
-%319 = OpBitcast %5 %304
-%320 = OpCompositeConstruct %261 %319 %319 %319 %319
-OpImageWrite %318 %199 %320
+%205 = OpBitwiseAnd %5 %55 %85
+%206 = OpIAdd %5 %205 %83
+%208 = OpAccessChain %61 %8 %85
+%209 = OpLoad %5 %208
+%210 = OpIAdd %5 %209 %206
+%211 = OpFunctionCall %5 %114 %210 %198 %94
+%207 = OpAccessChain %192 %17 %211
+%212 = OpLoad %14 %207
+%213 = OpImageFetch %42 %212 %55
+%214 = OpCompositeExtract %9 %213 0
+%215 = OpFAdd %9 %214 %203
 OpBranch %383
 %383 = OpLabel
-%321 = OpUGreaterThan %79 %199 %322
+%216 = OpPhi %9 %203 %381 %215 %382
+%217 = OpUGreaterThan %56 %55 %104
 OpSelectionMerge %385 None
-OpBranchConditional %321 %384 %385
+OpBranchConditional %217 %384 %385
 %384 = OpLabel
-%323 = OpBitcast %5 %304
-%324 = OpShiftLeftLogical %5 %199 %86
-%325 = OpCompositeConstruct %261 %323 %323 %323 %323
-OpImageWrite %149 %199 %325
+%220 = OpAccessChain %61 %8 %85
+%221 = OpLoad %5 %220
+%222 = OpIAdd %5 %221 %94
+%223 = OpFunctionCall %5 %114 %222 %198 %96
+%219 = OpAccessChain %218 %21 %223
+%224 = OpLoad %18 %219
+%226 = OpImageFetch %225 %224 %55
+%227 = OpCompositeExtract %5 %226 0
+%228 = OpBitcast %9 %227
+%229 = OpFAdd %9 %228 %216
 OpBranch %385
 %385 = OpLabel
-%326 = OpUGreaterThan %79 %199 %327
+%230 = OpPhi %9 %216 %383 %229 %384
+%231 = OpUGreaterThan %56 %55 %128
 OpSelectionMerge %387 None
-OpBranchConditional %326 %386 %387
+OpBranchConditional %231 %386 %387
 %386 = OpLabel
-%328 = OpBitwiseAnd %5 %199 %77
-%329 = OpBitcast %5 %304
-%330 = OpShiftLeftLogical %5 %199 %86
-%331 = OpIAdd %5 %328 %75
-%333 = OpAccessChain %51 %8 %75
-%334 = OpLoad %5 %333
-%335 = OpIAdd %5 %334 %331
-%336 = OpFunctionCall %5 %108 %335 %148 %168
-%332 = OpAccessChain %142 %37 %336
-%337 = OpLoad %25 %332
-%338 = OpCompositeConstruct %261 %329 %329 %329 %329
-OpImageWrite %337 %199 %338
+%232 = OpBitwiseAnd %5 %55 %85
+%233 = OpIAdd %5 %232 %96
+%235 = OpAccessChain %61 %8 %85
+%236 = OpLoad %5 %235
+%237 = OpIAdd %5 %236 %233
+%238 = OpFunctionCall %5 %114 %237 %198 %104
+%234 = OpAccessChain %218 %21 %238
+%239 = OpLoad %18 %234
+%240 = OpImageFetch %225 %239 %55
+%241 = OpCompositeExtract %5 %240 0
+%242 = OpBitcast %9 %241
+%243 = OpFAdd %9 %242 %230
 OpBranch %387
 %387 = OpLabel
-%339 = OpUGreaterThan %79 %199 %340
+%244 = OpPhi %9 %230 %385 %243 %386
+%245 = OpUGreaterThan %56 %55 %246
 OpSelectionMerge %389 None
-OpBranchConditional %339 %388 %389
+OpBranchConditional %245 %388 %389
 %388 = OpLabel
-%341 = OpCompositeConstruct %58 %199 %78
-%342 = OpCompositeConstruct %42 %304 %304 %304 %304
-OpImageWrite %141 %341 %342
+%248 = OpAccessChain %61 %8 %85
+%249 = OpLoad %5 %248
+%250 = OpIAdd %5 %249 %128
+%251 = OpFunctionCall %5 %114 %250 %198 %128
+%247 = OpAccessChain %218 %24 %251
+%252 = OpLoad %18 %247
+%253 = OpShiftLeftLogical %5 %55 %58
+%254 = OpImageFetch %225 %252 %55
+%255 = OpCompositeExtract %5 %254 0
+%256 = OpBitcast %9 %255
+%257 = OpFAdd %9 %256 %244
 OpBranch %389
 %389 = OpLabel
-%343 = OpUGreaterThan %79 %199 %344
+%258 = OpPhi %9 %244 %387 %257 %388
+%259 = OpUGreaterThan %56 %55 %260
 OpSelectionMerge %391 None
-OpBranchConditional %343 %390 %391
+OpBranchConditional %259 %390 %391
 %390 = OpLabel
-%345 = OpBitwiseAnd %5 %199 %77
-%346 = OpIAdd %5 %345 %89
-%348 = OpAccessChain %51 %8 %53
-%349 = OpLoad %5 %348
-%350 = OpIAdd %5 %349 %346
-%351 = OpFunctionCall %5 %108 %350 %86 %352
-%347 = OpAccessChain %49 %41 %351
-%353 = OpLoad %38 %347
-%354 = OpCompositeConstruct %58 %78 %199
-%355 = OpCompositeConstruct %42 %304 %304 %304 %304
-OpImageWrite %353 %354 %355
+%261 = OpBitwiseAnd %5 %55 %85
+%262 = OpIAdd %5 %261 %246
+%264 = OpAccessChain %61 %8 %85
+%265 = OpLoad %5 %264
+%266 = OpIAdd %5 %265 %262
+%267 = OpFunctionCall %5 %114 %266 %198 %246
+%263 = OpAccessChain %218 %24 %267
+%268 = OpLoad %18 %263
+%269 = OpShiftRightLogical %5 %55 %58
+%270 = OpImageFetch %225 %268 %269
+%271 = OpCompositeExtract %5 %270 0
+%272 = OpBitcast %9 %271
+%273 = OpFAdd %9 %272 %258
 OpBranch %391
 %391 = OpLabel
-%357 = OpAccessChain %356 %161 %78
-%358 = OpAtomicIAdd %5 %357 %77 %78 %77
+%274 = OpPhi %9 %258 %389 %273 %390
+%275 = OpUGreaterThan %56 %55 %85
+OpSelectionMerge %393 None
+OpBranchConditional %275 %392 %393
+%392 = OpLabel
+%278 = OpAccessChain %61 %8 %83
+%279 = OpLoad %5 %278
+%280 = OpFunctionCall %5 %114 %279 %281 %260
+%277 = OpAccessChain %276 %28 %280
+%282 = OpLoad %25 %277
+%285 = OpAccessChain %61 %8 %83
+%286 = OpLoad %5 %285
+%287 = OpFunctionCall %5 %114 %286 %288 %289
+%284 = OpAccessChain %283 %34 %54 %287
+%290 = OpLoad %30 %284
+%291 = OpBitcast %5 %274
+%292 = OpCompositeConstruct %225 %291 %291 %291 %291
+OpImageWrite %282 %55 %292
+OpBranch %393
+%393 = OpLabel
+%293 = OpUGreaterThan %56 %55 %294
+OpSelectionMerge %395 None
+OpBranchConditional %293 %394 %395
+%394 = OpLabel
+%295 = OpBitwiseAnd %5 %55 %85
+%296 = OpIAdd %5 %295 %85
+%298 = OpAccessChain %61 %8 %83
+%299 = OpLoad %5 %298
+%300 = OpIAdd %5 %299 %296
+%301 = OpFunctionCall %5 %114 %300 %281 %302
+%297 = OpAccessChain %276 %28 %301
+%303 = OpLoad %25 %297
+%304 = OpBitcast %5 %274
+%305 = OpCompositeConstruct %225 %304 %304 %304 %304
+OpImageWrite %303 %55 %305
+OpBranch %395
+%395 = OpLabel
+%306 = OpUGreaterThan %56 %55 %307
+OpSelectionMerge %397 None
+OpBranchConditional %306 %396 %397
+%396 = OpLabel
+%309 = OpAccessChain %61 %8 %83
+%310 = OpLoad %5 %309
+%311 = OpIAdd %5 %310 %90
+%312 = OpFunctionCall %5 %114 %311 %281 %313
+%308 = OpAccessChain %276 %37 %312
+%314 = OpLoad %25 %308
+%315 = OpBitcast %5 %274
+%316 = OpShiftLeftLogical %5 %55 %58
+%317 = OpCompositeConstruct %225 %315 %315 %315 %315
+OpImageWrite %314 %55 %317
+OpBranch %397
+%397 = OpLabel
+%318 = OpUGreaterThan %56 %55 %319
+OpSelectionMerge %399 None
+OpBranchConditional %318 %398 %399
+%398 = OpLabel
+%320 = OpBitwiseAnd %5 %55 %85
+%321 = OpBitcast %5 %274
+%322 = OpShiftLeftLogical %5 %55 %58
+%323 = OpIAdd %5 %320 %83
+%325 = OpAccessChain %61 %8 %83
+%326 = OpLoad %5 %325
+%327 = OpIAdd %5 %326 %323
+%328 = OpFunctionCall %5 %114 %327 %281 %329
+%324 = OpAccessChain %276 %37 %328
+%330 = OpLoad %25 %324
+%331 = OpCompositeConstruct %225 %321 %321 %321 %321
+OpImageWrite %330 %55 %331
+OpBranch %399
+%399 = OpLabel
+%332 = OpUGreaterThan %56 %55 %333
+OpSelectionMerge %401 None
+OpBranchConditional %332 %400 %401
+%400 = OpLabel
+%336 = OpAccessChain %61 %8 %90
+%337 = OpLoad %5 %336
+%338 = OpIAdd %5 %337 %94
+%339 = OpFunctionCall %5 %114 %338 %58 %198
+%335 = OpAccessChain %334 %41 %339
+%340 = OpLoad %38 %335
+%341 = OpCompositeConstruct %66 %55 %54
+%342 = OpCompositeConstruct %42 %274 %274 %274 %274
+OpImageWrite %340 %341 %342
+OpBranch %401
+%401 = OpLabel
+%343 = OpUGreaterThan %56 %55 %344
+OpSelectionMerge %403 None
+OpBranchConditional %343 %402 %403
+%402 = OpLabel
+%345 = OpBitwiseAnd %5 %55 %85
+%346 = OpIAdd %5 %345 %96
+%348 = OpAccessChain %61 %8 %90
+%349 = OpLoad %5 %348
+%350 = OpIAdd %5 %349 %346
+%351 = OpFunctionCall %5 %114 %350 %58 %352
+%347 = OpAccessChain %334 %41 %351
+%353 = OpLoad %38 %347
+%354 = OpCompositeConstruct %66 %54 %55
+%355 = OpCompositeConstruct %42 %274 %274 %274 %274
+OpImageWrite %353 %354 %355
+OpBranch %403
+%403 = OpLabel
+%357 = OpAccessChain %61 %8 %83
+%358 = OpLoad %5 %357
+%359 = OpFunctionCall %5 %114 %358 %281 %360
+%356 = OpAccessChain %276 %28 %359
+%361 = OpLoad %25 %356
+%363 = OpAccessChain %61 %8 %83
+%364 = OpLoad %5 %363
+%365 = OpFunctionCall %5 %114 %364 %288 %366
+%362 = OpAccessChain %283 %34 %54 %365
+%367 = OpLoad %30 %362
+%369 = OpAccessChain %368 %367 %54
+%370 = OpAtomicIAdd %5 %369 %85 %54 %85
 OpReturn
 OpFunctionEnd
-%71 = OpFunction %1 None %63
-%64 = OpFunctionParameter %5
-%65 = OpFunctionParameter %5
-%66 = OpFunctionParameter %5
-%67 = OpFunctionParameter %5
-%68 = OpFunctionParameter %5
-%69 = OpFunctionParameter %5
-%70 = OpFunctionParameter %5
-%72 = OpLabel
-%74 = OpAccessChain %73 %62 %75
-%76 = OpAtomicIAdd %5 %74 %77 %78 %77
-%80 = OpIEqual %79 %76 %78
-OpSelectionMerge %82 None
-OpBranchConditional %80 %81 %82
-%81 = OpLabel
-%83 = OpAccessChain %73 %62 %53
-OpStore %83 %66
-%84 = OpAccessChain %73 %62 %77
-OpStore %84 %65
-%85 = OpAccessChain %73 %62 %86
-OpStore %85 %67
-%87 = OpAccessChain %73 %62 %56
-OpStore %87 %68
-%88 = OpAccessChain %73 %62 %89
-OpStore %88 %69
-%90 = OpAccessChain %73 %62 %91
-OpStore %90 %70
-%95 = OpAccessChain %94 %62 %78
-OpStore %95 %93
-OpMemoryBarrier %77 %96
-%97 = OpAccessChain %73 %62 %98
-OpStore %97 %64
-OpBranch %82
-%82 = OpLabel
+%79 = OpFunction %1 None %71
+%72 = OpFunctionParameter %5
+%73 = OpFunctionParameter %5
+%74 = OpFunctionParameter %5
+%75 = OpFunctionParameter %5
+%76 = OpFunctionParameter %5
+%77 = OpFunctionParameter %5
+%78 = OpFunctionParameter %5
+%80 = OpLabel
+%82 = OpAccessChain %81 %70 %83
+%84 = OpAtomicIAdd %5 %82 %85 %54 %85
+%86 = OpIEqual %56 %84 %54
+OpSelectionMerge %88 None
+OpBranchConditional %86 %87 %88
+%87 = OpLabel
+%89 = OpAccessChain %81 %70 %90
+OpStore %89 %74
+%91 = OpAccessChain %81 %70 %85
+OpStore %91 %73
+%92 = OpAccessChain %81 %70 %58
+OpStore %92 %75
+%93 = OpAccessChain %81 %70 %94
+OpStore %93 %76
+%95 = OpAccessChain %81 %70 %96
+OpStore %95 %77
+%97 = OpAccessChain %81 %70 %63
+OpStore %97 %78
+%101 = OpAccessChain %100 %70 %54
+OpStore %101 %99
+OpMemoryBarrier %85 %102
+%103 = OpAccessChain %81 %70 %104
+OpStore %103 %72
+OpBranch %88
+%88 = OpLabel
 OpReturn
 OpFunctionEnd
-%108 = OpFunction %5 None %104
-%105 = OpFunctionParameter %5
-%106 = OpFunctionParameter %5
-%107 = OpFunctionParameter %5
-%109 = OpLabel
-%110 = OpAccessChain %73 %103 %78
-%111 = OpLoad %5 %110
-%112 = OpAccessChain %73 %103 %77
-%113 = OpLoad %5 %112
-%114 = OpAccessChain %94 %103 %86 %105
-%115 = OpLoad %58 %114
-%116 = OpCompositeExtract %5 %115 0
-%118 = OpShiftRightLogical %5 %116 %91
-%119 = OpBitwiseAnd %5 %116 %120
-%117 = OpCompositeExtract %5 %115 1
-%121 = OpAccessChain %73 %62 %122 %118
-%123 = OpLoad %5 %121
-%124 = OpShiftLeftLogical %5 %77 %119
-%125 = OpBitwiseAnd %5 %123 %124
-%126 = OpINotEqual %79 %125 %78
-%127 = OpBitwiseAnd %5 %117 %106
-%128 = OpIEqual %79 %127 %106
-%129 = OpUGreaterThanEqual %79 %105 %111
-%130 = OpSelect %5 %129 %77 %78
-%131 = OpSelect %5 %128 %78 %86
-%132 = OpSelect %5 %126 %78 %75
-%133 = OpBitwiseOr %5 %130 %131
-%134 = OpBitwiseOr %5 %133 %132
-%135 = OpINotEqual %79 %134 %78
-OpSelectionMerge %137 None
-OpBranchConditional %135 %136 %137
-%136 = OpLabel
-%138 = OpFunctionCall %1 %71 %134 %105 %116 %113 %106 %117 %107
+%114 = OpFunction %5 None %110
+%111 = OpFunctionParameter %5
+%112 = OpFunctionParameter %5
+%113 = OpFunctionParameter %5
+%115 = OpLabel
+%116 = OpAccessChain %81 %109 %54
+%117 = OpLoad %5 %116
+%118 = OpAccessChain %81 %109 %85
+%119 = OpLoad %5 %118
+%120 = OpAccessChain %100 %109 %58 %111
+%121 = OpLoad %66 %120
+%122 = OpCompositeExtract %5 %121 0
+%124 = OpShiftRightLogical %5 %122 %63
+%125 = OpBitwiseAnd %5 %122 %126
+%123 = OpCompositeExtract %5 %121 1
+%127 = OpAccessChain %81 %70 %128 %124
+%129 = OpLoad %5 %127
+%130 = OpShiftLeftLogical %5 %85 %125
+%131 = OpBitwiseAnd %5 %129 %130
+%132 = OpINotEqual %56 %131 %54
+%133 = OpBitwiseAnd %5 %123 %112
+%134 = OpIEqual %56 %133 %112
+%135 = OpUGreaterThanEqual %56 %111 %117
+%136 = OpSelect %5 %135 %85 %54
+%137 = OpSelect %5 %134 %54 %58
+%138 = OpSelect %5 %132 %54 %83
+%139 = OpBitwiseOr %5 %136 %137
+%140 = OpBitwiseOr %5 %139 %138
+%141 = OpINotEqual %56 %140 %54
+OpSelectionMerge %143 None
+OpBranchConditional %141 %142 %143
+%142 = OpLabel
+%144 = OpFunctionCall %1 %79 %140 %111 %122 %119 %112 %123 %113
+OpReturnValue %117
+%143 = OpLabel
 OpReturnValue %111
-%137 = OpLabel
-OpReturnValue %105
 OpFunctionEnd
 #endif

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
@@ -64,8 +64,8 @@ layout(set = 2, binding = 0) uniform sampler _52[];
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _80 = atomicAdd(QAGlobalData.fault_atomic, 1u);
-    if (_80 == 0u)
+    uint _88 = atomicAdd(QAGlobalData.fault_atomic, 1u);
+    if (_88 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
         QAGlobalData.failed_offset = heap_offset;
@@ -81,154 +81,155 @@ void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, 
 
 uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
 {
-    uint _115 = QAHeapData.descriptor_count;
-    uint _117 = QAHeapData.heap_index;
-    uvec2 _119 = QAHeapData.cookies_descriptor_info[heap_offset];
-    uint _127 = QAGlobalData.live_status_table[_119.x >> 5u];
-    uint _138 = (uint(heap_offset >= _115) | (((_119.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_127 & (1u << (_119.x & 31u))) != 0u) ? 0u : 4u);
-    if (_138 != 0u)
+    uint _121 = QAHeapData.descriptor_count;
+    uint _123 = QAHeapData.heap_index;
+    uvec2 _125 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _133 = QAGlobalData.live_status_table[_125.x >> 5u];
+    uint _144 = (uint(heap_offset >= _121) | (((_125.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_133 & (1u << (_125.x & 31u))) != 0u) ? 0u : 4u);
+    if (_144 != 0u)
     {
-        descriptor_qa_report_fault(_138, heap_offset, _119.x, _117, descriptor_type_mask, _119.y, instruction);
-        return _115;
+        descriptor_qa_report_fault(_144, heap_offset, _125.x, _123, descriptor_type_mask, _125.y, instruction);
+        return _121;
     }
     return heap_offset;
 }
 
 void main()
 {
-    uint _61 = descriptor_qa_check(registers._m3 + 6u, 2u, 1u);
-    uint _151 = descriptor_qa_check(registers._m4 + 3u, 32u, 2u);
-    uint _157 = descriptor_qa_check(registers._m4, 32u, 3u);
-    uint _163 = descriptor_qa_check(registers._m4, 256u, 4u);
-    AtomicCounter _165 = _34.counters[_163];
-    uint _171 = descriptor_qa_check(registers._m1 + 9u, 16u, 5u);
-    uint _178 = descriptor_qa_check(registers._m1 + 6u, 16u, 6u);
-    uint _185 = descriptor_qa_check(registers._m1 + 3u, 16u, 7u);
-    uint _191 = descriptor_qa_check(registers._m0, 1u, 8u);
-    uint _202 = descriptor_qa_check(registers._m5, 4u, 9u);
-    float _214;
+    float _155;
     if (gl_GlobalInvocationID.x > 2u)
     {
-        _214 = _48[_202]._m0[0u].x;
+        uint _69 = descriptor_qa_check(registers._m5, 4u, 1u);
+        _155 = _48[_69]._m0[0u].x;
     }
     else
     {
-        _214 = 0.0;
+        _155 = 0.0;
     }
-    float _228;
+    float _168;
     if (gl_GlobalInvocationID.x > 3u)
     {
-        uint _222 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 4u, 10u);
-        _228 = _48[_222]._m0[0u].x + _214;
+        uint _163 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 4u, 2u);
+        _168 = _48[_163]._m0[0u].x + _155;
     }
     else
     {
-        _228 = _214;
+        _168 = _155;
     }
-    float _238;
+    float _189;
     if (gl_GlobalInvocationID.x > 4u)
     {
-        _238 = textureLod(sampler2D(_13[_191], _52[registers._m2]), vec2(0.5), 0.0).x + _228;
+        uint _174 = descriptor_qa_check(registers._m0, 1u, 3u);
+        _189 = textureLod(sampler2D(_13[_174], _52[registers._m2]), vec2(0.5), 0.0).x + _168;
     }
     else
     {
-        _238 = _228;
+        _189 = _168;
     }
-    float _253;
+    float _203;
     if (gl_GlobalInvocationID.x > 5u)
     {
-        uint _246 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 11u);
-        _253 = texelFetch(_13[_246], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _238;
+        uint _197 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 4u);
+        _203 = texelFetch(_13[_197], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _189;
     }
     else
     {
-        _253 = _238;
+        _203 = _189;
     }
-    float _258;
+    float _216;
     if (gl_GlobalInvocationID.x > 6u)
     {
-        _258 = texelFetch(_17[_185], int(gl_GlobalInvocationID.x)).x + _253;
+        uint _210 = descriptor_qa_check(registers._m1 + 3u, 16u, 5u);
+        _216 = texelFetch(_17[_210], int(gl_GlobalInvocationID.x)).x + _203;
     }
     else
     {
-        _258 = _253;
+        _216 = _203;
     }
-    float _272;
+    float _229;
     if (gl_GlobalInvocationID.x > 7u)
     {
-        uint _266 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 12u);
-        _272 = texelFetch(_17[_266], int(gl_GlobalInvocationID.x)).x + _258;
+        uint _224 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 6u);
+        _229 = texelFetch(_17[_224], int(gl_GlobalInvocationID.x)).x + _216;
     }
     else
     {
-        _272 = _258;
+        _229 = _216;
     }
-    float _279;
+    float _243;
     if (gl_GlobalInvocationID.x > 8u)
     {
-        _279 = uintBitsToFloat(texelFetch(_21[_178], int(gl_GlobalInvocationID.x)).x) + _272;
+        uint _236 = descriptor_qa_check(registers._m1 + 6u, 16u, 7u);
+        _243 = uintBitsToFloat(texelFetch(_21[_236], int(gl_GlobalInvocationID.x)).x) + _229;
     }
     else
     {
-        _279 = _272;
+        _243 = _229;
     }
-    float _294;
+    float _257;
     if (gl_GlobalInvocationID.x > 9u)
     {
-        uint _287 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 16u, 13u);
-        _294 = uintBitsToFloat(texelFetch(_21[_287], int(gl_GlobalInvocationID.x)).x) + _279;
+        uint _251 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 16u, 8u);
+        _257 = uintBitsToFloat(texelFetch(_21[_251], int(gl_GlobalInvocationID.x)).x) + _243;
     }
     else
     {
-        _294 = _279;
+        _257 = _243;
     }
-    float _301;
+    float _271;
     if (gl_GlobalInvocationID.x > 10u)
     {
-        _301 = uintBitsToFloat(texelFetch(_24[_171], int(gl_GlobalInvocationID.x)).x) + _294;
+        uint _264 = descriptor_qa_check(registers._m1 + 9u, 16u, 9u);
+        _271 = uintBitsToFloat(texelFetch(_24[_264], int(gl_GlobalInvocationID.x)).x) + _257;
     }
     else
     {
-        _301 = _294;
+        _271 = _257;
     }
-    float _317;
+    float _287;
     if (gl_GlobalInvocationID.x > 11u)
     {
-        uint _309 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 16u, 14u);
-        _317 = uintBitsToFloat(texelFetch(_24[_309], int(gl_GlobalInvocationID.x >> 2u)).x) + _301;
+        uint _280 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 16u, 10u);
+        _287 = uintBitsToFloat(texelFetch(_24[_280], int(gl_GlobalInvocationID.x >> 2u)).x) + _271;
     }
     else
     {
-        _317 = _301;
+        _287 = _271;
     }
     if (gl_GlobalInvocationID.x > 1u)
     {
-        imageStore(_28[_157], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+        uint _293 = descriptor_qa_check(registers._m4, 32u, 11u);
+        uint _300 = descriptor_qa_check(registers._m4, 256u, 12u);
+        imageStore(_28[_293], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_287)));
     }
     if (gl_GlobalInvocationID.x > 30u)
     {
-        uint _329 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 32u, 15u);
-        imageStore(_28[_329], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+        uint _314 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 32u, 13u);
+        imageStore(_28[_314], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_287)));
     }
     if (gl_GlobalInvocationID.x > 40u)
     {
-        imageStore(_37[_151], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+        uint _325 = descriptor_qa_check(registers._m4 + 3u, 32u, 14u);
+        imageStore(_37[_325], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_287)));
     }
     if (gl_GlobalInvocationID.x > 50u)
     {
-        uint _349 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 32u, 16u);
-        imageStore(_37[_349], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+        uint _341 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 32u, 15u);
+        imageStore(_37[_341], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_287)));
     }
     if (gl_GlobalInvocationID.x > 80u)
     {
-        imageStore(_41[_61], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_317));
+        uint _352 = descriptor_qa_check(registers._m3 + 6u, 2u, 16u);
+        imageStore(_41[_352], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_287));
     }
     if (gl_GlobalInvocationID.x > 90u)
     {
         uint _364 = descriptor_qa_check(registers._m3 + ((gl_GlobalInvocationID.x & 1u) + 7u), 2u, 17u);
-        imageStore(_41[_364], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_317));
+        imageStore(_41[_364], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_287));
     }
-    uint _371 = atomicAdd(_165._m0, 1u);
+    uint _372 = descriptor_qa_check(registers._m4, 32u, 18u);
+    uint _378 = descriptor_qa_check(registers._m4, 256u, 19u);
+    uint _383 = atomicAdd(_34.counters[_378]._m0, 1u);
 }
 
 
@@ -237,7 +238,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 406
+; Bound: 418
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -253,7 +254,7 @@ OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel PhysicalStorageBuffer64 GLSL450
-OpEntryPoint GLCompute %3 "main" %205
+OpEntryPoint GLCompute %3 "main" %55
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
 OpName %6 "RootConstants"
@@ -262,35 +263,35 @@ OpName %29 "AtomicCounter"
 OpName %32 "AtomicCounters"
 OpMemberName %32 0 "counters"
 OpName %45 "BindlessCBV"
-OpName %64 "DescriptorHeapGlobalQAData"
-OpMemberName %64 0 "failed_shader_hash"
-OpMemberName %64 1 "failed_offset"
-OpMemberName %64 2 "failed_heap"
-OpMemberName %64 3 "failed_cookie"
-OpMemberName %64 4 "fault_atomic"
-OpMemberName %64 5 "failed_instruction"
-OpMemberName %64 6 "failed_descriptor_type_mask"
-OpMemberName %64 7 "actual_descriptor_type_mask"
-OpMemberName %64 8 "fault_type"
-OpMemberName %64 9 "live_status_table"
-OpName %66 "QAGlobalData"
-OpName %75 "descriptor_qa_report_fault"
-OpName %68 "fault_type"
-OpName %69 "heap_offset"
-OpName %70 "cookie"
-OpName %71 "heap_index"
-OpName %72 "descriptor_type"
-OpName %73 "actual_descriptor_type"
-OpName %74 "instruction"
-OpName %105 "DescriptorHeapQAData"
-OpMemberName %105 0 "descriptor_count"
-OpMemberName %105 1 "heap_index"
-OpMemberName %105 2 "cookies_descriptor_info"
-OpName %107 "QAHeapData"
-OpName %112 "descriptor_qa_check"
-OpName %109 "heap_offset"
-OpName %110 "descriptor_type_mask"
-OpName %111 "instruction"
+OpName %72 "DescriptorHeapGlobalQAData"
+OpMemberName %72 0 "failed_shader_hash"
+OpMemberName %72 1 "failed_offset"
+OpMemberName %72 2 "failed_heap"
+OpMemberName %72 3 "failed_cookie"
+OpMemberName %72 4 "fault_atomic"
+OpMemberName %72 5 "failed_instruction"
+OpMemberName %72 6 "failed_descriptor_type_mask"
+OpMemberName %72 7 "actual_descriptor_type_mask"
+OpMemberName %72 8 "fault_type"
+OpMemberName %72 9 "live_status_table"
+OpName %74 "QAGlobalData"
+OpName %83 "descriptor_qa_report_fault"
+OpName %76 "fault_type"
+OpName %77 "heap_offset"
+OpName %78 "cookie"
+OpName %79 "heap_index"
+OpName %80 "descriptor_type"
+OpName %81 "actual_descriptor_type"
+OpName %82 "instruction"
+OpName %111 "DescriptorHeapQAData"
+OpMemberName %111 0 "descriptor_count"
+OpMemberName %111 1 "heap_index"
+OpMemberName %111 2 "cookies_descriptor_info"
+OpName %113 "QAHeapData"
+OpName %118 "descriptor_qa_check"
+OpName %115 "heap_offset"
+OpName %116 "descriptor_type_mask"
+OpName %117 "instruction"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 4
@@ -333,29 +334,29 @@ OpDecorate %48 DescriptorSet 5
 OpDecorate %48 Binding 0
 OpDecorate %52 DescriptorSet 2
 OpDecorate %52 Binding 0
-OpDecorate %63 ArrayStride 4
-OpMemberDecorate %64 0 Offset 0
-OpMemberDecorate %64 1 Offset 8
-OpMemberDecorate %64 2 Offset 12
-OpMemberDecorate %64 3 Offset 16
-OpMemberDecorate %64 4 Offset 20
-OpMemberDecorate %64 5 Offset 24
-OpMemberDecorate %64 6 Offset 28
-OpMemberDecorate %64 7 Offset 32
-OpMemberDecorate %64 8 Offset 36
-OpMemberDecorate %64 9 Offset 40
-OpDecorate %64 Block
-OpDecorate %66 DescriptorSet 10
-OpDecorate %66 Binding 10
-OpDecorate %104 ArrayStride 8
-OpMemberDecorate %105 0 Offset 0
-OpMemberDecorate %105 1 Offset 4
-OpMemberDecorate %105 2 Offset 8
-OpDecorate %105 Block
-OpDecorate %107 DescriptorSet 10
-OpDecorate %107 Binding 11
-OpDecorate %107 NonWritable
-OpDecorate %205 BuiltIn GlobalInvocationId
+OpDecorate %55 BuiltIn GlobalInvocationId
+OpDecorate %71 ArrayStride 4
+OpMemberDecorate %72 0 Offset 0
+OpMemberDecorate %72 1 Offset 8
+OpMemberDecorate %72 2 Offset 12
+OpMemberDecorate %72 3 Offset 16
+OpMemberDecorate %72 4 Offset 20
+OpMemberDecorate %72 5 Offset 24
+OpMemberDecorate %72 6 Offset 28
+OpMemberDecorate %72 7 Offset 32
+OpMemberDecorate %72 8 Offset 36
+OpMemberDecorate %72 9 Offset 40
+OpDecorate %72 Block
+OpDecorate %74 DescriptorSet 10
+OpDecorate %74 Binding 10
+OpDecorate %110 ArrayStride 8
+OpMemberDecorate %111 0 Offset 0
+OpMemberDecorate %111 1 Offset 4
+OpMemberDecorate %111 2 Offset 8
+OpDecorate %111 Block
+OpDecorate %113 DescriptorSet 10
+OpDecorate %113 Binding 11
+OpDecorate %113 NonWritable
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -406,431 +407,443 @@ OpDecorate %205 BuiltIn GlobalInvocationId
 %50 = OpTypeRuntimeArray %49
 %51 = OpTypePointer UniformConstant %50
 %52 = OpVariable %51 UniformConstant
-%53 = OpTypePointer UniformConstant %38
-%55 = OpTypePointer PushConstant %5
-%57 = OpConstant %5 3
-%60 = OpConstant %5 6
-%62 = OpTypeVector %5 2
-%63 = OpTypeRuntimeArray %5
-%64 = OpTypeStruct %62 %5 %5 %5 %5 %5 %5 %5 %5 %63
-%65 = OpTypePointer StorageBuffer %64
-%66 = OpVariable %65 StorageBuffer
-%67 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
-%77 = OpTypePointer StorageBuffer %5
-%79 = OpConstant %5 4
-%81 = OpConstant %5 1
-%82 = OpConstant %5 0
-%83 = OpTypeBool
-%90 = OpConstant %5 2
-%93 = OpConstant %5 7
-%95 = OpConstant %5 5
-%96 = OpConstant %5 3735928559
-%97 = OpConstantComposite %62 %96 %82
-%98 = OpTypePointer StorageBuffer %62
-%100 = OpConstant %5 72
-%102 = OpConstant %5 8
-%104 = OpTypeRuntimeArray %62
-%105 = OpTypeStruct %5 %5 %104
-%106 = OpTypePointer StorageBuffer %105
-%107 = OpVariable %106 StorageBuffer
-%108 = OpTypeFunction %5 %5 %5 %5
-%124 = OpConstant %5 31
-%126 = OpConstant %5 9
-%146 = OpTypePointer UniformConstant %25
-%152 = OpConstant %5 32
-%159 = OpTypePointer StorageBuffer %30
-%164 = OpConstant %5 256
-%166 = OpTypePointer UniformConstant %18
-%172 = OpConstant %5 16
-%180 = OpTypePointer UniformConstant %14
-%187 = OpTypePointer UniformConstant %10
-%193 = OpTypePointer UniformConstant %49
-%198 = OpTypePointer Uniform %45
-%203 = OpTypeVector %5 3
-%204 = OpTypePointer Input %203
-%205 = OpVariable %204 Input
-%206 = OpTypePointer Input %5
-%210 = OpTypePointer Uniform %42
-%215 = OpConstant %9 0
-%223 = OpConstant %5 10
-%230 = OpTypeSampledImage %10
-%232 = OpConstant %9 0.5
-%234 = OpTypeVector %9 2
-%247 = OpConstant %5 11
-%267 = OpConstant %5 12
-%274 = OpTypeVector %5 4
-%288 = OpConstant %5 13
-%310 = OpConstant %5 14
-%322 = OpConstant %5 30
-%330 = OpConstant %5 15
-%335 = OpConstant %5 40
-%340 = OpConstant %5 50
-%353 = OpConstant %5 80
+%53 = OpTypeVector %5 3
+%54 = OpTypePointer Input %53
+%55 = OpVariable %54 Input
+%56 = OpTypePointer Input %5
+%58 = OpConstant %5 0
+%60 = OpTypeBool
+%62 = OpConstant %5 2
+%63 = OpTypePointer Uniform %45
+%65 = OpTypePointer PushConstant %5
+%67 = OpConstant %5 5
+%70 = OpTypeVector %5 2
+%71 = OpTypeRuntimeArray %5
+%72 = OpTypeStruct %70 %5 %5 %5 %5 %5 %5 %5 %5 %71
+%73 = OpTypePointer StorageBuffer %72
+%74 = OpVariable %73 StorageBuffer
+%75 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%85 = OpTypePointer StorageBuffer %5
+%87 = OpConstant %5 4
+%89 = OpConstant %5 1
+%94 = OpConstant %5 3
+%98 = OpConstant %5 6
+%100 = OpConstant %5 7
+%102 = OpConstant %5 3735928559
+%103 = OpConstantComposite %70 %102 %58
+%104 = OpTypePointer StorageBuffer %70
+%106 = OpConstant %5 72
+%108 = OpConstant %5 8
+%110 = OpTypeRuntimeArray %70
+%111 = OpTypeStruct %5 %5 %110
+%112 = OpTypePointer StorageBuffer %111
+%113 = OpVariable %112 StorageBuffer
+%114 = OpTypeFunction %5 %5 %5 %5
+%130 = OpConstant %5 31
+%132 = OpConstant %5 9
+%151 = OpTypePointer Uniform %42
+%156 = OpConstant %9 0
+%170 = OpTypePointer UniformConstant %10
+%176 = OpTypePointer UniformConstant %49
+%181 = OpTypeSampledImage %10
+%183 = OpConstant %9 0.5
+%185 = OpTypeVector %9 2
+%205 = OpTypePointer UniformConstant %14
+%211 = OpConstant %5 16
+%231 = OpTypePointer UniformConstant %18
+%238 = OpTypeVector %5 4
+%259 = OpConstant %5 10
+%273 = OpConstant %5 11
+%289 = OpTypePointer UniformConstant %25
+%294 = OpConstant %5 32
+%296 = OpTypePointer StorageBuffer %30
+%301 = OpConstant %5 256
+%302 = OpConstant %5 12
+%307 = OpConstant %5 30
+%315 = OpConstant %5 13
+%320 = OpConstant %5 40
+%326 = OpConstant %5 14
+%332 = OpConstant %5 50
+%342 = OpConstant %5 15
+%346 = OpConstant %5 80
+%347 = OpTypePointer UniformConstant %38
 %357 = OpConstant %5 90
 %365 = OpConstant %5 17
-%369 = OpTypePointer PhysicalStorageBuffer %5
+%373 = OpConstant %5 18
+%379 = OpConstant %5 19
+%381 = OpTypePointer PhysicalStorageBuffer %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %372
-%372 = OpLabel
-%56 = OpAccessChain %55 %8 %57
-%58 = OpLoad %5 %56
-%59 = OpIAdd %5 %58 %60
-%61 = OpFunctionCall %5 %112 %59 %90 %81
-%54 = OpAccessChain %53 %41 %61
-%145 = OpLoad %38 %54
-%148 = OpAccessChain %55 %8 %79
-%149 = OpLoad %5 %148
-%150 = OpIAdd %5 %149 %57
-%151 = OpFunctionCall %5 %112 %150 %152 %90
-%147 = OpAccessChain %146 %37 %151
-%153 = OpLoad %25 %147
-%155 = OpAccessChain %55 %8 %79
-%156 = OpLoad %5 %155
-%157 = OpFunctionCall %5 %112 %156 %152 %57
-%154 = OpAccessChain %146 %28 %157
-%158 = OpLoad %25 %154
-%161 = OpAccessChain %55 %8 %79
-%162 = OpLoad %5 %161
-%163 = OpFunctionCall %5 %112 %162 %164 %79
-%160 = OpAccessChain %159 %34 %82 %163
-%165 = OpLoad %30 %160
-%168 = OpAccessChain %55 %8 %81
-%169 = OpLoad %5 %168
-%170 = OpIAdd %5 %169 %126
-%171 = OpFunctionCall %5 %112 %170 %172 %95
-%167 = OpAccessChain %166 %24 %171
-%173 = OpLoad %18 %167
-%175 = OpAccessChain %55 %8 %81
-%176 = OpLoad %5 %175
-%177 = OpIAdd %5 %176 %60
-%178 = OpFunctionCall %5 %112 %177 %172 %60
-%174 = OpAccessChain %166 %21 %178
-%179 = OpLoad %18 %174
-%182 = OpAccessChain %55 %8 %81
-%183 = OpLoad %5 %182
-%184 = OpIAdd %5 %183 %57
-%185 = OpFunctionCall %5 %112 %184 %172 %93
-%181 = OpAccessChain %180 %17 %185
-%186 = OpLoad %14 %181
-%189 = OpAccessChain %55 %8 %82
-%190 = OpLoad %5 %189
-%191 = OpFunctionCall %5 %112 %190 %81 %102
-%188 = OpAccessChain %187 %13 %191
-%192 = OpLoad %10 %188
-%195 = OpAccessChain %55 %8 %90
-%196 = OpLoad %5 %195
-%194 = OpAccessChain %193 %52 %196
-%197 = OpLoad %49 %194
-%200 = OpAccessChain %55 %8 %95
-%201 = OpLoad %5 %200
-%202 = OpFunctionCall %5 %112 %201 %79 %126
-%199 = OpAccessChain %198 %48 %202
-%207 = OpAccessChain %206 %205 %82
-%208 = OpLoad %5 %207
-%209 = OpUGreaterThan %83 %208 %90
-OpSelectionMerge %374 None
-OpBranchConditional %209 %373 %374
-%373 = OpLabel
-%211 = OpAccessChain %210 %199 %82 %82
-%212 = OpLoad %42 %211
-%213 = OpCompositeExtract %9 %212 0
-OpBranch %374
-%374 = OpLabel
-%214 = OpPhi %9 %215 %372 %213 %373
-%216 = OpUGreaterThan %83 %208 %57
-OpSelectionMerge %376 None
-OpBranchConditional %216 %375 %376
-%375 = OpLabel
-%217 = OpIAdd %5 %208 %81
-%219 = OpAccessChain %55 %8 %95
-%220 = OpLoad %5 %219
-%221 = OpIAdd %5 %220 %217
-%222 = OpFunctionCall %5 %112 %221 %79 %223
-%218 = OpAccessChain %198 %48 %222
-%224 = OpAccessChain %210 %218 %82 %82
-%225 = OpLoad %42 %224
-%226 = OpCompositeExtract %9 %225 0
-%227 = OpFAdd %9 %226 %214
-OpBranch %376
-%376 = OpLabel
-%228 = OpPhi %9 %214 %374 %227 %375
-%229 = OpUGreaterThan %83 %208 %79
-OpSelectionMerge %378 None
-OpBranchConditional %229 %377 %378
-%377 = OpLabel
-%231 = OpSampledImage %230 %192 %197
-%235 = OpCompositeConstruct %234 %232 %232
-%233 = OpImageSampleExplicitLod %42 %231 %235 Lod %215
-%236 = OpCompositeExtract %9 %233 0
-%237 = OpFAdd %9 %236 %228
-OpBranch %378
-%378 = OpLabel
-%238 = OpPhi %9 %228 %376 %237 %377
-%239 = OpUGreaterThan %83 %208 %95
-OpSelectionMerge %380 None
-OpBranchConditional %239 %379 %380
-%379 = OpLabel
-%240 = OpBitwiseAnd %5 %208 %81
-%241 = OpIAdd %5 %240 %81
-%243 = OpAccessChain %55 %8 %82
-%244 = OpLoad %5 %243
-%245 = OpIAdd %5 %244 %241
-%246 = OpFunctionCall %5 %112 %245 %81 %247
-%242 = OpAccessChain %187 %13 %246
-%248 = OpLoad %10 %242
-%250 = OpCompositeConstruct %62 %82 %208
-%249 = OpImageFetch %42 %248 %250 Lod %82
-%251 = OpCompositeExtract %9 %249 0
-%252 = OpFAdd %9 %251 %238
-OpBranch %380
-%380 = OpLabel
-%253 = OpPhi %9 %238 %378 %252 %379
-%254 = OpUGreaterThan %83 %208 %60
-OpSelectionMerge %382 None
-OpBranchConditional %254 %381 %382
-%381 = OpLabel
-%255 = OpImageFetch %42 %186 %208
-%256 = OpCompositeExtract %9 %255 0
-%257 = OpFAdd %9 %256 %253
-OpBranch %382
-%382 = OpLabel
-%258 = OpPhi %9 %253 %380 %257 %381
-%259 = OpUGreaterThan %83 %208 %93
-OpSelectionMerge %384 None
-OpBranchConditional %259 %383 %384
-%383 = OpLabel
-%260 = OpBitwiseAnd %5 %208 %81
-%261 = OpIAdd %5 %260 %79
-%263 = OpAccessChain %55 %8 %81
-%264 = OpLoad %5 %263
-%265 = OpIAdd %5 %264 %261
-%266 = OpFunctionCall %5 %112 %265 %172 %267
-%262 = OpAccessChain %180 %17 %266
-%268 = OpLoad %14 %262
-%269 = OpImageFetch %42 %268 %208
-%270 = OpCompositeExtract %9 %269 0
-%271 = OpFAdd %9 %270 %258
 OpBranch %384
 %384 = OpLabel
-%272 = OpPhi %9 %258 %382 %271 %383
-%273 = OpUGreaterThan %83 %208 %102
+%57 = OpAccessChain %56 %55 %58
+%59 = OpLoad %5 %57
+%61 = OpUGreaterThan %60 %59 %62
 OpSelectionMerge %386 None
-OpBranchConditional %273 %385 %386
+OpBranchConditional %61 %385 %386
 %385 = OpLabel
-%275 = OpImageFetch %274 %179 %208
-%276 = OpCompositeExtract %5 %275 0
-%277 = OpBitcast %9 %276
-%278 = OpFAdd %9 %277 %272
+%66 = OpAccessChain %65 %8 %67
+%68 = OpLoad %5 %66
+%69 = OpFunctionCall %5 %118 %68 %87 %89
+%64 = OpAccessChain %63 %48 %69
+%152 = OpAccessChain %151 %64 %58 %58
+%153 = OpLoad %42 %152
+%154 = OpCompositeExtract %9 %153 0
 OpBranch %386
 %386 = OpLabel
-%279 = OpPhi %9 %272 %384 %278 %385
-%280 = OpUGreaterThan %83 %208 %126
+%155 = OpPhi %9 %156 %384 %154 %385
+%157 = OpUGreaterThan %60 %59 %94
 OpSelectionMerge %388 None
-OpBranchConditional %280 %387 %388
+OpBranchConditional %157 %387 %388
 %387 = OpLabel
-%281 = OpBitwiseAnd %5 %208 %81
-%282 = OpIAdd %5 %281 %93
-%284 = OpAccessChain %55 %8 %81
-%285 = OpLoad %5 %284
-%286 = OpIAdd %5 %285 %282
-%287 = OpFunctionCall %5 %112 %286 %172 %288
-%283 = OpAccessChain %166 %21 %287
-%289 = OpLoad %18 %283
-%290 = OpImageFetch %274 %289 %208
-%291 = OpCompositeExtract %5 %290 0
-%292 = OpBitcast %9 %291
-%293 = OpFAdd %9 %292 %279
+%158 = OpIAdd %5 %59 %89
+%160 = OpAccessChain %65 %8 %67
+%161 = OpLoad %5 %160
+%162 = OpIAdd %5 %161 %158
+%163 = OpFunctionCall %5 %118 %162 %87 %62
+%159 = OpAccessChain %63 %48 %163
+%164 = OpAccessChain %151 %159 %58 %58
+%165 = OpLoad %42 %164
+%166 = OpCompositeExtract %9 %165 0
+%167 = OpFAdd %9 %166 %155
 OpBranch %388
 %388 = OpLabel
-%294 = OpPhi %9 %279 %386 %293 %387
-%295 = OpUGreaterThan %83 %208 %223
+%168 = OpPhi %9 %155 %386 %167 %387
+%169 = OpUGreaterThan %60 %59 %87
 OpSelectionMerge %390 None
-OpBranchConditional %295 %389 %390
+OpBranchConditional %169 %389 %390
 %389 = OpLabel
-%296 = OpShiftLeftLogical %5 %208 %90
-%297 = OpImageFetch %274 %173 %208
-%298 = OpCompositeExtract %5 %297 0
-%299 = OpBitcast %9 %298
-%300 = OpFAdd %9 %299 %294
+%172 = OpAccessChain %65 %8 %58
+%173 = OpLoad %5 %172
+%174 = OpFunctionCall %5 %118 %173 %89 %94
+%171 = OpAccessChain %170 %13 %174
+%175 = OpLoad %10 %171
+%178 = OpAccessChain %65 %8 %62
+%179 = OpLoad %5 %178
+%177 = OpAccessChain %176 %52 %179
+%180 = OpLoad %49 %177
+%182 = OpSampledImage %181 %175 %180
+%186 = OpCompositeConstruct %185 %183 %183
+%184 = OpImageSampleExplicitLod %42 %182 %186 Lod %156
+%187 = OpCompositeExtract %9 %184 0
+%188 = OpFAdd %9 %187 %168
 OpBranch %390
 %390 = OpLabel
-%301 = OpPhi %9 %294 %388 %300 %389
-%302 = OpUGreaterThan %83 %208 %247
+%189 = OpPhi %9 %168 %388 %188 %389
+%190 = OpUGreaterThan %60 %59 %67
 OpSelectionMerge %392 None
-OpBranchConditional %302 %391 %392
+OpBranchConditional %190 %391 %392
 %391 = OpLabel
-%303 = OpBitwiseAnd %5 %208 %81
-%304 = OpIAdd %5 %303 %223
-%306 = OpAccessChain %55 %8 %81
-%307 = OpLoad %5 %306
-%308 = OpIAdd %5 %307 %304
-%309 = OpFunctionCall %5 %112 %308 %172 %310
-%305 = OpAccessChain %166 %24 %309
-%311 = OpLoad %18 %305
-%312 = OpShiftRightLogical %5 %208 %90
-%313 = OpImageFetch %274 %311 %312
-%314 = OpCompositeExtract %5 %313 0
-%315 = OpBitcast %9 %314
-%316 = OpFAdd %9 %315 %301
+%191 = OpBitwiseAnd %5 %59 %89
+%192 = OpIAdd %5 %191 %89
+%194 = OpAccessChain %65 %8 %58
+%195 = OpLoad %5 %194
+%196 = OpIAdd %5 %195 %192
+%197 = OpFunctionCall %5 %118 %196 %89 %87
+%193 = OpAccessChain %170 %13 %197
+%198 = OpLoad %10 %193
+%200 = OpCompositeConstruct %70 %58 %59
+%199 = OpImageFetch %42 %198 %200 Lod %58
+%201 = OpCompositeExtract %9 %199 0
+%202 = OpFAdd %9 %201 %189
 OpBranch %392
 %392 = OpLabel
-%317 = OpPhi %9 %301 %390 %316 %391
-%318 = OpUGreaterThan %83 %208 %81
+%203 = OpPhi %9 %189 %390 %202 %391
+%204 = OpUGreaterThan %60 %59 %98
 OpSelectionMerge %394 None
-OpBranchConditional %318 %393 %394
+OpBranchConditional %204 %393 %394
 %393 = OpLabel
-%319 = OpBitcast %5 %317
-%320 = OpCompositeConstruct %274 %319 %319 %319 %319
-OpImageWrite %158 %208 %320
+%207 = OpAccessChain %65 %8 %89
+%208 = OpLoad %5 %207
+%209 = OpIAdd %5 %208 %94
+%210 = OpFunctionCall %5 %118 %209 %211 %67
+%206 = OpAccessChain %205 %17 %210
+%212 = OpLoad %14 %206
+%213 = OpImageFetch %42 %212 %59
+%214 = OpCompositeExtract %9 %213 0
+%215 = OpFAdd %9 %214 %203
 OpBranch %394
 %394 = OpLabel
-%321 = OpUGreaterThan %83 %208 %322
+%216 = OpPhi %9 %203 %392 %215 %393
+%217 = OpUGreaterThan %60 %59 %100
 OpSelectionMerge %396 None
-OpBranchConditional %321 %395 %396
+OpBranchConditional %217 %395 %396
 %395 = OpLabel
-%323 = OpBitwiseAnd %5 %208 %81
-%324 = OpIAdd %5 %323 %81
-%326 = OpAccessChain %55 %8 %79
-%327 = OpLoad %5 %326
-%328 = OpIAdd %5 %327 %324
-%329 = OpFunctionCall %5 %112 %328 %152 %330
-%325 = OpAccessChain %146 %28 %329
-%331 = OpLoad %25 %325
-%332 = OpBitcast %5 %317
-%333 = OpCompositeConstruct %274 %332 %332 %332 %332
-OpImageWrite %331 %208 %333
+%218 = OpBitwiseAnd %5 %59 %89
+%219 = OpIAdd %5 %218 %87
+%221 = OpAccessChain %65 %8 %89
+%222 = OpLoad %5 %221
+%223 = OpIAdd %5 %222 %219
+%224 = OpFunctionCall %5 %118 %223 %211 %98
+%220 = OpAccessChain %205 %17 %224
+%225 = OpLoad %14 %220
+%226 = OpImageFetch %42 %225 %59
+%227 = OpCompositeExtract %9 %226 0
+%228 = OpFAdd %9 %227 %216
 OpBranch %396
 %396 = OpLabel
-%334 = OpUGreaterThan %83 %208 %335
+%229 = OpPhi %9 %216 %394 %228 %395
+%230 = OpUGreaterThan %60 %59 %108
 OpSelectionMerge %398 None
-OpBranchConditional %334 %397 %398
+OpBranchConditional %230 %397 %398
 %397 = OpLabel
-%336 = OpBitcast %5 %317
-%337 = OpShiftLeftLogical %5 %208 %90
-%338 = OpCompositeConstruct %274 %336 %336 %336 %336
-OpImageWrite %153 %208 %338
+%233 = OpAccessChain %65 %8 %89
+%234 = OpLoad %5 %233
+%235 = OpIAdd %5 %234 %98
+%236 = OpFunctionCall %5 %118 %235 %211 %100
+%232 = OpAccessChain %231 %21 %236
+%237 = OpLoad %18 %232
+%239 = OpImageFetch %238 %237 %59
+%240 = OpCompositeExtract %5 %239 0
+%241 = OpBitcast %9 %240
+%242 = OpFAdd %9 %241 %229
 OpBranch %398
 %398 = OpLabel
-%339 = OpUGreaterThan %83 %208 %340
+%243 = OpPhi %9 %229 %396 %242 %397
+%244 = OpUGreaterThan %60 %59 %132
 OpSelectionMerge %400 None
-OpBranchConditional %339 %399 %400
+OpBranchConditional %244 %399 %400
 %399 = OpLabel
-%341 = OpBitwiseAnd %5 %208 %81
-%342 = OpBitcast %5 %317
-%343 = OpShiftLeftLogical %5 %208 %90
-%344 = OpIAdd %5 %341 %79
-%346 = OpAccessChain %55 %8 %79
-%347 = OpLoad %5 %346
-%348 = OpIAdd %5 %347 %344
-%349 = OpFunctionCall %5 %112 %348 %152 %172
-%345 = OpAccessChain %146 %37 %349
-%350 = OpLoad %25 %345
-%351 = OpCompositeConstruct %274 %342 %342 %342 %342
-OpImageWrite %350 %208 %351
+%245 = OpBitwiseAnd %5 %59 %89
+%246 = OpIAdd %5 %245 %100
+%248 = OpAccessChain %65 %8 %89
+%249 = OpLoad %5 %248
+%250 = OpIAdd %5 %249 %246
+%251 = OpFunctionCall %5 %118 %250 %211 %108
+%247 = OpAccessChain %231 %21 %251
+%252 = OpLoad %18 %247
+%253 = OpImageFetch %238 %252 %59
+%254 = OpCompositeExtract %5 %253 0
+%255 = OpBitcast %9 %254
+%256 = OpFAdd %9 %255 %243
 OpBranch %400
 %400 = OpLabel
-%352 = OpUGreaterThan %83 %208 %353
+%257 = OpPhi %9 %243 %398 %256 %399
+%258 = OpUGreaterThan %60 %59 %259
 OpSelectionMerge %402 None
-OpBranchConditional %352 %401 %402
+OpBranchConditional %258 %401 %402
 %401 = OpLabel
-%354 = OpCompositeConstruct %62 %208 %82
-%355 = OpCompositeConstruct %42 %317 %317 %317 %317
-OpImageWrite %145 %354 %355
+%261 = OpAccessChain %65 %8 %89
+%262 = OpLoad %5 %261
+%263 = OpIAdd %5 %262 %132
+%264 = OpFunctionCall %5 %118 %263 %211 %132
+%260 = OpAccessChain %231 %24 %264
+%265 = OpLoad %18 %260
+%266 = OpShiftLeftLogical %5 %59 %62
+%267 = OpImageFetch %238 %265 %59
+%268 = OpCompositeExtract %5 %267 0
+%269 = OpBitcast %9 %268
+%270 = OpFAdd %9 %269 %257
 OpBranch %402
 %402 = OpLabel
-%356 = OpUGreaterThan %83 %208 %357
+%271 = OpPhi %9 %257 %400 %270 %401
+%272 = OpUGreaterThan %60 %59 %273
 OpSelectionMerge %404 None
-OpBranchConditional %356 %403 %404
+OpBranchConditional %272 %403 %404
 %403 = OpLabel
-%358 = OpBitwiseAnd %5 %208 %81
-%359 = OpIAdd %5 %358 %93
-%361 = OpAccessChain %55 %8 %57
-%362 = OpLoad %5 %361
-%363 = OpIAdd %5 %362 %359
-%364 = OpFunctionCall %5 %112 %363 %90 %365
-%360 = OpAccessChain %53 %41 %364
-%366 = OpLoad %38 %360
-%367 = OpCompositeConstruct %62 %82 %208
-%368 = OpCompositeConstruct %42 %317 %317 %317 %317
-OpImageWrite %366 %367 %368
+%274 = OpBitwiseAnd %5 %59 %89
+%275 = OpIAdd %5 %274 %259
+%277 = OpAccessChain %65 %8 %89
+%278 = OpLoad %5 %277
+%279 = OpIAdd %5 %278 %275
+%280 = OpFunctionCall %5 %118 %279 %211 %259
+%276 = OpAccessChain %231 %24 %280
+%281 = OpLoad %18 %276
+%282 = OpShiftRightLogical %5 %59 %62
+%283 = OpImageFetch %238 %281 %282
+%284 = OpCompositeExtract %5 %283 0
+%285 = OpBitcast %9 %284
+%286 = OpFAdd %9 %285 %271
 OpBranch %404
 %404 = OpLabel
-%370 = OpAccessChain %369 %165 %82
-%371 = OpAtomicIAdd %5 %370 %81 %82 %81
+%287 = OpPhi %9 %271 %402 %286 %403
+%288 = OpUGreaterThan %60 %59 %89
+OpSelectionMerge %406 None
+OpBranchConditional %288 %405 %406
+%405 = OpLabel
+%291 = OpAccessChain %65 %8 %87
+%292 = OpLoad %5 %291
+%293 = OpFunctionCall %5 %118 %292 %294 %273
+%290 = OpAccessChain %289 %28 %293
+%295 = OpLoad %25 %290
+%298 = OpAccessChain %65 %8 %87
+%299 = OpLoad %5 %298
+%300 = OpFunctionCall %5 %118 %299 %301 %302
+%297 = OpAccessChain %296 %34 %58 %300
+%303 = OpLoad %30 %297
+%304 = OpBitcast %5 %287
+%305 = OpCompositeConstruct %238 %304 %304 %304 %304
+OpImageWrite %295 %59 %305
+OpBranch %406
+%406 = OpLabel
+%306 = OpUGreaterThan %60 %59 %307
+OpSelectionMerge %408 None
+OpBranchConditional %306 %407 %408
+%407 = OpLabel
+%308 = OpBitwiseAnd %5 %59 %89
+%309 = OpIAdd %5 %308 %89
+%311 = OpAccessChain %65 %8 %87
+%312 = OpLoad %5 %311
+%313 = OpIAdd %5 %312 %309
+%314 = OpFunctionCall %5 %118 %313 %294 %315
+%310 = OpAccessChain %289 %28 %314
+%316 = OpLoad %25 %310
+%317 = OpBitcast %5 %287
+%318 = OpCompositeConstruct %238 %317 %317 %317 %317
+OpImageWrite %316 %59 %318
+OpBranch %408
+%408 = OpLabel
+%319 = OpUGreaterThan %60 %59 %320
+OpSelectionMerge %410 None
+OpBranchConditional %319 %409 %410
+%409 = OpLabel
+%322 = OpAccessChain %65 %8 %87
+%323 = OpLoad %5 %322
+%324 = OpIAdd %5 %323 %94
+%325 = OpFunctionCall %5 %118 %324 %294 %326
+%321 = OpAccessChain %289 %37 %325
+%327 = OpLoad %25 %321
+%328 = OpBitcast %5 %287
+%329 = OpShiftLeftLogical %5 %59 %62
+%330 = OpCompositeConstruct %238 %328 %328 %328 %328
+OpImageWrite %327 %59 %330
+OpBranch %410
+%410 = OpLabel
+%331 = OpUGreaterThan %60 %59 %332
+OpSelectionMerge %412 None
+OpBranchConditional %331 %411 %412
+%411 = OpLabel
+%333 = OpBitwiseAnd %5 %59 %89
+%334 = OpBitcast %5 %287
+%335 = OpShiftLeftLogical %5 %59 %62
+%336 = OpIAdd %5 %333 %87
+%338 = OpAccessChain %65 %8 %87
+%339 = OpLoad %5 %338
+%340 = OpIAdd %5 %339 %336
+%341 = OpFunctionCall %5 %118 %340 %294 %342
+%337 = OpAccessChain %289 %37 %341
+%343 = OpLoad %25 %337
+%344 = OpCompositeConstruct %238 %334 %334 %334 %334
+OpImageWrite %343 %59 %344
+OpBranch %412
+%412 = OpLabel
+%345 = OpUGreaterThan %60 %59 %346
+OpSelectionMerge %414 None
+OpBranchConditional %345 %413 %414
+%413 = OpLabel
+%349 = OpAccessChain %65 %8 %94
+%350 = OpLoad %5 %349
+%351 = OpIAdd %5 %350 %98
+%352 = OpFunctionCall %5 %118 %351 %62 %211
+%348 = OpAccessChain %347 %41 %352
+%353 = OpLoad %38 %348
+%354 = OpCompositeConstruct %70 %59 %58
+%355 = OpCompositeConstruct %42 %287 %287 %287 %287
+OpImageWrite %353 %354 %355
+OpBranch %414
+%414 = OpLabel
+%356 = OpUGreaterThan %60 %59 %357
+OpSelectionMerge %416 None
+OpBranchConditional %356 %415 %416
+%415 = OpLabel
+%358 = OpBitwiseAnd %5 %59 %89
+%359 = OpIAdd %5 %358 %100
+%361 = OpAccessChain %65 %8 %94
+%362 = OpLoad %5 %361
+%363 = OpIAdd %5 %362 %359
+%364 = OpFunctionCall %5 %118 %363 %62 %365
+%360 = OpAccessChain %347 %41 %364
+%366 = OpLoad %38 %360
+%367 = OpCompositeConstruct %70 %58 %59
+%368 = OpCompositeConstruct %42 %287 %287 %287 %287
+OpImageWrite %366 %367 %368
+OpBranch %416
+%416 = OpLabel
+%370 = OpAccessChain %65 %8 %87
+%371 = OpLoad %5 %370
+%372 = OpFunctionCall %5 %118 %371 %294 %373
+%369 = OpAccessChain %289 %28 %372
+%374 = OpLoad %25 %369
+%376 = OpAccessChain %65 %8 %87
+%377 = OpLoad %5 %376
+%378 = OpFunctionCall %5 %118 %377 %301 %379
+%375 = OpAccessChain %296 %34 %58 %378
+%380 = OpLoad %30 %375
+%382 = OpAccessChain %381 %380 %58
+%383 = OpAtomicIAdd %5 %382 %89 %58 %89
 OpReturn
 OpFunctionEnd
-%75 = OpFunction %1 None %67
-%68 = OpFunctionParameter %5
-%69 = OpFunctionParameter %5
-%70 = OpFunctionParameter %5
-%71 = OpFunctionParameter %5
-%72 = OpFunctionParameter %5
-%73 = OpFunctionParameter %5
-%74 = OpFunctionParameter %5
-%76 = OpLabel
-%78 = OpAccessChain %77 %66 %79
-%80 = OpAtomicIAdd %5 %78 %81 %82 %81
-%84 = OpIEqual %83 %80 %82
-OpSelectionMerge %86 None
-OpBranchConditional %84 %85 %86
-%85 = OpLabel
-%87 = OpAccessChain %77 %66 %57
-OpStore %87 %70
-%88 = OpAccessChain %77 %66 %81
-OpStore %88 %69
-%89 = OpAccessChain %77 %66 %90
-OpStore %89 %71
-%91 = OpAccessChain %77 %66 %60
-OpStore %91 %72
-%92 = OpAccessChain %77 %66 %93
-OpStore %92 %73
-%94 = OpAccessChain %77 %66 %95
-OpStore %94 %74
-%99 = OpAccessChain %98 %66 %82
-OpStore %99 %97
-OpMemoryBarrier %81 %100
-%101 = OpAccessChain %77 %66 %102
-OpStore %101 %68
-OpBranch %86
-%86 = OpLabel
+%83 = OpFunction %1 None %75
+%76 = OpFunctionParameter %5
+%77 = OpFunctionParameter %5
+%78 = OpFunctionParameter %5
+%79 = OpFunctionParameter %5
+%80 = OpFunctionParameter %5
+%81 = OpFunctionParameter %5
+%82 = OpFunctionParameter %5
+%84 = OpLabel
+%86 = OpAccessChain %85 %74 %87
+%88 = OpAtomicIAdd %5 %86 %89 %58 %89
+%90 = OpIEqual %60 %88 %58
+OpSelectionMerge %92 None
+OpBranchConditional %90 %91 %92
+%91 = OpLabel
+%93 = OpAccessChain %85 %74 %94
+OpStore %93 %78
+%95 = OpAccessChain %85 %74 %89
+OpStore %95 %77
+%96 = OpAccessChain %85 %74 %62
+OpStore %96 %79
+%97 = OpAccessChain %85 %74 %98
+OpStore %97 %80
+%99 = OpAccessChain %85 %74 %100
+OpStore %99 %81
+%101 = OpAccessChain %85 %74 %67
+OpStore %101 %82
+%105 = OpAccessChain %104 %74 %58
+OpStore %105 %103
+OpMemoryBarrier %89 %106
+%107 = OpAccessChain %85 %74 %108
+OpStore %107 %76
+OpBranch %92
+%92 = OpLabel
 OpReturn
 OpFunctionEnd
-%112 = OpFunction %5 None %108
-%109 = OpFunctionParameter %5
-%110 = OpFunctionParameter %5
-%111 = OpFunctionParameter %5
-%113 = OpLabel
-%114 = OpAccessChain %77 %107 %82
-%115 = OpLoad %5 %114
-%116 = OpAccessChain %77 %107 %81
-%117 = OpLoad %5 %116
-%118 = OpAccessChain %98 %107 %90 %109
-%119 = OpLoad %62 %118
-%120 = OpCompositeExtract %5 %119 0
-%122 = OpShiftRightLogical %5 %120 %95
-%123 = OpBitwiseAnd %5 %120 %124
-%121 = OpCompositeExtract %5 %119 1
-%125 = OpAccessChain %77 %66 %126 %122
-%127 = OpLoad %5 %125
-%128 = OpShiftLeftLogical %5 %81 %123
-%129 = OpBitwiseAnd %5 %127 %128
-%130 = OpINotEqual %83 %129 %82
-%131 = OpBitwiseAnd %5 %121 %110
-%132 = OpIEqual %83 %131 %110
-%133 = OpUGreaterThanEqual %83 %109 %115
-%134 = OpSelect %5 %133 %81 %82
-%135 = OpSelect %5 %132 %82 %90
-%136 = OpSelect %5 %130 %82 %79
-%137 = OpBitwiseOr %5 %134 %135
-%138 = OpBitwiseOr %5 %137 %136
-%139 = OpINotEqual %83 %138 %82
-OpSelectionMerge %141 None
-OpBranchConditional %139 %140 %141
-%140 = OpLabel
-%142 = OpFunctionCall %1 %75 %138 %109 %120 %117 %110 %121 %111
+%118 = OpFunction %5 None %114
+%115 = OpFunctionParameter %5
+%116 = OpFunctionParameter %5
+%117 = OpFunctionParameter %5
+%119 = OpLabel
+%120 = OpAccessChain %85 %113 %58
+%121 = OpLoad %5 %120
+%122 = OpAccessChain %85 %113 %89
+%123 = OpLoad %5 %122
+%124 = OpAccessChain %104 %113 %62 %115
+%125 = OpLoad %70 %124
+%126 = OpCompositeExtract %5 %125 0
+%128 = OpShiftRightLogical %5 %126 %67
+%129 = OpBitwiseAnd %5 %126 %130
+%127 = OpCompositeExtract %5 %125 1
+%131 = OpAccessChain %85 %74 %132 %128
+%133 = OpLoad %5 %131
+%134 = OpShiftLeftLogical %5 %89 %129
+%135 = OpBitwiseAnd %5 %133 %134
+%136 = OpINotEqual %60 %135 %58
+%137 = OpBitwiseAnd %5 %127 %116
+%138 = OpIEqual %60 %137 %116
+%139 = OpUGreaterThanEqual %60 %115 %121
+%140 = OpSelect %5 %139 %89 %58
+%141 = OpSelect %5 %138 %58 %62
+%142 = OpSelect %5 %136 %58 %87
+%143 = OpBitwiseOr %5 %140 %141
+%144 = OpBitwiseOr %5 %143 %142
+%145 = OpINotEqual %60 %144 %58
+OpSelectionMerge %147 None
+OpBranchConditional %145 %146 %147
+%146 = OpLabel
+%148 = OpFunctionCall %1 %83 %144 %115 %126 %123 %116 %127 %117
+OpReturnValue %121
+%147 = OpLabel
 OpReturnValue %115
-%141 = OpLabel
-OpReturnValue %109
 OpFunctionEnd
 #endif

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
@@ -64,7 +64,7 @@ layout(set = 2, binding = 0) uniform sampler _52[];
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _80 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _80 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_80 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -770,7 +770,7 @@ OpFunctionEnd
 %74 = OpFunctionParameter %5
 %76 = OpLabel
 %78 = OpAccessChain %77 %66 %79
-%80 = OpAtomicExchange %5 %78 %81 %82 %81
+%80 = OpAtomicIAdd %5 %78 %81 %82 %81
 %84 = OpIEqual %83 %80 %82
 OpSelectionMerge %86 None
 OpBranchConditional %84 %85 %86

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
@@ -1,0 +1,836 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer AtomicCounter;
+layout(buffer_reference, std430) buffer AtomicCounter
+{
+    uint _m0;
+};
+
+layout(set = 7, binding = 0, std430) readonly buffer AtomicCounters
+{
+    AtomicCounter counters[];
+} _34;
+
+layout(set = 5, binding = 0, std140) uniform BindlessCBV
+{
+    vec4 _m0[4096];
+} _48[];
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 1, binding = 0) uniform samplerBuffer _17[];
+layout(set = 1, binding = 0) uniform usamplerBuffer _21[];
+layout(set = 1, binding = 0) uniform usamplerBuffer _24[];
+layout(set = 4, binding = 0, r32ui) uniform writeonly uimageBuffer _28[];
+layout(set = 4, binding = 0, r32ui) uniform writeonly uimageBuffer _37[];
+layout(set = 3, binding = 0) uniform writeonly image2D _41[];
+layout(set = 2, binding = 0) uniform sampler _52[];
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _80 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_80 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _115 = QAHeapData.descriptor_count;
+    uint _117 = QAHeapData.heap_index;
+    uvec2 _119 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _127 = QAGlobalData.live_status_table[_119.x >> 5u];
+    uint _138 = (uint(heap_offset >= _115) | (((_119.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_127 & (1u << (_119.x & 31u))) != 0u) ? 0u : 4u);
+    if (_138 != 0u)
+    {
+        descriptor_qa_report_fault(_138, heap_offset, _119.x, _117, descriptor_type_mask, _119.y, instruction);
+        return _115;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _61 = descriptor_qa_check(registers._m3 + 6u, 2u, 1u);
+    uint _151 = descriptor_qa_check(registers._m4 + 3u, 32u, 2u);
+    uint _157 = descriptor_qa_check(registers._m4, 32u, 3u);
+    uint _163 = descriptor_qa_check(registers._m4, 256u, 4u);
+    AtomicCounter _165 = _34.counters[_163];
+    uint _171 = descriptor_qa_check(registers._m1 + 9u, 16u, 5u);
+    uint _178 = descriptor_qa_check(registers._m1 + 6u, 16u, 6u);
+    uint _185 = descriptor_qa_check(registers._m1 + 3u, 16u, 7u);
+    uint _191 = descriptor_qa_check(registers._m0, 1u, 8u);
+    uint _202 = descriptor_qa_check(registers._m5, 4u, 9u);
+    float _214;
+    if (gl_GlobalInvocationID.x > 2u)
+    {
+        _214 = _48[_202]._m0[0u].x;
+    }
+    else
+    {
+        _214 = 0.0;
+    }
+    float _228;
+    if (gl_GlobalInvocationID.x > 3u)
+    {
+        uint _222 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 4u, 10u);
+        _228 = _48[_222]._m0[0u].x + _214;
+    }
+    else
+    {
+        _228 = _214;
+    }
+    float _238;
+    if (gl_GlobalInvocationID.x > 4u)
+    {
+        _238 = textureLod(sampler2D(_13[_191], _52[registers._m2]), vec2(0.5), 0.0).x + _228;
+    }
+    else
+    {
+        _238 = _228;
+    }
+    float _253;
+    if (gl_GlobalInvocationID.x > 5u)
+    {
+        uint _246 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 11u);
+        _253 = texelFetch(_13[_246], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _238;
+    }
+    else
+    {
+        _253 = _238;
+    }
+    float _258;
+    if (gl_GlobalInvocationID.x > 6u)
+    {
+        _258 = texelFetch(_17[_185], int(gl_GlobalInvocationID.x)).x + _253;
+    }
+    else
+    {
+        _258 = _253;
+    }
+    float _272;
+    if (gl_GlobalInvocationID.x > 7u)
+    {
+        uint _266 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 12u);
+        _272 = texelFetch(_17[_266], int(gl_GlobalInvocationID.x)).x + _258;
+    }
+    else
+    {
+        _272 = _258;
+    }
+    float _279;
+    if (gl_GlobalInvocationID.x > 8u)
+    {
+        _279 = uintBitsToFloat(texelFetch(_21[_178], int(gl_GlobalInvocationID.x)).x) + _272;
+    }
+    else
+    {
+        _279 = _272;
+    }
+    float _294;
+    if (gl_GlobalInvocationID.x > 9u)
+    {
+        uint _287 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 16u, 13u);
+        _294 = uintBitsToFloat(texelFetch(_21[_287], int(gl_GlobalInvocationID.x)).x) + _279;
+    }
+    else
+    {
+        _294 = _279;
+    }
+    float _301;
+    if (gl_GlobalInvocationID.x > 10u)
+    {
+        _301 = uintBitsToFloat(texelFetch(_24[_171], int(gl_GlobalInvocationID.x)).x) + _294;
+    }
+    else
+    {
+        _301 = _294;
+    }
+    float _317;
+    if (gl_GlobalInvocationID.x > 11u)
+    {
+        uint _309 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 16u, 14u);
+        _317 = uintBitsToFloat(texelFetch(_24[_309], int(gl_GlobalInvocationID.x >> 2u)).x) + _301;
+    }
+    else
+    {
+        _317 = _301;
+    }
+    if (gl_GlobalInvocationID.x > 1u)
+    {
+        imageStore(_28[_157], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+    }
+    if (gl_GlobalInvocationID.x > 30u)
+    {
+        uint _329 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 32u, 15u);
+        imageStore(_28[_329], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+    }
+    if (gl_GlobalInvocationID.x > 40u)
+    {
+        imageStore(_37[_151], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+    }
+    if (gl_GlobalInvocationID.x > 50u)
+    {
+        uint _349 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 32u, 16u);
+        imageStore(_37[_349], int(gl_GlobalInvocationID.x), uvec4(floatBitsToUint(_317)));
+    }
+    if (gl_GlobalInvocationID.x > 80u)
+    {
+        imageStore(_41[_61], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_317));
+    }
+    if (gl_GlobalInvocationID.x > 90u)
+    {
+        uint _364 = descriptor_qa_check(registers._m3 + ((gl_GlobalInvocationID.x & 1u) + 7u), 2u, 17u);
+        imageStore(_41[_364], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_317));
+    }
+    uint _371 = atomicAdd(_165._m0, 1u);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 406
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability SampledBuffer
+OpCapability ImageBuffer
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RuntimeDescriptorArray
+OpCapability UniformTexelBufferArrayDynamicIndexing
+OpCapability StorageTexelBufferArrayDynamicIndexing
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint GLCompute %3 "main" %205
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %29 "AtomicCounter"
+OpName %32 "AtomicCounters"
+OpMemberName %32 0 "counters"
+OpName %45 "BindlessCBV"
+OpName %64 "DescriptorHeapGlobalQAData"
+OpMemberName %64 0 "failed_shader_hash"
+OpMemberName %64 1 "failed_offset"
+OpMemberName %64 2 "failed_heap"
+OpMemberName %64 3 "failed_cookie"
+OpMemberName %64 4 "fault_atomic"
+OpMemberName %64 5 "failed_instruction"
+OpMemberName %64 6 "failed_descriptor_type_mask"
+OpMemberName %64 7 "actual_descriptor_type_mask"
+OpMemberName %64 8 "fault_type"
+OpMemberName %64 9 "live_status_table"
+OpName %66 "QAGlobalData"
+OpName %75 "descriptor_qa_report_fault"
+OpName %68 "fault_type"
+OpName %69 "heap_offset"
+OpName %70 "cookie"
+OpName %71 "heap_index"
+OpName %72 "descriptor_type"
+OpName %73 "actual_descriptor_type"
+OpName %74 "instruction"
+OpName %105 "DescriptorHeapQAData"
+OpMemberName %105 0 "descriptor_count"
+OpMemberName %105 1 "heap_index"
+OpMemberName %105 2 "cookies_descriptor_info"
+OpName %107 "QAHeapData"
+OpName %112 "descriptor_qa_check"
+OpName %109 "heap_offset"
+OpName %110 "descriptor_type_mask"
+OpName %111 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 1
+OpDecorate %17 Binding 0
+OpDecorate %21 DescriptorSet 1
+OpDecorate %21 Binding 0
+OpDecorate %24 DescriptorSet 1
+OpDecorate %24 Binding 0
+OpDecorate %28 DescriptorSet 4
+OpDecorate %28 Binding 0
+OpDecorate %28 NonReadable
+OpDecorate %29 Block
+OpMemberDecorate %29 0 Offset 0
+OpDecorate %31 ArrayStride 8
+OpDecorate %32 Block
+OpMemberDecorate %32 0 Offset 0
+OpMemberDecorate %32 0 NonWritable
+OpDecorate %34 DescriptorSet 7
+OpDecorate %34 Binding 0
+OpDecorate %34 AliasedPointer
+OpDecorate %37 DescriptorSet 4
+OpDecorate %37 Binding 0
+OpDecorate %37 NonReadable
+OpDecorate %41 DescriptorSet 3
+OpDecorate %41 Binding 0
+OpDecorate %41 NonReadable
+OpDecorate %44 ArrayStride 16
+OpDecorate %45 Block
+OpMemberDecorate %45 0 Offset 0
+OpDecorate %48 DescriptorSet 5
+OpDecorate %48 Binding 0
+OpDecorate %52 DescriptorSet 2
+OpDecorate %52 Binding 0
+OpDecorate %63 ArrayStride 4
+OpMemberDecorate %64 0 Offset 0
+OpMemberDecorate %64 1 Offset 8
+OpMemberDecorate %64 2 Offset 12
+OpMemberDecorate %64 3 Offset 16
+OpMemberDecorate %64 4 Offset 20
+OpMemberDecorate %64 5 Offset 24
+OpMemberDecorate %64 6 Offset 28
+OpMemberDecorate %64 7 Offset 32
+OpMemberDecorate %64 8 Offset 36
+OpMemberDecorate %64 9 Offset 40
+OpDecorate %64 Block
+OpDecorate %66 DescriptorSet 10
+OpDecorate %66 Binding 10
+OpDecorate %104 ArrayStride 8
+OpMemberDecorate %105 0 Offset 0
+OpMemberDecorate %105 1 Offset 4
+OpMemberDecorate %105 2 Offset 8
+OpDecorate %105 Block
+OpDecorate %107 DescriptorSet 10
+OpDecorate %107 Binding 11
+OpDecorate %107 NonWritable
+OpDecorate %205 BuiltIn GlobalInvocationId
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeImage %9 Buffer 0 0 0 1 Unknown
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeImage %5 Buffer 0 0 0 1 Unknown
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypePointer UniformConstant %19
+%21 = OpVariable %20 UniformConstant
+%22 = OpTypeRuntimeArray %18
+%23 = OpTypePointer UniformConstant %22
+%24 = OpVariable %23 UniformConstant
+%25 = OpTypeImage %5 Buffer 0 0 0 2 R32ui
+%26 = OpTypeRuntimeArray %25
+%27 = OpTypePointer UniformConstant %26
+%28 = OpVariable %27 UniformConstant
+%29 = OpTypeStruct %5
+%30 = OpTypePointer PhysicalStorageBuffer %29
+%31 = OpTypeRuntimeArray %30
+%32 = OpTypeStruct %31
+%33 = OpTypePointer StorageBuffer %32
+%34 = OpVariable %33 StorageBuffer
+%35 = OpTypeRuntimeArray %25
+%36 = OpTypePointer UniformConstant %35
+%37 = OpVariable %36 UniformConstant
+%38 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%39 = OpTypeRuntimeArray %38
+%40 = OpTypePointer UniformConstant %39
+%41 = OpVariable %40 UniformConstant
+%42 = OpTypeVector %9 4
+%43 = OpConstant %5 4096
+%44 = OpTypeArray %42 %43
+%45 = OpTypeStruct %44
+%46 = OpTypeRuntimeArray %45
+%47 = OpTypePointer Uniform %46
+%48 = OpVariable %47 Uniform
+%49 = OpTypeSampler
+%50 = OpTypeRuntimeArray %49
+%51 = OpTypePointer UniformConstant %50
+%52 = OpVariable %51 UniformConstant
+%53 = OpTypePointer UniformConstant %38
+%55 = OpTypePointer PushConstant %5
+%57 = OpConstant %5 3
+%60 = OpConstant %5 6
+%62 = OpTypeVector %5 2
+%63 = OpTypeRuntimeArray %5
+%64 = OpTypeStruct %62 %5 %5 %5 %5 %5 %5 %5 %5 %63
+%65 = OpTypePointer StorageBuffer %64
+%66 = OpVariable %65 StorageBuffer
+%67 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%77 = OpTypePointer StorageBuffer %5
+%79 = OpConstant %5 4
+%81 = OpConstant %5 1
+%82 = OpConstant %5 0
+%83 = OpTypeBool
+%90 = OpConstant %5 2
+%93 = OpConstant %5 7
+%95 = OpConstant %5 5
+%96 = OpConstant %5 3735928559
+%97 = OpConstantComposite %62 %96 %82
+%98 = OpTypePointer StorageBuffer %62
+%100 = OpConstant %5 72
+%102 = OpConstant %5 8
+%104 = OpTypeRuntimeArray %62
+%105 = OpTypeStruct %5 %5 %104
+%106 = OpTypePointer StorageBuffer %105
+%107 = OpVariable %106 StorageBuffer
+%108 = OpTypeFunction %5 %5 %5 %5
+%124 = OpConstant %5 31
+%126 = OpConstant %5 9
+%146 = OpTypePointer UniformConstant %25
+%152 = OpConstant %5 32
+%159 = OpTypePointer StorageBuffer %30
+%164 = OpConstant %5 256
+%166 = OpTypePointer UniformConstant %18
+%172 = OpConstant %5 16
+%180 = OpTypePointer UniformConstant %14
+%187 = OpTypePointer UniformConstant %10
+%193 = OpTypePointer UniformConstant %49
+%198 = OpTypePointer Uniform %45
+%203 = OpTypeVector %5 3
+%204 = OpTypePointer Input %203
+%205 = OpVariable %204 Input
+%206 = OpTypePointer Input %5
+%210 = OpTypePointer Uniform %42
+%215 = OpConstant %9 0
+%223 = OpConstant %5 10
+%230 = OpTypeSampledImage %10
+%232 = OpConstant %9 0.5
+%234 = OpTypeVector %9 2
+%247 = OpConstant %5 11
+%267 = OpConstant %5 12
+%274 = OpTypeVector %5 4
+%288 = OpConstant %5 13
+%310 = OpConstant %5 14
+%322 = OpConstant %5 30
+%330 = OpConstant %5 15
+%335 = OpConstant %5 40
+%340 = OpConstant %5 50
+%353 = OpConstant %5 80
+%357 = OpConstant %5 90
+%365 = OpConstant %5 17
+%369 = OpTypePointer PhysicalStorageBuffer %5
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %372
+%372 = OpLabel
+%56 = OpAccessChain %55 %8 %57
+%58 = OpLoad %5 %56
+%59 = OpIAdd %5 %58 %60
+%61 = OpFunctionCall %5 %112 %59 %90 %81
+%54 = OpAccessChain %53 %41 %61
+%145 = OpLoad %38 %54
+%148 = OpAccessChain %55 %8 %79
+%149 = OpLoad %5 %148
+%150 = OpIAdd %5 %149 %57
+%151 = OpFunctionCall %5 %112 %150 %152 %90
+%147 = OpAccessChain %146 %37 %151
+%153 = OpLoad %25 %147
+%155 = OpAccessChain %55 %8 %79
+%156 = OpLoad %5 %155
+%157 = OpFunctionCall %5 %112 %156 %152 %57
+%154 = OpAccessChain %146 %28 %157
+%158 = OpLoad %25 %154
+%161 = OpAccessChain %55 %8 %79
+%162 = OpLoad %5 %161
+%163 = OpFunctionCall %5 %112 %162 %164 %79
+%160 = OpAccessChain %159 %34 %82 %163
+%165 = OpLoad %30 %160
+%168 = OpAccessChain %55 %8 %81
+%169 = OpLoad %5 %168
+%170 = OpIAdd %5 %169 %126
+%171 = OpFunctionCall %5 %112 %170 %172 %95
+%167 = OpAccessChain %166 %24 %171
+%173 = OpLoad %18 %167
+%175 = OpAccessChain %55 %8 %81
+%176 = OpLoad %5 %175
+%177 = OpIAdd %5 %176 %60
+%178 = OpFunctionCall %5 %112 %177 %172 %60
+%174 = OpAccessChain %166 %21 %178
+%179 = OpLoad %18 %174
+%182 = OpAccessChain %55 %8 %81
+%183 = OpLoad %5 %182
+%184 = OpIAdd %5 %183 %57
+%185 = OpFunctionCall %5 %112 %184 %172 %93
+%181 = OpAccessChain %180 %17 %185
+%186 = OpLoad %14 %181
+%189 = OpAccessChain %55 %8 %82
+%190 = OpLoad %5 %189
+%191 = OpFunctionCall %5 %112 %190 %81 %102
+%188 = OpAccessChain %187 %13 %191
+%192 = OpLoad %10 %188
+%195 = OpAccessChain %55 %8 %90
+%196 = OpLoad %5 %195
+%194 = OpAccessChain %193 %52 %196
+%197 = OpLoad %49 %194
+%200 = OpAccessChain %55 %8 %95
+%201 = OpLoad %5 %200
+%202 = OpFunctionCall %5 %112 %201 %79 %126
+%199 = OpAccessChain %198 %48 %202
+%207 = OpAccessChain %206 %205 %82
+%208 = OpLoad %5 %207
+%209 = OpUGreaterThan %83 %208 %90
+OpSelectionMerge %374 None
+OpBranchConditional %209 %373 %374
+%373 = OpLabel
+%211 = OpAccessChain %210 %199 %82 %82
+%212 = OpLoad %42 %211
+%213 = OpCompositeExtract %9 %212 0
+OpBranch %374
+%374 = OpLabel
+%214 = OpPhi %9 %215 %372 %213 %373
+%216 = OpUGreaterThan %83 %208 %57
+OpSelectionMerge %376 None
+OpBranchConditional %216 %375 %376
+%375 = OpLabel
+%217 = OpIAdd %5 %208 %81
+%219 = OpAccessChain %55 %8 %95
+%220 = OpLoad %5 %219
+%221 = OpIAdd %5 %220 %217
+%222 = OpFunctionCall %5 %112 %221 %79 %223
+%218 = OpAccessChain %198 %48 %222
+%224 = OpAccessChain %210 %218 %82 %82
+%225 = OpLoad %42 %224
+%226 = OpCompositeExtract %9 %225 0
+%227 = OpFAdd %9 %226 %214
+OpBranch %376
+%376 = OpLabel
+%228 = OpPhi %9 %214 %374 %227 %375
+%229 = OpUGreaterThan %83 %208 %79
+OpSelectionMerge %378 None
+OpBranchConditional %229 %377 %378
+%377 = OpLabel
+%231 = OpSampledImage %230 %192 %197
+%235 = OpCompositeConstruct %234 %232 %232
+%233 = OpImageSampleExplicitLod %42 %231 %235 Lod %215
+%236 = OpCompositeExtract %9 %233 0
+%237 = OpFAdd %9 %236 %228
+OpBranch %378
+%378 = OpLabel
+%238 = OpPhi %9 %228 %376 %237 %377
+%239 = OpUGreaterThan %83 %208 %95
+OpSelectionMerge %380 None
+OpBranchConditional %239 %379 %380
+%379 = OpLabel
+%240 = OpBitwiseAnd %5 %208 %81
+%241 = OpIAdd %5 %240 %81
+%243 = OpAccessChain %55 %8 %82
+%244 = OpLoad %5 %243
+%245 = OpIAdd %5 %244 %241
+%246 = OpFunctionCall %5 %112 %245 %81 %247
+%242 = OpAccessChain %187 %13 %246
+%248 = OpLoad %10 %242
+%250 = OpCompositeConstruct %62 %82 %208
+%249 = OpImageFetch %42 %248 %250 Lod %82
+%251 = OpCompositeExtract %9 %249 0
+%252 = OpFAdd %9 %251 %238
+OpBranch %380
+%380 = OpLabel
+%253 = OpPhi %9 %238 %378 %252 %379
+%254 = OpUGreaterThan %83 %208 %60
+OpSelectionMerge %382 None
+OpBranchConditional %254 %381 %382
+%381 = OpLabel
+%255 = OpImageFetch %42 %186 %208
+%256 = OpCompositeExtract %9 %255 0
+%257 = OpFAdd %9 %256 %253
+OpBranch %382
+%382 = OpLabel
+%258 = OpPhi %9 %253 %380 %257 %381
+%259 = OpUGreaterThan %83 %208 %93
+OpSelectionMerge %384 None
+OpBranchConditional %259 %383 %384
+%383 = OpLabel
+%260 = OpBitwiseAnd %5 %208 %81
+%261 = OpIAdd %5 %260 %79
+%263 = OpAccessChain %55 %8 %81
+%264 = OpLoad %5 %263
+%265 = OpIAdd %5 %264 %261
+%266 = OpFunctionCall %5 %112 %265 %172 %267
+%262 = OpAccessChain %180 %17 %266
+%268 = OpLoad %14 %262
+%269 = OpImageFetch %42 %268 %208
+%270 = OpCompositeExtract %9 %269 0
+%271 = OpFAdd %9 %270 %258
+OpBranch %384
+%384 = OpLabel
+%272 = OpPhi %9 %258 %382 %271 %383
+%273 = OpUGreaterThan %83 %208 %102
+OpSelectionMerge %386 None
+OpBranchConditional %273 %385 %386
+%385 = OpLabel
+%275 = OpImageFetch %274 %179 %208
+%276 = OpCompositeExtract %5 %275 0
+%277 = OpBitcast %9 %276
+%278 = OpFAdd %9 %277 %272
+OpBranch %386
+%386 = OpLabel
+%279 = OpPhi %9 %272 %384 %278 %385
+%280 = OpUGreaterThan %83 %208 %126
+OpSelectionMerge %388 None
+OpBranchConditional %280 %387 %388
+%387 = OpLabel
+%281 = OpBitwiseAnd %5 %208 %81
+%282 = OpIAdd %5 %281 %93
+%284 = OpAccessChain %55 %8 %81
+%285 = OpLoad %5 %284
+%286 = OpIAdd %5 %285 %282
+%287 = OpFunctionCall %5 %112 %286 %172 %288
+%283 = OpAccessChain %166 %21 %287
+%289 = OpLoad %18 %283
+%290 = OpImageFetch %274 %289 %208
+%291 = OpCompositeExtract %5 %290 0
+%292 = OpBitcast %9 %291
+%293 = OpFAdd %9 %292 %279
+OpBranch %388
+%388 = OpLabel
+%294 = OpPhi %9 %279 %386 %293 %387
+%295 = OpUGreaterThan %83 %208 %223
+OpSelectionMerge %390 None
+OpBranchConditional %295 %389 %390
+%389 = OpLabel
+%296 = OpShiftLeftLogical %5 %208 %90
+%297 = OpImageFetch %274 %173 %208
+%298 = OpCompositeExtract %5 %297 0
+%299 = OpBitcast %9 %298
+%300 = OpFAdd %9 %299 %294
+OpBranch %390
+%390 = OpLabel
+%301 = OpPhi %9 %294 %388 %300 %389
+%302 = OpUGreaterThan %83 %208 %247
+OpSelectionMerge %392 None
+OpBranchConditional %302 %391 %392
+%391 = OpLabel
+%303 = OpBitwiseAnd %5 %208 %81
+%304 = OpIAdd %5 %303 %223
+%306 = OpAccessChain %55 %8 %81
+%307 = OpLoad %5 %306
+%308 = OpIAdd %5 %307 %304
+%309 = OpFunctionCall %5 %112 %308 %172 %310
+%305 = OpAccessChain %166 %24 %309
+%311 = OpLoad %18 %305
+%312 = OpShiftRightLogical %5 %208 %90
+%313 = OpImageFetch %274 %311 %312
+%314 = OpCompositeExtract %5 %313 0
+%315 = OpBitcast %9 %314
+%316 = OpFAdd %9 %315 %301
+OpBranch %392
+%392 = OpLabel
+%317 = OpPhi %9 %301 %390 %316 %391
+%318 = OpUGreaterThan %83 %208 %81
+OpSelectionMerge %394 None
+OpBranchConditional %318 %393 %394
+%393 = OpLabel
+%319 = OpBitcast %5 %317
+%320 = OpCompositeConstruct %274 %319 %319 %319 %319
+OpImageWrite %158 %208 %320
+OpBranch %394
+%394 = OpLabel
+%321 = OpUGreaterThan %83 %208 %322
+OpSelectionMerge %396 None
+OpBranchConditional %321 %395 %396
+%395 = OpLabel
+%323 = OpBitwiseAnd %5 %208 %81
+%324 = OpIAdd %5 %323 %81
+%326 = OpAccessChain %55 %8 %79
+%327 = OpLoad %5 %326
+%328 = OpIAdd %5 %327 %324
+%329 = OpFunctionCall %5 %112 %328 %152 %330
+%325 = OpAccessChain %146 %28 %329
+%331 = OpLoad %25 %325
+%332 = OpBitcast %5 %317
+%333 = OpCompositeConstruct %274 %332 %332 %332 %332
+OpImageWrite %331 %208 %333
+OpBranch %396
+%396 = OpLabel
+%334 = OpUGreaterThan %83 %208 %335
+OpSelectionMerge %398 None
+OpBranchConditional %334 %397 %398
+%397 = OpLabel
+%336 = OpBitcast %5 %317
+%337 = OpShiftLeftLogical %5 %208 %90
+%338 = OpCompositeConstruct %274 %336 %336 %336 %336
+OpImageWrite %153 %208 %338
+OpBranch %398
+%398 = OpLabel
+%339 = OpUGreaterThan %83 %208 %340
+OpSelectionMerge %400 None
+OpBranchConditional %339 %399 %400
+%399 = OpLabel
+%341 = OpBitwiseAnd %5 %208 %81
+%342 = OpBitcast %5 %317
+%343 = OpShiftLeftLogical %5 %208 %90
+%344 = OpIAdd %5 %341 %79
+%346 = OpAccessChain %55 %8 %79
+%347 = OpLoad %5 %346
+%348 = OpIAdd %5 %347 %344
+%349 = OpFunctionCall %5 %112 %348 %152 %172
+%345 = OpAccessChain %146 %37 %349
+%350 = OpLoad %25 %345
+%351 = OpCompositeConstruct %274 %342 %342 %342 %342
+OpImageWrite %350 %208 %351
+OpBranch %400
+%400 = OpLabel
+%352 = OpUGreaterThan %83 %208 %353
+OpSelectionMerge %402 None
+OpBranchConditional %352 %401 %402
+%401 = OpLabel
+%354 = OpCompositeConstruct %62 %208 %82
+%355 = OpCompositeConstruct %42 %317 %317 %317 %317
+OpImageWrite %145 %354 %355
+OpBranch %402
+%402 = OpLabel
+%356 = OpUGreaterThan %83 %208 %357
+OpSelectionMerge %404 None
+OpBranchConditional %356 %403 %404
+%403 = OpLabel
+%358 = OpBitwiseAnd %5 %208 %81
+%359 = OpIAdd %5 %358 %93
+%361 = OpAccessChain %55 %8 %57
+%362 = OpLoad %5 %361
+%363 = OpIAdd %5 %362 %359
+%364 = OpFunctionCall %5 %112 %363 %90 %365
+%360 = OpAccessChain %53 %41 %364
+%366 = OpLoad %38 %360
+%367 = OpCompositeConstruct %62 %82 %208
+%368 = OpCompositeConstruct %42 %317 %317 %317 %317
+OpImageWrite %366 %367 %368
+OpBranch %404
+%404 = OpLabel
+%370 = OpAccessChain %369 %165 %82
+%371 = OpAtomicIAdd %5 %370 %81 %82 %81
+OpReturn
+OpFunctionEnd
+%75 = OpFunction %1 None %67
+%68 = OpFunctionParameter %5
+%69 = OpFunctionParameter %5
+%70 = OpFunctionParameter %5
+%71 = OpFunctionParameter %5
+%72 = OpFunctionParameter %5
+%73 = OpFunctionParameter %5
+%74 = OpFunctionParameter %5
+%76 = OpLabel
+%78 = OpAccessChain %77 %66 %79
+%80 = OpAtomicExchange %5 %78 %81 %82 %81
+%84 = OpIEqual %83 %80 %82
+OpSelectionMerge %86 None
+OpBranchConditional %84 %85 %86
+%85 = OpLabel
+%87 = OpAccessChain %77 %66 %57
+OpStore %87 %70
+%88 = OpAccessChain %77 %66 %81
+OpStore %88 %69
+%89 = OpAccessChain %77 %66 %90
+OpStore %89 %71
+%91 = OpAccessChain %77 %66 %60
+OpStore %91 %72
+%92 = OpAccessChain %77 %66 %93
+OpStore %92 %73
+%94 = OpAccessChain %77 %66 %95
+OpStore %94 %74
+%99 = OpAccessChain %98 %66 %82
+OpStore %99 %97
+OpMemoryBarrier %81 %100
+%101 = OpAccessChain %77 %66 %102
+OpStore %101 %68
+OpBranch %86
+%86 = OpLabel
+OpReturn
+OpFunctionEnd
+%112 = OpFunction %5 None %108
+%109 = OpFunctionParameter %5
+%110 = OpFunctionParameter %5
+%111 = OpFunctionParameter %5
+%113 = OpLabel
+%114 = OpAccessChain %77 %107 %82
+%115 = OpLoad %5 %114
+%116 = OpAccessChain %77 %107 %81
+%117 = OpLoad %5 %116
+%118 = OpAccessChain %98 %107 %90 %109
+%119 = OpLoad %62 %118
+%120 = OpCompositeExtract %5 %119 0
+%122 = OpShiftRightLogical %5 %120 %95
+%123 = OpBitwiseAnd %5 %120 %124
+%121 = OpCompositeExtract %5 %119 1
+%125 = OpAccessChain %77 %66 %126 %122
+%127 = OpLoad %5 %125
+%128 = OpShiftLeftLogical %5 %81 %123
+%129 = OpBitwiseAnd %5 %127 %128
+%130 = OpINotEqual %83 %129 %82
+%131 = OpBitwiseAnd %5 %121 %110
+%132 = OpIEqual %83 %131 %110
+%133 = OpUGreaterThanEqual %83 %109 %115
+%134 = OpSelect %5 %133 %81 %82
+%135 = OpSelect %5 %132 %82 %90
+%136 = OpSelect %5 %130 %82 %79
+%137 = OpBitwiseOr %5 %134 %135
+%138 = OpBitwiseOr %5 %137 %136
+%139 = OpINotEqual %83 %138 %82
+OpSelectionMerge %141 None
+OpBranchConditional %139 %140 %141
+%140 = OpLabel
+%142 = OpFunctionCall %1 %75 %138 %109 %120 %117 %110 %121 %111
+OpReturnValue %115
+%141 = OpLabel
+OpReturnValue %109
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
@@ -1,0 +1,853 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_samplerless_texture_functions : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(buffer_reference) buffer AtomicCounter;
+layout(buffer_reference, std430) buffer AtomicCounter
+{
+    uint _m0;
+};
+
+layout(set = 1, binding = 0, std430) restrict readonly buffer SSBO
+{
+    uint _m0[];
+} _22[];
+
+layout(set = 1, binding = 0, std430) restrict readonly buffer _24_27
+{
+    uint _m0[];
+} _27[];
+
+layout(set = 4, binding = 0, std430) writeonly buffer _29_32
+{
+    uint _m0[];
+} _32[];
+
+layout(set = 7, binding = 0, std430) readonly buffer AtomicCounters
+{
+    AtomicCounter counters[];
+} _38;
+
+layout(set = 4, binding = 0, std430) writeonly buffer _40_43
+{
+    uint _m0[];
+} _43[];
+
+layout(set = 5, binding = 0, std140) uniform BindlessCBV
+{
+    vec4 _m0[4096];
+} _54[];
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 1, binding = 0) uniform samplerBuffer _17[];
+layout(set = 3, binding = 0) uniform writeonly image2D _47[];
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _82 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_82 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _117 = QAHeapData.descriptor_count;
+    uint _119 = QAHeapData.heap_index;
+    uvec2 _121 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _129 = QAGlobalData.live_status_table[_121.x >> 5u];
+    uint _140 = (uint(heap_offset >= _117) | (((_121.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_129 & (1u << (_121.x & 31u))) != 0u) ? 0u : 4u);
+    if (_140 != 0u)
+    {
+        descriptor_qa_report_fault(_140, heap_offset, _121.x, _119, descriptor_type_mask, _121.y, instruction);
+        return _117;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _63 = descriptor_qa_check(registers._m3 + 6u, 2u, 1u);
+    uint _153 = descriptor_qa_check(registers._m4 + 3u, 8u, 2u);
+    uint _158 = descriptor_qa_check(registers._m4, 8u, 3u);
+    uint _163 = descriptor_qa_check(registers._m4, 256u, 4u);
+    AtomicCounter _165 = _38.counters[_163];
+    uint _171 = descriptor_qa_check(registers._m1 + 9u, 8u, 5u);
+    uint _177 = descriptor_qa_check(registers._m1 + 6u, 8u, 6u);
+    uint _183 = descriptor_qa_check(registers._m1 + 3u, 16u, 7u);
+    uint _190 = descriptor_qa_check(registers._m0, 1u, 8u);
+    uint _196 = descriptor_qa_check(registers._m5, 4u, 9u);
+    float _208;
+    if (gl_GlobalInvocationID.x > 2u)
+    {
+        _208 = _54[_196]._m0[0u].x;
+    }
+    else
+    {
+        _208 = 0.0;
+    }
+    float _222;
+    if (gl_GlobalInvocationID.x > 3u)
+    {
+        uint _216 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 4u, 10u);
+        _222 = _54[_216]._m0[0u].x + _208;
+    }
+    else
+    {
+        _222 = _208;
+    }
+    float _228;
+    if (gl_GlobalInvocationID.x > 4u)
+    {
+        _228 = texelFetch(_13[_190], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), int(0u)).x + _222;
+    }
+    else
+    {
+        _228 = _222;
+    }
+    float _243;
+    if (gl_GlobalInvocationID.x > 5u)
+    {
+        uint _236 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 11u);
+        _243 = texelFetch(_13[_236], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _228;
+    }
+    else
+    {
+        _243 = _228;
+    }
+    float _248;
+    if (gl_GlobalInvocationID.x > 6u)
+    {
+        _248 = texelFetch(_17[_183], int(gl_GlobalInvocationID.x)).x + _243;
+    }
+    else
+    {
+        _248 = _243;
+    }
+    float _262;
+    if (gl_GlobalInvocationID.x > 7u)
+    {
+        uint _256 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 12u);
+        _262 = texelFetch(_17[_256], int(gl_GlobalInvocationID.x)).x + _248;
+    }
+    else
+    {
+        _262 = _248;
+    }
+    float _268;
+    if (gl_GlobalInvocationID.x > 8u)
+    {
+        _268 = uintBitsToFloat(_22[_177]._m0[gl_GlobalInvocationID.x]) + _262;
+    }
+    else
+    {
+        _268 = _262;
+    }
+    float _282;
+    if (gl_GlobalInvocationID.x > 9u)
+    {
+        uint _276 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 8u, 13u);
+        _282 = uintBitsToFloat(_22[_276]._m0[gl_GlobalInvocationID.x]) + _268;
+    }
+    else
+    {
+        _282 = _268;
+    }
+    float _289;
+    if (gl_GlobalInvocationID.x > 10u)
+    {
+        _289 = uintBitsToFloat(_27[_171]._m0[gl_GlobalInvocationID.x]) + _282;
+    }
+    else
+    {
+        _289 = _282;
+    }
+    float _304;
+    if (gl_GlobalInvocationID.x > 11u)
+    {
+        uint _297 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 8u, 14u);
+        _304 = uintBitsToFloat(_27[_297]._m0[gl_GlobalInvocationID.x >> 2u]) + _289;
+    }
+    else
+    {
+        _304 = _289;
+    }
+    if (gl_GlobalInvocationID.x > 1u)
+    {
+        _32[_158]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+    }
+    if (gl_GlobalInvocationID.x > 30u)
+    {
+        uint _316 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 8u, 15u);
+        _32[_316]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+    }
+    if (gl_GlobalInvocationID.x > 40u)
+    {
+        _43[_153]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+    }
+    if (gl_GlobalInvocationID.x > 50u)
+    {
+        uint _335 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 8u, 16u);
+        _43[_335]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+    }
+    if (gl_GlobalInvocationID.x > 80u)
+    {
+        imageStore(_47[_63], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_304));
+    }
+    if (gl_GlobalInvocationID.x > 90u)
+    {
+        uint _349 = descriptor_qa_check(registers._m3 + ((gl_GlobalInvocationID.x & 1u) + 7u), 2u, 17u);
+        imageStore(_47[_349], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_304));
+    }
+    uint _356 = atomicAdd(_165._m0, 1u);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 391
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability SampledBuffer
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RuntimeDescriptorArray
+OpCapability UniformTexelBufferArrayDynamicIndexing
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint GLCompute %3 "main" %199
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %19 "SSBO"
+OpName %24 "SSBO"
+OpName %29 "SSBO"
+OpName %33 "AtomicCounter"
+OpName %36 "AtomicCounters"
+OpMemberName %36 0 "counters"
+OpName %40 "SSBO"
+OpName %51 "BindlessCBV"
+OpName %66 "DescriptorHeapGlobalQAData"
+OpMemberName %66 0 "failed_shader_hash"
+OpMemberName %66 1 "failed_offset"
+OpMemberName %66 2 "failed_heap"
+OpMemberName %66 3 "failed_cookie"
+OpMemberName %66 4 "fault_atomic"
+OpMemberName %66 5 "failed_instruction"
+OpMemberName %66 6 "failed_descriptor_type_mask"
+OpMemberName %66 7 "actual_descriptor_type_mask"
+OpMemberName %66 8 "fault_type"
+OpMemberName %66 9 "live_status_table"
+OpName %68 "QAGlobalData"
+OpName %77 "descriptor_qa_report_fault"
+OpName %70 "fault_type"
+OpName %71 "heap_offset"
+OpName %72 "cookie"
+OpName %73 "heap_index"
+OpName %74 "descriptor_type"
+OpName %75 "actual_descriptor_type"
+OpName %76 "instruction"
+OpName %107 "DescriptorHeapQAData"
+OpMemberName %107 0 "descriptor_count"
+OpMemberName %107 1 "heap_index"
+OpMemberName %107 2 "cookies_descriptor_info"
+OpName %109 "QAHeapData"
+OpName %114 "descriptor_qa_check"
+OpName %111 "heap_offset"
+OpName %112 "descriptor_type_mask"
+OpName %113 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 1
+OpDecorate %17 Binding 0
+OpDecorate %18 ArrayStride 4
+OpMemberDecorate %19 0 Offset 0
+OpDecorate %19 Block
+OpDecorate %22 DescriptorSet 1
+OpDecorate %22 Binding 0
+OpDecorate %22 NonWritable
+OpDecorate %22 Restrict
+OpDecorate %23 ArrayStride 4
+OpMemberDecorate %24 0 Offset 0
+OpDecorate %24 Block
+OpDecorate %27 DescriptorSet 1
+OpDecorate %27 Binding 0
+OpDecorate %27 NonWritable
+OpDecorate %27 Restrict
+OpDecorate %28 ArrayStride 4
+OpMemberDecorate %29 0 Offset 0
+OpDecorate %29 Block
+OpDecorate %32 DescriptorSet 4
+OpDecorate %32 Binding 0
+OpDecorate %32 NonReadable
+OpDecorate %33 Block
+OpMemberDecorate %33 0 Offset 0
+OpDecorate %35 ArrayStride 8
+OpDecorate %36 Block
+OpMemberDecorate %36 0 Offset 0
+OpMemberDecorate %36 0 NonWritable
+OpDecorate %38 DescriptorSet 7
+OpDecorate %38 Binding 0
+OpDecorate %38 AliasedPointer
+OpDecorate %39 ArrayStride 4
+OpMemberDecorate %40 0 Offset 0
+OpDecorate %40 Block
+OpDecorate %43 DescriptorSet 4
+OpDecorate %43 Binding 0
+OpDecorate %43 NonReadable
+OpDecorate %47 DescriptorSet 3
+OpDecorate %47 Binding 0
+OpDecorate %47 NonReadable
+OpDecorate %50 ArrayStride 16
+OpDecorate %51 Block
+OpMemberDecorate %51 0 Offset 0
+OpDecorate %54 DescriptorSet 5
+OpDecorate %54 Binding 0
+OpDecorate %65 ArrayStride 4
+OpMemberDecorate %66 0 Offset 0
+OpMemberDecorate %66 1 Offset 8
+OpMemberDecorate %66 2 Offset 12
+OpMemberDecorate %66 3 Offset 16
+OpMemberDecorate %66 4 Offset 20
+OpMemberDecorate %66 5 Offset 24
+OpMemberDecorate %66 6 Offset 28
+OpMemberDecorate %66 7 Offset 32
+OpMemberDecorate %66 8 Offset 36
+OpMemberDecorate %66 9 Offset 40
+OpDecorate %66 Block
+OpDecorate %68 DescriptorSet 10
+OpDecorate %68 Binding 10
+OpDecorate %106 ArrayStride 8
+OpMemberDecorate %107 0 Offset 0
+OpMemberDecorate %107 1 Offset 4
+OpMemberDecorate %107 2 Offset 8
+OpDecorate %107 Block
+OpDecorate %109 DescriptorSet 10
+OpDecorate %109 Binding 11
+OpDecorate %109 NonWritable
+OpDecorate %199 BuiltIn GlobalInvocationId
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeImage %9 Buffer 0 0 0 1 Unknown
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeRuntimeArray %5
+%19 = OpTypeStruct %18
+%20 = OpTypeRuntimeArray %19
+%21 = OpTypePointer StorageBuffer %20
+%22 = OpVariable %21 StorageBuffer
+%23 = OpTypeRuntimeArray %5
+%24 = OpTypeStruct %23
+%25 = OpTypeRuntimeArray %24
+%26 = OpTypePointer StorageBuffer %25
+%27 = OpVariable %26 StorageBuffer
+%28 = OpTypeRuntimeArray %5
+%29 = OpTypeStruct %28
+%30 = OpTypeRuntimeArray %29
+%31 = OpTypePointer StorageBuffer %30
+%32 = OpVariable %31 StorageBuffer
+%33 = OpTypeStruct %5
+%34 = OpTypePointer PhysicalStorageBuffer %33
+%35 = OpTypeRuntimeArray %34
+%36 = OpTypeStruct %35
+%37 = OpTypePointer StorageBuffer %36
+%38 = OpVariable %37 StorageBuffer
+%39 = OpTypeRuntimeArray %5
+%40 = OpTypeStruct %39
+%41 = OpTypeRuntimeArray %40
+%42 = OpTypePointer StorageBuffer %41
+%43 = OpVariable %42 StorageBuffer
+%44 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%45 = OpTypeRuntimeArray %44
+%46 = OpTypePointer UniformConstant %45
+%47 = OpVariable %46 UniformConstant
+%48 = OpTypeVector %9 4
+%49 = OpConstant %5 4096
+%50 = OpTypeArray %48 %49
+%51 = OpTypeStruct %50
+%52 = OpTypeRuntimeArray %51
+%53 = OpTypePointer Uniform %52
+%54 = OpVariable %53 Uniform
+%55 = OpTypePointer UniformConstant %44
+%57 = OpTypePointer PushConstant %5
+%59 = OpConstant %5 3
+%62 = OpConstant %5 6
+%64 = OpTypeVector %5 2
+%65 = OpTypeRuntimeArray %5
+%66 = OpTypeStruct %64 %5 %5 %5 %5 %5 %5 %5 %5 %65
+%67 = OpTypePointer StorageBuffer %66
+%68 = OpVariable %67 StorageBuffer
+%69 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%79 = OpTypePointer StorageBuffer %5
+%81 = OpConstant %5 4
+%83 = OpConstant %5 1
+%84 = OpConstant %5 0
+%85 = OpTypeBool
+%92 = OpConstant %5 2
+%95 = OpConstant %5 7
+%97 = OpConstant %5 5
+%98 = OpConstant %5 3735928559
+%99 = OpConstantComposite %64 %98 %84
+%100 = OpTypePointer StorageBuffer %64
+%102 = OpConstant %5 72
+%104 = OpConstant %5 8
+%106 = OpTypeRuntimeArray %64
+%107 = OpTypeStruct %5 %5 %106
+%108 = OpTypePointer StorageBuffer %107
+%109 = OpVariable %108 StorageBuffer
+%110 = OpTypeFunction %5 %5 %5 %5
+%126 = OpConstant %5 31
+%128 = OpConstant %5 9
+%148 = OpTypePointer StorageBuffer %40
+%154 = OpTypePointer StorageBuffer %29
+%159 = OpTypePointer StorageBuffer %34
+%164 = OpConstant %5 256
+%166 = OpTypePointer StorageBuffer %24
+%172 = OpTypePointer StorageBuffer %19
+%178 = OpTypePointer UniformConstant %14
+%184 = OpConstant %5 16
+%186 = OpTypePointer UniformConstant %10
+%192 = OpTypePointer Uniform %51
+%197 = OpTypeVector %5 3
+%198 = OpTypePointer Input %197
+%199 = OpVariable %198 Input
+%200 = OpTypePointer Input %5
+%204 = OpTypePointer Uniform %48
+%209 = OpConstant %9 0
+%217 = OpConstant %5 10
+%237 = OpConstant %5 11
+%257 = OpConstant %5 12
+%277 = OpConstant %5 13
+%298 = OpConstant %5 14
+%309 = OpConstant %5 30
+%317 = OpConstant %5 15
+%321 = OpConstant %5 40
+%326 = OpConstant %5 50
+%338 = OpConstant %5 80
+%342 = OpConstant %5 90
+%350 = OpConstant %5 17
+%354 = OpTypePointer PhysicalStorageBuffer %5
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %357
+%357 = OpLabel
+%58 = OpAccessChain %57 %8 %59
+%60 = OpLoad %5 %58
+%61 = OpIAdd %5 %60 %62
+%63 = OpFunctionCall %5 %114 %61 %92 %83
+%56 = OpAccessChain %55 %47 %63
+%147 = OpLoad %44 %56
+%150 = OpAccessChain %57 %8 %81
+%151 = OpLoad %5 %150
+%152 = OpIAdd %5 %151 %59
+%153 = OpFunctionCall %5 %114 %152 %104 %92
+%149 = OpAccessChain %148 %43 %153
+%156 = OpAccessChain %57 %8 %81
+%157 = OpLoad %5 %156
+%158 = OpFunctionCall %5 %114 %157 %104 %59
+%155 = OpAccessChain %154 %32 %158
+%161 = OpAccessChain %57 %8 %81
+%162 = OpLoad %5 %161
+%163 = OpFunctionCall %5 %114 %162 %164 %81
+%160 = OpAccessChain %159 %38 %84 %163
+%165 = OpLoad %34 %160
+%168 = OpAccessChain %57 %8 %83
+%169 = OpLoad %5 %168
+%170 = OpIAdd %5 %169 %128
+%171 = OpFunctionCall %5 %114 %170 %104 %97
+%167 = OpAccessChain %166 %27 %171
+%174 = OpAccessChain %57 %8 %83
+%175 = OpLoad %5 %174
+%176 = OpIAdd %5 %175 %62
+%177 = OpFunctionCall %5 %114 %176 %104 %62
+%173 = OpAccessChain %172 %22 %177
+%180 = OpAccessChain %57 %8 %83
+%181 = OpLoad %5 %180
+%182 = OpIAdd %5 %181 %59
+%183 = OpFunctionCall %5 %114 %182 %184 %95
+%179 = OpAccessChain %178 %17 %183
+%185 = OpLoad %14 %179
+%188 = OpAccessChain %57 %8 %84
+%189 = OpLoad %5 %188
+%190 = OpFunctionCall %5 %114 %189 %83 %104
+%187 = OpAccessChain %186 %13 %190
+%191 = OpLoad %10 %187
+%194 = OpAccessChain %57 %8 %97
+%195 = OpLoad %5 %194
+%196 = OpFunctionCall %5 %114 %195 %81 %128
+%193 = OpAccessChain %192 %54 %196
+%201 = OpAccessChain %200 %199 %84
+%202 = OpLoad %5 %201
+%203 = OpUGreaterThan %85 %202 %92
+OpSelectionMerge %359 None
+OpBranchConditional %203 %358 %359
+%358 = OpLabel
+%205 = OpAccessChain %204 %193 %84 %84
+%206 = OpLoad %48 %205
+%207 = OpCompositeExtract %9 %206 0
+OpBranch %359
+%359 = OpLabel
+%208 = OpPhi %9 %209 %357 %207 %358
+%210 = OpUGreaterThan %85 %202 %59
+OpSelectionMerge %361 None
+OpBranchConditional %210 %360 %361
+%360 = OpLabel
+%211 = OpIAdd %5 %202 %83
+%213 = OpAccessChain %57 %8 %97
+%214 = OpLoad %5 %213
+%215 = OpIAdd %5 %214 %211
+%216 = OpFunctionCall %5 %114 %215 %81 %217
+%212 = OpAccessChain %192 %54 %216
+%218 = OpAccessChain %204 %212 %84 %84
+%219 = OpLoad %48 %218
+%220 = OpCompositeExtract %9 %219 0
+%221 = OpFAdd %9 %220 %208
+OpBranch %361
+%361 = OpLabel
+%222 = OpPhi %9 %208 %359 %221 %360
+%223 = OpUGreaterThan %85 %202 %81
+OpSelectionMerge %363 None
+OpBranchConditional %223 %362 %363
+%362 = OpLabel
+%225 = OpCompositeConstruct %64 %202 %84
+%224 = OpImageFetch %48 %191 %225 Lod %84
+%226 = OpCompositeExtract %9 %224 0
+%227 = OpFAdd %9 %226 %222
+OpBranch %363
+%363 = OpLabel
+%228 = OpPhi %9 %222 %361 %227 %362
+%229 = OpUGreaterThan %85 %202 %97
+OpSelectionMerge %365 None
+OpBranchConditional %229 %364 %365
+%364 = OpLabel
+%230 = OpBitwiseAnd %5 %202 %83
+%231 = OpIAdd %5 %230 %83
+%233 = OpAccessChain %57 %8 %84
+%234 = OpLoad %5 %233
+%235 = OpIAdd %5 %234 %231
+%236 = OpFunctionCall %5 %114 %235 %83 %237
+%232 = OpAccessChain %186 %13 %236
+%238 = OpLoad %10 %232
+%240 = OpCompositeConstruct %64 %84 %202
+%239 = OpImageFetch %48 %238 %240 Lod %84
+%241 = OpCompositeExtract %9 %239 0
+%242 = OpFAdd %9 %241 %228
+OpBranch %365
+%365 = OpLabel
+%243 = OpPhi %9 %228 %363 %242 %364
+%244 = OpUGreaterThan %85 %202 %62
+OpSelectionMerge %367 None
+OpBranchConditional %244 %366 %367
+%366 = OpLabel
+%245 = OpImageFetch %48 %185 %202
+%246 = OpCompositeExtract %9 %245 0
+%247 = OpFAdd %9 %246 %243
+OpBranch %367
+%367 = OpLabel
+%248 = OpPhi %9 %243 %365 %247 %366
+%249 = OpUGreaterThan %85 %202 %95
+OpSelectionMerge %369 None
+OpBranchConditional %249 %368 %369
+%368 = OpLabel
+%250 = OpBitwiseAnd %5 %202 %83
+%251 = OpIAdd %5 %250 %81
+%253 = OpAccessChain %57 %8 %83
+%254 = OpLoad %5 %253
+%255 = OpIAdd %5 %254 %251
+%256 = OpFunctionCall %5 %114 %255 %184 %257
+%252 = OpAccessChain %178 %17 %256
+%258 = OpLoad %14 %252
+%259 = OpImageFetch %48 %258 %202
+%260 = OpCompositeExtract %9 %259 0
+%261 = OpFAdd %9 %260 %248
+OpBranch %369
+%369 = OpLabel
+%262 = OpPhi %9 %248 %367 %261 %368
+%263 = OpUGreaterThan %85 %202 %104
+OpSelectionMerge %371 None
+OpBranchConditional %263 %370 %371
+%370 = OpLabel
+%264 = OpAccessChain %79 %173 %84 %202
+%265 = OpLoad %5 %264
+%266 = OpBitcast %9 %265
+%267 = OpFAdd %9 %266 %262
+OpBranch %371
+%371 = OpLabel
+%268 = OpPhi %9 %262 %369 %267 %370
+%269 = OpUGreaterThan %85 %202 %128
+OpSelectionMerge %373 None
+OpBranchConditional %269 %372 %373
+%372 = OpLabel
+%270 = OpBitwiseAnd %5 %202 %83
+%271 = OpIAdd %5 %270 %95
+%273 = OpAccessChain %57 %8 %83
+%274 = OpLoad %5 %273
+%275 = OpIAdd %5 %274 %271
+%276 = OpFunctionCall %5 %114 %275 %104 %277
+%272 = OpAccessChain %172 %22 %276
+%278 = OpAccessChain %79 %272 %84 %202
+%279 = OpLoad %5 %278
+%280 = OpBitcast %9 %279
+%281 = OpFAdd %9 %280 %268
+OpBranch %373
+%373 = OpLabel
+%282 = OpPhi %9 %268 %371 %281 %372
+%283 = OpUGreaterThan %85 %202 %217
+OpSelectionMerge %375 None
+OpBranchConditional %283 %374 %375
+%374 = OpLabel
+%284 = OpShiftLeftLogical %5 %202 %92
+%285 = OpAccessChain %79 %167 %84 %202
+%286 = OpLoad %5 %285
+%287 = OpBitcast %9 %286
+%288 = OpFAdd %9 %287 %282
+OpBranch %375
+%375 = OpLabel
+%289 = OpPhi %9 %282 %373 %288 %374
+%290 = OpUGreaterThan %85 %202 %237
+OpSelectionMerge %377 None
+OpBranchConditional %290 %376 %377
+%376 = OpLabel
+%291 = OpBitwiseAnd %5 %202 %83
+%292 = OpIAdd %5 %291 %217
+%294 = OpAccessChain %57 %8 %83
+%295 = OpLoad %5 %294
+%296 = OpIAdd %5 %295 %292
+%297 = OpFunctionCall %5 %114 %296 %104 %298
+%293 = OpAccessChain %166 %27 %297
+%299 = OpShiftRightLogical %5 %202 %92
+%300 = OpAccessChain %79 %293 %84 %299
+%301 = OpLoad %5 %300
+%302 = OpBitcast %9 %301
+%303 = OpFAdd %9 %302 %289
+OpBranch %377
+%377 = OpLabel
+%304 = OpPhi %9 %289 %375 %303 %376
+%305 = OpUGreaterThan %85 %202 %83
+OpSelectionMerge %379 None
+OpBranchConditional %305 %378 %379
+%378 = OpLabel
+%306 = OpBitcast %5 %304
+%307 = OpAccessChain %79 %155 %84 %202
+OpStore %307 %306
+OpBranch %379
+%379 = OpLabel
+%308 = OpUGreaterThan %85 %202 %309
+OpSelectionMerge %381 None
+OpBranchConditional %308 %380 %381
+%380 = OpLabel
+%310 = OpBitwiseAnd %5 %202 %83
+%311 = OpIAdd %5 %310 %83
+%313 = OpAccessChain %57 %8 %81
+%314 = OpLoad %5 %313
+%315 = OpIAdd %5 %314 %311
+%316 = OpFunctionCall %5 %114 %315 %104 %317
+%312 = OpAccessChain %154 %32 %316
+%318 = OpBitcast %5 %304
+%319 = OpAccessChain %79 %312 %84 %202
+OpStore %319 %318
+OpBranch %381
+%381 = OpLabel
+%320 = OpUGreaterThan %85 %202 %321
+OpSelectionMerge %383 None
+OpBranchConditional %320 %382 %383
+%382 = OpLabel
+%322 = OpBitcast %5 %304
+%323 = OpShiftLeftLogical %5 %202 %92
+%324 = OpAccessChain %79 %149 %84 %202
+OpStore %324 %322
+OpBranch %383
+%383 = OpLabel
+%325 = OpUGreaterThan %85 %202 %326
+OpSelectionMerge %385 None
+OpBranchConditional %325 %384 %385
+%384 = OpLabel
+%327 = OpBitwiseAnd %5 %202 %83
+%328 = OpBitcast %5 %304
+%329 = OpShiftLeftLogical %5 %202 %92
+%330 = OpIAdd %5 %327 %81
+%332 = OpAccessChain %57 %8 %81
+%333 = OpLoad %5 %332
+%334 = OpIAdd %5 %333 %330
+%335 = OpFunctionCall %5 %114 %334 %104 %184
+%331 = OpAccessChain %148 %43 %335
+%336 = OpAccessChain %79 %331 %84 %202
+OpStore %336 %328
+OpBranch %385
+%385 = OpLabel
+%337 = OpUGreaterThan %85 %202 %338
+OpSelectionMerge %387 None
+OpBranchConditional %337 %386 %387
+%386 = OpLabel
+%339 = OpCompositeConstruct %64 %202 %84
+%340 = OpCompositeConstruct %48 %304 %304 %304 %304
+OpImageWrite %147 %339 %340
+OpBranch %387
+%387 = OpLabel
+%341 = OpUGreaterThan %85 %202 %342
+OpSelectionMerge %389 None
+OpBranchConditional %341 %388 %389
+%388 = OpLabel
+%343 = OpBitwiseAnd %5 %202 %83
+%344 = OpIAdd %5 %343 %95
+%346 = OpAccessChain %57 %8 %59
+%347 = OpLoad %5 %346
+%348 = OpIAdd %5 %347 %344
+%349 = OpFunctionCall %5 %114 %348 %92 %350
+%345 = OpAccessChain %55 %47 %349
+%351 = OpLoad %44 %345
+%352 = OpCompositeConstruct %64 %84 %202
+%353 = OpCompositeConstruct %48 %304 %304 %304 %304
+OpImageWrite %351 %352 %353
+OpBranch %389
+%389 = OpLabel
+%355 = OpAccessChain %354 %165 %84
+%356 = OpAtomicIAdd %5 %355 %83 %84 %83
+OpReturn
+OpFunctionEnd
+%77 = OpFunction %1 None %69
+%70 = OpFunctionParameter %5
+%71 = OpFunctionParameter %5
+%72 = OpFunctionParameter %5
+%73 = OpFunctionParameter %5
+%74 = OpFunctionParameter %5
+%75 = OpFunctionParameter %5
+%76 = OpFunctionParameter %5
+%78 = OpLabel
+%80 = OpAccessChain %79 %68 %81
+%82 = OpAtomicExchange %5 %80 %83 %84 %83
+%86 = OpIEqual %85 %82 %84
+OpSelectionMerge %88 None
+OpBranchConditional %86 %87 %88
+%87 = OpLabel
+%89 = OpAccessChain %79 %68 %59
+OpStore %89 %72
+%90 = OpAccessChain %79 %68 %83
+OpStore %90 %71
+%91 = OpAccessChain %79 %68 %92
+OpStore %91 %73
+%93 = OpAccessChain %79 %68 %62
+OpStore %93 %74
+%94 = OpAccessChain %79 %68 %95
+OpStore %94 %75
+%96 = OpAccessChain %79 %68 %97
+OpStore %96 %76
+%101 = OpAccessChain %100 %68 %84
+OpStore %101 %99
+OpMemoryBarrier %83 %102
+%103 = OpAccessChain %79 %68 %104
+OpStore %103 %70
+OpBranch %88
+%88 = OpLabel
+OpReturn
+OpFunctionEnd
+%114 = OpFunction %5 None %110
+%111 = OpFunctionParameter %5
+%112 = OpFunctionParameter %5
+%113 = OpFunctionParameter %5
+%115 = OpLabel
+%116 = OpAccessChain %79 %109 %84
+%117 = OpLoad %5 %116
+%118 = OpAccessChain %79 %109 %83
+%119 = OpLoad %5 %118
+%120 = OpAccessChain %100 %109 %92 %111
+%121 = OpLoad %64 %120
+%122 = OpCompositeExtract %5 %121 0
+%124 = OpShiftRightLogical %5 %122 %97
+%125 = OpBitwiseAnd %5 %122 %126
+%123 = OpCompositeExtract %5 %121 1
+%127 = OpAccessChain %79 %68 %128 %124
+%129 = OpLoad %5 %127
+%130 = OpShiftLeftLogical %5 %83 %125
+%131 = OpBitwiseAnd %5 %129 %130
+%132 = OpINotEqual %85 %131 %84
+%133 = OpBitwiseAnd %5 %123 %112
+%134 = OpIEqual %85 %133 %112
+%135 = OpUGreaterThanEqual %85 %111 %117
+%136 = OpSelect %5 %135 %83 %84
+%137 = OpSelect %5 %134 %84 %92
+%138 = OpSelect %5 %132 %84 %81
+%139 = OpBitwiseOr %5 %136 %137
+%140 = OpBitwiseOr %5 %139 %138
+%141 = OpINotEqual %85 %140 %84
+OpSelectionMerge %143 None
+OpBranchConditional %141 %142 %143
+%142 = OpLabel
+%144 = OpFunctionCall %1 %77 %140 %111 %122 %119 %112 %123 %113
+OpReturnValue %117
+%143 = OpLabel
+OpReturnValue %111
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
@@ -79,7 +79,7 @@ layout(set = 3, binding = 0) uniform writeonly image2D _47[];
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _82 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _82 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_82 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -787,7 +787,7 @@ OpFunctionEnd
 %76 = OpFunctionParameter %5
 %78 = OpLabel
 %80 = OpAccessChain %79 %68 %81
-%82 = OpAtomicExchange %5 %80 %83 %84 %83
+%82 = OpAtomicIAdd %5 %80 %83 %84 %83
 %86 = OpIEqual %85 %82 %84
 OpSelectionMerge %88 None
 OpBranchConditional %86 %87 %88

--- a/reference/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
+++ b/reference/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
@@ -79,8 +79,8 @@ layout(set = 3, binding = 0) uniform writeonly image2D _47[];
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _82 = atomicAdd(QAGlobalData.fault_atomic, 1u);
-    if (_82 == 0u)
+    uint _90 = atomicAdd(QAGlobalData.fault_atomic, 1u);
+    if (_90 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
         QAGlobalData.failed_offset = heap_offset;
@@ -96,154 +96,155 @@ void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, 
 
 uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
 {
-    uint _117 = QAHeapData.descriptor_count;
-    uint _119 = QAHeapData.heap_index;
-    uvec2 _121 = QAHeapData.cookies_descriptor_info[heap_offset];
-    uint _129 = QAGlobalData.live_status_table[_121.x >> 5u];
-    uint _140 = (uint(heap_offset >= _117) | (((_121.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_129 & (1u << (_121.x & 31u))) != 0u) ? 0u : 4u);
-    if (_140 != 0u)
+    uint _123 = QAHeapData.descriptor_count;
+    uint _125 = QAHeapData.heap_index;
+    uvec2 _127 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _135 = QAGlobalData.live_status_table[_127.x >> 5u];
+    uint _146 = (uint(heap_offset >= _123) | (((_127.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_135 & (1u << (_127.x & 31u))) != 0u) ? 0u : 4u);
+    if (_146 != 0u)
     {
-        descriptor_qa_report_fault(_140, heap_offset, _121.x, _119, descriptor_type_mask, _121.y, instruction);
-        return _117;
+        descriptor_qa_report_fault(_146, heap_offset, _127.x, _125, descriptor_type_mask, _127.y, instruction);
+        return _123;
     }
     return heap_offset;
 }
 
 void main()
 {
-    uint _63 = descriptor_qa_check(registers._m3 + 6u, 2u, 1u);
-    uint _153 = descriptor_qa_check(registers._m4 + 3u, 8u, 2u);
-    uint _158 = descriptor_qa_check(registers._m4, 8u, 3u);
-    uint _163 = descriptor_qa_check(registers._m4, 256u, 4u);
-    AtomicCounter _165 = _38.counters[_163];
-    uint _171 = descriptor_qa_check(registers._m1 + 9u, 8u, 5u);
-    uint _177 = descriptor_qa_check(registers._m1 + 6u, 8u, 6u);
-    uint _183 = descriptor_qa_check(registers._m1 + 3u, 16u, 7u);
-    uint _190 = descriptor_qa_check(registers._m0, 1u, 8u);
-    uint _196 = descriptor_qa_check(registers._m5, 4u, 9u);
-    float _208;
+    float _157;
     if (gl_GlobalInvocationID.x > 2u)
     {
-        _208 = _54[_196]._m0[0u].x;
+        uint _71 = descriptor_qa_check(registers._m5, 4u, 1u);
+        _157 = _54[_71]._m0[0u].x;
     }
     else
     {
-        _208 = 0.0;
+        _157 = 0.0;
     }
-    float _222;
+    float _170;
     if (gl_GlobalInvocationID.x > 3u)
     {
-        uint _216 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 4u, 10u);
-        _222 = _54[_216]._m0[0u].x + _208;
+        uint _165 = descriptor_qa_check(registers._m5 + (gl_GlobalInvocationID.x + 1u), 4u, 2u);
+        _170 = _54[_165]._m0[0u].x + _157;
     }
     else
     {
-        _222 = _208;
+        _170 = _157;
     }
-    float _228;
+    float _182;
     if (gl_GlobalInvocationID.x > 4u)
     {
-        _228 = texelFetch(_13[_190], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), int(0u)).x + _222;
+        uint _176 = descriptor_qa_check(registers._m0, 1u, 3u);
+        _182 = texelFetch(_13[_176], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), int(0u)).x + _170;
     }
     else
     {
-        _228 = _222;
+        _182 = _170;
     }
-    float _243;
+    float _196;
     if (gl_GlobalInvocationID.x > 5u)
     {
-        uint _236 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 11u);
-        _243 = texelFetch(_13[_236], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _228;
+        uint _190 = descriptor_qa_check(registers._m0 + ((gl_GlobalInvocationID.x & 1u) + 1u), 1u, 4u);
+        _196 = texelFetch(_13[_190], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), int(0u)).x + _182;
     }
     else
     {
-        _243 = _228;
+        _196 = _182;
     }
-    float _248;
+    float _209;
     if (gl_GlobalInvocationID.x > 6u)
     {
-        _248 = texelFetch(_17[_183], int(gl_GlobalInvocationID.x)).x + _243;
+        uint _203 = descriptor_qa_check(registers._m1 + 3u, 16u, 5u);
+        _209 = texelFetch(_17[_203], int(gl_GlobalInvocationID.x)).x + _196;
     }
     else
     {
-        _248 = _243;
+        _209 = _196;
     }
-    float _262;
+    float _222;
     if (gl_GlobalInvocationID.x > 7u)
     {
-        uint _256 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 12u);
-        _262 = texelFetch(_17[_256], int(gl_GlobalInvocationID.x)).x + _248;
+        uint _217 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 4u), 16u, 6u);
+        _222 = texelFetch(_17[_217], int(gl_GlobalInvocationID.x)).x + _209;
     }
     else
     {
-        _262 = _248;
+        _222 = _209;
     }
-    float _268;
+    float _234;
     if (gl_GlobalInvocationID.x > 8u)
     {
-        _268 = uintBitsToFloat(_22[_177]._m0[gl_GlobalInvocationID.x]) + _262;
+        uint _229 = descriptor_qa_check(registers._m1 + 6u, 8u, 7u);
+        _234 = uintBitsToFloat(_22[_229]._m0[gl_GlobalInvocationID.x]) + _222;
     }
     else
     {
-        _268 = _262;
+        _234 = _222;
     }
-    float _282;
+    float _247;
     if (gl_GlobalInvocationID.x > 9u)
     {
-        uint _276 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 8u, 13u);
-        _282 = uintBitsToFloat(_22[_276]._m0[gl_GlobalInvocationID.x]) + _268;
+        uint _242 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 7u), 8u, 8u);
+        _247 = uintBitsToFloat(_22[_242]._m0[gl_GlobalInvocationID.x]) + _234;
     }
     else
     {
-        _282 = _268;
+        _247 = _234;
     }
-    float _289;
+    float _261;
     if (gl_GlobalInvocationID.x > 10u)
     {
-        _289 = uintBitsToFloat(_27[_171]._m0[gl_GlobalInvocationID.x]) + _282;
+        uint _255 = descriptor_qa_check(registers._m1 + 9u, 8u, 9u);
+        _261 = uintBitsToFloat(_27[_255]._m0[gl_GlobalInvocationID.x]) + _247;
     }
     else
     {
-        _289 = _282;
+        _261 = _247;
     }
-    float _304;
+    float _276;
     if (gl_GlobalInvocationID.x > 11u)
     {
-        uint _297 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 8u, 14u);
-        _304 = uintBitsToFloat(_27[_297]._m0[gl_GlobalInvocationID.x >> 2u]) + _289;
+        uint _270 = descriptor_qa_check(registers._m1 + ((gl_GlobalInvocationID.x & 1u) + 10u), 8u, 10u);
+        _276 = uintBitsToFloat(_27[_270]._m0[gl_GlobalInvocationID.x >> 2u]) + _261;
     }
     else
     {
-        _304 = _289;
+        _276 = _261;
     }
     if (gl_GlobalInvocationID.x > 1u)
     {
-        _32[_158]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+        uint _282 = descriptor_qa_check(registers._m4, 8u, 11u);
+        uint _287 = descriptor_qa_check(registers._m4, 256u, 12u);
+        _32[_282]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_276);
     }
     if (gl_GlobalInvocationID.x > 30u)
     {
-        uint _316 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 8u, 15u);
-        _32[_316]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+        uint _301 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 1u), 8u, 13u);
+        _32[_301]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_276);
     }
     if (gl_GlobalInvocationID.x > 40u)
     {
-        _43[_153]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+        uint _312 = descriptor_qa_check(registers._m4 + 3u, 8u, 14u);
+        _43[_312]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_276);
     }
     if (gl_GlobalInvocationID.x > 50u)
     {
-        uint _335 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 8u, 16u);
-        _43[_335]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_304);
+        uint _327 = descriptor_qa_check(registers._m4 + ((gl_GlobalInvocationID.x & 1u) + 4u), 8u, 15u);
+        _43[_327]._m0[gl_GlobalInvocationID.x] = floatBitsToUint(_276);
     }
     if (gl_GlobalInvocationID.x > 80u)
     {
-        imageStore(_47[_63], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_304));
+        uint _337 = descriptor_qa_check(registers._m3 + 6u, 2u, 16u);
+        imageStore(_47[_337], ivec2(uvec2(gl_GlobalInvocationID.x, 0u)), vec4(_276));
     }
     if (gl_GlobalInvocationID.x > 90u)
     {
         uint _349 = descriptor_qa_check(registers._m3 + ((gl_GlobalInvocationID.x & 1u) + 7u), 2u, 17u);
-        imageStore(_47[_349], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_304));
+        imageStore(_47[_349], ivec2(uvec2(0u, gl_GlobalInvocationID.x)), vec4(_276));
     }
-    uint _356 = atomicAdd(_165._m0, 1u);
+    uint _357 = descriptor_qa_check(registers._m4, 8u, 18u);
+    uint _362 = descriptor_qa_check(registers._m4, 256u, 19u);
+    uint _367 = atomicAdd(_38.counters[_362]._m0, 1u);
 }
 
 
@@ -252,7 +253,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 391
+; Bound: 402
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -267,7 +268,7 @@ OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel PhysicalStorageBuffer64 GLSL450
-OpEntryPoint GLCompute %3 "main" %199
+OpEntryPoint GLCompute %3 "main" %57
 OpExecutionMode %3 LocalSize 1 1 1
 OpName %3 "main"
 OpName %6 "RootConstants"
@@ -280,35 +281,35 @@ OpName %36 "AtomicCounters"
 OpMemberName %36 0 "counters"
 OpName %40 "SSBO"
 OpName %51 "BindlessCBV"
-OpName %66 "DescriptorHeapGlobalQAData"
-OpMemberName %66 0 "failed_shader_hash"
-OpMemberName %66 1 "failed_offset"
-OpMemberName %66 2 "failed_heap"
-OpMemberName %66 3 "failed_cookie"
-OpMemberName %66 4 "fault_atomic"
-OpMemberName %66 5 "failed_instruction"
-OpMemberName %66 6 "failed_descriptor_type_mask"
-OpMemberName %66 7 "actual_descriptor_type_mask"
-OpMemberName %66 8 "fault_type"
-OpMemberName %66 9 "live_status_table"
-OpName %68 "QAGlobalData"
-OpName %77 "descriptor_qa_report_fault"
-OpName %70 "fault_type"
-OpName %71 "heap_offset"
-OpName %72 "cookie"
-OpName %73 "heap_index"
-OpName %74 "descriptor_type"
-OpName %75 "actual_descriptor_type"
-OpName %76 "instruction"
-OpName %107 "DescriptorHeapQAData"
-OpMemberName %107 0 "descriptor_count"
-OpMemberName %107 1 "heap_index"
-OpMemberName %107 2 "cookies_descriptor_info"
-OpName %109 "QAHeapData"
-OpName %114 "descriptor_qa_check"
-OpName %111 "heap_offset"
-OpName %112 "descriptor_type_mask"
-OpName %113 "instruction"
+OpName %74 "DescriptorHeapGlobalQAData"
+OpMemberName %74 0 "failed_shader_hash"
+OpMemberName %74 1 "failed_offset"
+OpMemberName %74 2 "failed_heap"
+OpMemberName %74 3 "failed_cookie"
+OpMemberName %74 4 "fault_atomic"
+OpMemberName %74 5 "failed_instruction"
+OpMemberName %74 6 "failed_descriptor_type_mask"
+OpMemberName %74 7 "actual_descriptor_type_mask"
+OpMemberName %74 8 "fault_type"
+OpMemberName %74 9 "live_status_table"
+OpName %76 "QAGlobalData"
+OpName %85 "descriptor_qa_report_fault"
+OpName %78 "fault_type"
+OpName %79 "heap_offset"
+OpName %80 "cookie"
+OpName %81 "heap_index"
+OpName %82 "descriptor_type"
+OpName %83 "actual_descriptor_type"
+OpName %84 "instruction"
+OpName %113 "DescriptorHeapQAData"
+OpMemberName %113 0 "descriptor_count"
+OpMemberName %113 1 "heap_index"
+OpMemberName %113 2 "cookies_descriptor_info"
+OpName %115 "QAHeapData"
+OpName %120 "descriptor_qa_check"
+OpName %117 "heap_offset"
+OpName %118 "descriptor_type_mask"
+OpName %119 "instruction"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 4
@@ -365,29 +366,29 @@ OpDecorate %51 Block
 OpMemberDecorate %51 0 Offset 0
 OpDecorate %54 DescriptorSet 5
 OpDecorate %54 Binding 0
-OpDecorate %65 ArrayStride 4
-OpMemberDecorate %66 0 Offset 0
-OpMemberDecorate %66 1 Offset 8
-OpMemberDecorate %66 2 Offset 12
-OpMemberDecorate %66 3 Offset 16
-OpMemberDecorate %66 4 Offset 20
-OpMemberDecorate %66 5 Offset 24
-OpMemberDecorate %66 6 Offset 28
-OpMemberDecorate %66 7 Offset 32
-OpMemberDecorate %66 8 Offset 36
-OpMemberDecorate %66 9 Offset 40
-OpDecorate %66 Block
-OpDecorate %68 DescriptorSet 10
-OpDecorate %68 Binding 10
-OpDecorate %106 ArrayStride 8
-OpMemberDecorate %107 0 Offset 0
-OpMemberDecorate %107 1 Offset 4
-OpMemberDecorate %107 2 Offset 8
-OpDecorate %107 Block
-OpDecorate %109 DescriptorSet 10
-OpDecorate %109 Binding 11
-OpDecorate %109 NonWritable
-OpDecorate %199 BuiltIn GlobalInvocationId
+OpDecorate %57 BuiltIn GlobalInvocationId
+OpDecorate %73 ArrayStride 4
+OpMemberDecorate %74 0 Offset 0
+OpMemberDecorate %74 1 Offset 8
+OpMemberDecorate %74 2 Offset 12
+OpMemberDecorate %74 3 Offset 16
+OpMemberDecorate %74 4 Offset 20
+OpMemberDecorate %74 5 Offset 24
+OpMemberDecorate %74 6 Offset 28
+OpMemberDecorate %74 7 Offset 32
+OpMemberDecorate %74 8 Offset 36
+OpMemberDecorate %74 9 Offset 40
+OpDecorate %74 Block
+OpDecorate %76 DescriptorSet 10
+OpDecorate %76 Binding 10
+OpDecorate %112 ArrayStride 8
+OpMemberDecorate %113 0 Offset 0
+OpMemberDecorate %113 1 Offset 4
+OpMemberDecorate %113 2 Offset 8
+OpDecorate %113 Block
+OpDecorate %115 DescriptorSet 10
+OpDecorate %115 Binding 11
+OpDecorate %115 NonWritable
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -440,414 +441,425 @@ OpDecorate %199 BuiltIn GlobalInvocationId
 %52 = OpTypeRuntimeArray %51
 %53 = OpTypePointer Uniform %52
 %54 = OpVariable %53 Uniform
-%55 = OpTypePointer UniformConstant %44
-%57 = OpTypePointer PushConstant %5
-%59 = OpConstant %5 3
-%62 = OpConstant %5 6
-%64 = OpTypeVector %5 2
-%65 = OpTypeRuntimeArray %5
-%66 = OpTypeStruct %64 %5 %5 %5 %5 %5 %5 %5 %5 %65
-%67 = OpTypePointer StorageBuffer %66
-%68 = OpVariable %67 StorageBuffer
-%69 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
-%79 = OpTypePointer StorageBuffer %5
-%81 = OpConstant %5 4
-%83 = OpConstant %5 1
-%84 = OpConstant %5 0
-%85 = OpTypeBool
-%92 = OpConstant %5 2
-%95 = OpConstant %5 7
-%97 = OpConstant %5 5
-%98 = OpConstant %5 3735928559
-%99 = OpConstantComposite %64 %98 %84
-%100 = OpTypePointer StorageBuffer %64
-%102 = OpConstant %5 72
-%104 = OpConstant %5 8
-%106 = OpTypeRuntimeArray %64
-%107 = OpTypeStruct %5 %5 %106
-%108 = OpTypePointer StorageBuffer %107
-%109 = OpVariable %108 StorageBuffer
-%110 = OpTypeFunction %5 %5 %5 %5
-%126 = OpConstant %5 31
-%128 = OpConstant %5 9
-%148 = OpTypePointer StorageBuffer %40
-%154 = OpTypePointer StorageBuffer %29
-%159 = OpTypePointer StorageBuffer %34
-%164 = OpConstant %5 256
-%166 = OpTypePointer StorageBuffer %24
-%172 = OpTypePointer StorageBuffer %19
-%178 = OpTypePointer UniformConstant %14
-%184 = OpConstant %5 16
-%186 = OpTypePointer UniformConstant %10
-%192 = OpTypePointer Uniform %51
-%197 = OpTypeVector %5 3
-%198 = OpTypePointer Input %197
-%199 = OpVariable %198 Input
-%200 = OpTypePointer Input %5
-%204 = OpTypePointer Uniform %48
-%209 = OpConstant %9 0
-%217 = OpConstant %5 10
-%237 = OpConstant %5 11
-%257 = OpConstant %5 12
-%277 = OpConstant %5 13
-%298 = OpConstant %5 14
-%309 = OpConstant %5 30
-%317 = OpConstant %5 15
-%321 = OpConstant %5 40
-%326 = OpConstant %5 50
-%338 = OpConstant %5 80
+%55 = OpTypeVector %5 3
+%56 = OpTypePointer Input %55
+%57 = OpVariable %56 Input
+%58 = OpTypePointer Input %5
+%60 = OpConstant %5 0
+%62 = OpTypeBool
+%64 = OpConstant %5 2
+%65 = OpTypePointer Uniform %51
+%67 = OpTypePointer PushConstant %5
+%69 = OpConstant %5 5
+%72 = OpTypeVector %5 2
+%73 = OpTypeRuntimeArray %5
+%74 = OpTypeStruct %72 %5 %5 %5 %5 %5 %5 %5 %5 %73
+%75 = OpTypePointer StorageBuffer %74
+%76 = OpVariable %75 StorageBuffer
+%77 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%87 = OpTypePointer StorageBuffer %5
+%89 = OpConstant %5 4
+%91 = OpConstant %5 1
+%96 = OpConstant %5 3
+%100 = OpConstant %5 6
+%102 = OpConstant %5 7
+%104 = OpConstant %5 3735928559
+%105 = OpConstantComposite %72 %104 %60
+%106 = OpTypePointer StorageBuffer %72
+%108 = OpConstant %5 72
+%110 = OpConstant %5 8
+%112 = OpTypeRuntimeArray %72
+%113 = OpTypeStruct %5 %5 %112
+%114 = OpTypePointer StorageBuffer %113
+%115 = OpVariable %114 StorageBuffer
+%116 = OpTypeFunction %5 %5 %5 %5
+%132 = OpConstant %5 31
+%134 = OpConstant %5 9
+%153 = OpTypePointer Uniform %48
+%158 = OpConstant %9 0
+%172 = OpTypePointer UniformConstant %10
+%198 = OpTypePointer UniformConstant %14
+%204 = OpConstant %5 16
+%224 = OpTypePointer StorageBuffer %19
+%249 = OpConstant %5 10
+%250 = OpTypePointer StorageBuffer %24
+%263 = OpConstant %5 11
+%278 = OpTypePointer StorageBuffer %29
+%283 = OpTypePointer StorageBuffer %34
+%288 = OpConstant %5 256
+%289 = OpConstant %5 12
+%294 = OpConstant %5 30
+%302 = OpConstant %5 13
+%306 = OpConstant %5 40
+%307 = OpTypePointer StorageBuffer %40
+%313 = OpConstant %5 14
+%318 = OpConstant %5 50
+%328 = OpConstant %5 15
+%331 = OpConstant %5 80
+%332 = OpTypePointer UniformConstant %44
 %342 = OpConstant %5 90
 %350 = OpConstant %5 17
-%354 = OpTypePointer PhysicalStorageBuffer %5
+%358 = OpConstant %5 18
+%363 = OpConstant %5 19
+%365 = OpTypePointer PhysicalStorageBuffer %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %357
-%357 = OpLabel
-%58 = OpAccessChain %57 %8 %59
-%60 = OpLoad %5 %58
-%61 = OpIAdd %5 %60 %62
-%63 = OpFunctionCall %5 %114 %61 %92 %83
-%56 = OpAccessChain %55 %47 %63
-%147 = OpLoad %44 %56
-%150 = OpAccessChain %57 %8 %81
-%151 = OpLoad %5 %150
-%152 = OpIAdd %5 %151 %59
-%153 = OpFunctionCall %5 %114 %152 %104 %92
-%149 = OpAccessChain %148 %43 %153
-%156 = OpAccessChain %57 %8 %81
-%157 = OpLoad %5 %156
-%158 = OpFunctionCall %5 %114 %157 %104 %59
-%155 = OpAccessChain %154 %32 %158
-%161 = OpAccessChain %57 %8 %81
-%162 = OpLoad %5 %161
-%163 = OpFunctionCall %5 %114 %162 %164 %81
-%160 = OpAccessChain %159 %38 %84 %163
-%165 = OpLoad %34 %160
-%168 = OpAccessChain %57 %8 %83
-%169 = OpLoad %5 %168
-%170 = OpIAdd %5 %169 %128
-%171 = OpFunctionCall %5 %114 %170 %104 %97
-%167 = OpAccessChain %166 %27 %171
-%174 = OpAccessChain %57 %8 %83
-%175 = OpLoad %5 %174
-%176 = OpIAdd %5 %175 %62
-%177 = OpFunctionCall %5 %114 %176 %104 %62
-%173 = OpAccessChain %172 %22 %177
-%180 = OpAccessChain %57 %8 %83
-%181 = OpLoad %5 %180
-%182 = OpIAdd %5 %181 %59
-%183 = OpFunctionCall %5 %114 %182 %184 %95
-%179 = OpAccessChain %178 %17 %183
-%185 = OpLoad %14 %179
-%188 = OpAccessChain %57 %8 %84
-%189 = OpLoad %5 %188
-%190 = OpFunctionCall %5 %114 %189 %83 %104
-%187 = OpAccessChain %186 %13 %190
-%191 = OpLoad %10 %187
-%194 = OpAccessChain %57 %8 %97
-%195 = OpLoad %5 %194
-%196 = OpFunctionCall %5 %114 %195 %81 %128
-%193 = OpAccessChain %192 %54 %196
-%201 = OpAccessChain %200 %199 %84
-%202 = OpLoad %5 %201
-%203 = OpUGreaterThan %85 %202 %92
-OpSelectionMerge %359 None
-OpBranchConditional %203 %358 %359
-%358 = OpLabel
-%205 = OpAccessChain %204 %193 %84 %84
-%206 = OpLoad %48 %205
-%207 = OpCompositeExtract %9 %206 0
-OpBranch %359
-%359 = OpLabel
-%208 = OpPhi %9 %209 %357 %207 %358
-%210 = OpUGreaterThan %85 %202 %59
-OpSelectionMerge %361 None
-OpBranchConditional %210 %360 %361
-%360 = OpLabel
-%211 = OpIAdd %5 %202 %83
-%213 = OpAccessChain %57 %8 %97
-%214 = OpLoad %5 %213
-%215 = OpIAdd %5 %214 %211
-%216 = OpFunctionCall %5 %114 %215 %81 %217
-%212 = OpAccessChain %192 %54 %216
-%218 = OpAccessChain %204 %212 %84 %84
-%219 = OpLoad %48 %218
-%220 = OpCompositeExtract %9 %219 0
-%221 = OpFAdd %9 %220 %208
-OpBranch %361
-%361 = OpLabel
-%222 = OpPhi %9 %208 %359 %221 %360
-%223 = OpUGreaterThan %85 %202 %81
-OpSelectionMerge %363 None
-OpBranchConditional %223 %362 %363
-%362 = OpLabel
-%225 = OpCompositeConstruct %64 %202 %84
-%224 = OpImageFetch %48 %191 %225 Lod %84
-%226 = OpCompositeExtract %9 %224 0
-%227 = OpFAdd %9 %226 %222
-OpBranch %363
-%363 = OpLabel
-%228 = OpPhi %9 %222 %361 %227 %362
-%229 = OpUGreaterThan %85 %202 %97
-OpSelectionMerge %365 None
-OpBranchConditional %229 %364 %365
-%364 = OpLabel
-%230 = OpBitwiseAnd %5 %202 %83
-%231 = OpIAdd %5 %230 %83
-%233 = OpAccessChain %57 %8 %84
-%234 = OpLoad %5 %233
-%235 = OpIAdd %5 %234 %231
-%236 = OpFunctionCall %5 %114 %235 %83 %237
-%232 = OpAccessChain %186 %13 %236
-%238 = OpLoad %10 %232
-%240 = OpCompositeConstruct %64 %84 %202
-%239 = OpImageFetch %48 %238 %240 Lod %84
-%241 = OpCompositeExtract %9 %239 0
-%242 = OpFAdd %9 %241 %228
-OpBranch %365
-%365 = OpLabel
-%243 = OpPhi %9 %228 %363 %242 %364
-%244 = OpUGreaterThan %85 %202 %62
-OpSelectionMerge %367 None
-OpBranchConditional %244 %366 %367
-%366 = OpLabel
-%245 = OpImageFetch %48 %185 %202
-%246 = OpCompositeExtract %9 %245 0
-%247 = OpFAdd %9 %246 %243
-OpBranch %367
-%367 = OpLabel
-%248 = OpPhi %9 %243 %365 %247 %366
-%249 = OpUGreaterThan %85 %202 %95
-OpSelectionMerge %369 None
-OpBranchConditional %249 %368 %369
+OpBranch %368
 %368 = OpLabel
-%250 = OpBitwiseAnd %5 %202 %83
-%251 = OpIAdd %5 %250 %81
-%253 = OpAccessChain %57 %8 %83
-%254 = OpLoad %5 %253
-%255 = OpIAdd %5 %254 %251
-%256 = OpFunctionCall %5 %114 %255 %184 %257
-%252 = OpAccessChain %178 %17 %256
-%258 = OpLoad %14 %252
-%259 = OpImageFetch %48 %258 %202
-%260 = OpCompositeExtract %9 %259 0
-%261 = OpFAdd %9 %260 %248
-OpBranch %369
+%59 = OpAccessChain %58 %57 %60
+%61 = OpLoad %5 %59
+%63 = OpUGreaterThan %62 %61 %64
+OpSelectionMerge %370 None
+OpBranchConditional %63 %369 %370
 %369 = OpLabel
-%262 = OpPhi %9 %248 %367 %261 %368
-%263 = OpUGreaterThan %85 %202 %104
-OpSelectionMerge %371 None
-OpBranchConditional %263 %370 %371
+%68 = OpAccessChain %67 %8 %69
+%70 = OpLoad %5 %68
+%71 = OpFunctionCall %5 %120 %70 %89 %91
+%66 = OpAccessChain %65 %54 %71
+%154 = OpAccessChain %153 %66 %60 %60
+%155 = OpLoad %48 %154
+%156 = OpCompositeExtract %9 %155 0
+OpBranch %370
 %370 = OpLabel
-%264 = OpAccessChain %79 %173 %84 %202
-%265 = OpLoad %5 %264
-%266 = OpBitcast %9 %265
-%267 = OpFAdd %9 %266 %262
-OpBranch %371
+%157 = OpPhi %9 %158 %368 %156 %369
+%159 = OpUGreaterThan %62 %61 %96
+OpSelectionMerge %372 None
+OpBranchConditional %159 %371 %372
 %371 = OpLabel
-%268 = OpPhi %9 %262 %369 %267 %370
-%269 = OpUGreaterThan %85 %202 %128
-OpSelectionMerge %373 None
-OpBranchConditional %269 %372 %373
+%160 = OpIAdd %5 %61 %91
+%162 = OpAccessChain %67 %8 %69
+%163 = OpLoad %5 %162
+%164 = OpIAdd %5 %163 %160
+%165 = OpFunctionCall %5 %120 %164 %89 %64
+%161 = OpAccessChain %65 %54 %165
+%166 = OpAccessChain %153 %161 %60 %60
+%167 = OpLoad %48 %166
+%168 = OpCompositeExtract %9 %167 0
+%169 = OpFAdd %9 %168 %157
+OpBranch %372
 %372 = OpLabel
-%270 = OpBitwiseAnd %5 %202 %83
-%271 = OpIAdd %5 %270 %95
-%273 = OpAccessChain %57 %8 %83
-%274 = OpLoad %5 %273
-%275 = OpIAdd %5 %274 %271
-%276 = OpFunctionCall %5 %114 %275 %104 %277
-%272 = OpAccessChain %172 %22 %276
-%278 = OpAccessChain %79 %272 %84 %202
-%279 = OpLoad %5 %278
-%280 = OpBitcast %9 %279
-%281 = OpFAdd %9 %280 %268
-OpBranch %373
+%170 = OpPhi %9 %157 %370 %169 %371
+%171 = OpUGreaterThan %62 %61 %89
+OpSelectionMerge %374 None
+OpBranchConditional %171 %373 %374
 %373 = OpLabel
-%282 = OpPhi %9 %268 %371 %281 %372
-%283 = OpUGreaterThan %85 %202 %217
-OpSelectionMerge %375 None
-OpBranchConditional %283 %374 %375
+%174 = OpAccessChain %67 %8 %60
+%175 = OpLoad %5 %174
+%176 = OpFunctionCall %5 %120 %175 %91 %96
+%173 = OpAccessChain %172 %13 %176
+%177 = OpLoad %10 %173
+%179 = OpCompositeConstruct %72 %61 %60
+%178 = OpImageFetch %48 %177 %179 Lod %60
+%180 = OpCompositeExtract %9 %178 0
+%181 = OpFAdd %9 %180 %170
+OpBranch %374
 %374 = OpLabel
-%284 = OpShiftLeftLogical %5 %202 %92
-%285 = OpAccessChain %79 %167 %84 %202
-%286 = OpLoad %5 %285
-%287 = OpBitcast %9 %286
-%288 = OpFAdd %9 %287 %282
-OpBranch %375
+%182 = OpPhi %9 %170 %372 %181 %373
+%183 = OpUGreaterThan %62 %61 %69
+OpSelectionMerge %376 None
+OpBranchConditional %183 %375 %376
 %375 = OpLabel
-%289 = OpPhi %9 %282 %373 %288 %374
-%290 = OpUGreaterThan %85 %202 %237
-OpSelectionMerge %377 None
-OpBranchConditional %290 %376 %377
+%184 = OpBitwiseAnd %5 %61 %91
+%185 = OpIAdd %5 %184 %91
+%187 = OpAccessChain %67 %8 %60
+%188 = OpLoad %5 %187
+%189 = OpIAdd %5 %188 %185
+%190 = OpFunctionCall %5 %120 %189 %91 %89
+%186 = OpAccessChain %172 %13 %190
+%191 = OpLoad %10 %186
+%193 = OpCompositeConstruct %72 %60 %61
+%192 = OpImageFetch %48 %191 %193 Lod %60
+%194 = OpCompositeExtract %9 %192 0
+%195 = OpFAdd %9 %194 %182
+OpBranch %376
 %376 = OpLabel
-%291 = OpBitwiseAnd %5 %202 %83
-%292 = OpIAdd %5 %291 %217
-%294 = OpAccessChain %57 %8 %83
-%295 = OpLoad %5 %294
-%296 = OpIAdd %5 %295 %292
-%297 = OpFunctionCall %5 %114 %296 %104 %298
-%293 = OpAccessChain %166 %27 %297
-%299 = OpShiftRightLogical %5 %202 %92
-%300 = OpAccessChain %79 %293 %84 %299
-%301 = OpLoad %5 %300
-%302 = OpBitcast %9 %301
-%303 = OpFAdd %9 %302 %289
-OpBranch %377
+%196 = OpPhi %9 %182 %374 %195 %375
+%197 = OpUGreaterThan %62 %61 %100
+OpSelectionMerge %378 None
+OpBranchConditional %197 %377 %378
 %377 = OpLabel
-%304 = OpPhi %9 %289 %375 %303 %376
-%305 = OpUGreaterThan %85 %202 %83
-OpSelectionMerge %379 None
-OpBranchConditional %305 %378 %379
+%200 = OpAccessChain %67 %8 %91
+%201 = OpLoad %5 %200
+%202 = OpIAdd %5 %201 %96
+%203 = OpFunctionCall %5 %120 %202 %204 %69
+%199 = OpAccessChain %198 %17 %203
+%205 = OpLoad %14 %199
+%206 = OpImageFetch %48 %205 %61
+%207 = OpCompositeExtract %9 %206 0
+%208 = OpFAdd %9 %207 %196
+OpBranch %378
 %378 = OpLabel
-%306 = OpBitcast %5 %304
-%307 = OpAccessChain %79 %155 %84 %202
-OpStore %307 %306
-OpBranch %379
+%209 = OpPhi %9 %196 %376 %208 %377
+%210 = OpUGreaterThan %62 %61 %102
+OpSelectionMerge %380 None
+OpBranchConditional %210 %379 %380
 %379 = OpLabel
-%308 = OpUGreaterThan %85 %202 %309
-OpSelectionMerge %381 None
-OpBranchConditional %308 %380 %381
+%211 = OpBitwiseAnd %5 %61 %91
+%212 = OpIAdd %5 %211 %89
+%214 = OpAccessChain %67 %8 %91
+%215 = OpLoad %5 %214
+%216 = OpIAdd %5 %215 %212
+%217 = OpFunctionCall %5 %120 %216 %204 %100
+%213 = OpAccessChain %198 %17 %217
+%218 = OpLoad %14 %213
+%219 = OpImageFetch %48 %218 %61
+%220 = OpCompositeExtract %9 %219 0
+%221 = OpFAdd %9 %220 %209
+OpBranch %380
 %380 = OpLabel
-%310 = OpBitwiseAnd %5 %202 %83
-%311 = OpIAdd %5 %310 %83
-%313 = OpAccessChain %57 %8 %81
-%314 = OpLoad %5 %313
-%315 = OpIAdd %5 %314 %311
-%316 = OpFunctionCall %5 %114 %315 %104 %317
-%312 = OpAccessChain %154 %32 %316
-%318 = OpBitcast %5 %304
-%319 = OpAccessChain %79 %312 %84 %202
-OpStore %319 %318
-OpBranch %381
+%222 = OpPhi %9 %209 %378 %221 %379
+%223 = OpUGreaterThan %62 %61 %110
+OpSelectionMerge %382 None
+OpBranchConditional %223 %381 %382
 %381 = OpLabel
-%320 = OpUGreaterThan %85 %202 %321
-OpSelectionMerge %383 None
-OpBranchConditional %320 %382 %383
+%226 = OpAccessChain %67 %8 %91
+%227 = OpLoad %5 %226
+%228 = OpIAdd %5 %227 %100
+%229 = OpFunctionCall %5 %120 %228 %110 %102
+%225 = OpAccessChain %224 %22 %229
+%230 = OpAccessChain %87 %225 %60 %61
+%231 = OpLoad %5 %230
+%232 = OpBitcast %9 %231
+%233 = OpFAdd %9 %232 %222
+OpBranch %382
 %382 = OpLabel
-%322 = OpBitcast %5 %304
-%323 = OpShiftLeftLogical %5 %202 %92
-%324 = OpAccessChain %79 %149 %84 %202
-OpStore %324 %322
-OpBranch %383
+%234 = OpPhi %9 %222 %380 %233 %381
+%235 = OpUGreaterThan %62 %61 %134
+OpSelectionMerge %384 None
+OpBranchConditional %235 %383 %384
 %383 = OpLabel
-%325 = OpUGreaterThan %85 %202 %326
-OpSelectionMerge %385 None
-OpBranchConditional %325 %384 %385
+%236 = OpBitwiseAnd %5 %61 %91
+%237 = OpIAdd %5 %236 %102
+%239 = OpAccessChain %67 %8 %91
+%240 = OpLoad %5 %239
+%241 = OpIAdd %5 %240 %237
+%242 = OpFunctionCall %5 %120 %241 %110 %110
+%238 = OpAccessChain %224 %22 %242
+%243 = OpAccessChain %87 %238 %60 %61
+%244 = OpLoad %5 %243
+%245 = OpBitcast %9 %244
+%246 = OpFAdd %9 %245 %234
+OpBranch %384
 %384 = OpLabel
-%327 = OpBitwiseAnd %5 %202 %83
-%328 = OpBitcast %5 %304
-%329 = OpShiftLeftLogical %5 %202 %92
-%330 = OpIAdd %5 %327 %81
-%332 = OpAccessChain %57 %8 %81
-%333 = OpLoad %5 %332
-%334 = OpIAdd %5 %333 %330
-%335 = OpFunctionCall %5 %114 %334 %104 %184
-%331 = OpAccessChain %148 %43 %335
-%336 = OpAccessChain %79 %331 %84 %202
-OpStore %336 %328
-OpBranch %385
+%247 = OpPhi %9 %234 %382 %246 %383
+%248 = OpUGreaterThan %62 %61 %249
+OpSelectionMerge %386 None
+OpBranchConditional %248 %385 %386
 %385 = OpLabel
-%337 = OpUGreaterThan %85 %202 %338
-OpSelectionMerge %387 None
-OpBranchConditional %337 %386 %387
+%252 = OpAccessChain %67 %8 %91
+%253 = OpLoad %5 %252
+%254 = OpIAdd %5 %253 %134
+%255 = OpFunctionCall %5 %120 %254 %110 %134
+%251 = OpAccessChain %250 %27 %255
+%256 = OpShiftLeftLogical %5 %61 %64
+%257 = OpAccessChain %87 %251 %60 %61
+%258 = OpLoad %5 %257
+%259 = OpBitcast %9 %258
+%260 = OpFAdd %9 %259 %247
+OpBranch %386
 %386 = OpLabel
-%339 = OpCompositeConstruct %64 %202 %84
-%340 = OpCompositeConstruct %48 %304 %304 %304 %304
-OpImageWrite %147 %339 %340
-OpBranch %387
+%261 = OpPhi %9 %247 %384 %260 %385
+%262 = OpUGreaterThan %62 %61 %263
+OpSelectionMerge %388 None
+OpBranchConditional %262 %387 %388
 %387 = OpLabel
-%341 = OpUGreaterThan %85 %202 %342
-OpSelectionMerge %389 None
-OpBranchConditional %341 %388 %389
+%264 = OpBitwiseAnd %5 %61 %91
+%265 = OpIAdd %5 %264 %249
+%267 = OpAccessChain %67 %8 %91
+%268 = OpLoad %5 %267
+%269 = OpIAdd %5 %268 %265
+%270 = OpFunctionCall %5 %120 %269 %110 %249
+%266 = OpAccessChain %250 %27 %270
+%271 = OpShiftRightLogical %5 %61 %64
+%272 = OpAccessChain %87 %266 %60 %271
+%273 = OpLoad %5 %272
+%274 = OpBitcast %9 %273
+%275 = OpFAdd %9 %274 %261
+OpBranch %388
 %388 = OpLabel
-%343 = OpBitwiseAnd %5 %202 %83
-%344 = OpIAdd %5 %343 %95
-%346 = OpAccessChain %57 %8 %59
+%276 = OpPhi %9 %261 %386 %275 %387
+%277 = OpUGreaterThan %62 %61 %91
+OpSelectionMerge %390 None
+OpBranchConditional %277 %389 %390
+%389 = OpLabel
+%280 = OpAccessChain %67 %8 %89
+%281 = OpLoad %5 %280
+%282 = OpFunctionCall %5 %120 %281 %110 %263
+%279 = OpAccessChain %278 %32 %282
+%285 = OpAccessChain %67 %8 %89
+%286 = OpLoad %5 %285
+%287 = OpFunctionCall %5 %120 %286 %288 %289
+%284 = OpAccessChain %283 %38 %60 %287
+%290 = OpLoad %34 %284
+%291 = OpBitcast %5 %276
+%292 = OpAccessChain %87 %279 %60 %61
+OpStore %292 %291
+OpBranch %390
+%390 = OpLabel
+%293 = OpUGreaterThan %62 %61 %294
+OpSelectionMerge %392 None
+OpBranchConditional %293 %391 %392
+%391 = OpLabel
+%295 = OpBitwiseAnd %5 %61 %91
+%296 = OpIAdd %5 %295 %91
+%298 = OpAccessChain %67 %8 %89
+%299 = OpLoad %5 %298
+%300 = OpIAdd %5 %299 %296
+%301 = OpFunctionCall %5 %120 %300 %110 %302
+%297 = OpAccessChain %278 %32 %301
+%303 = OpBitcast %5 %276
+%304 = OpAccessChain %87 %297 %60 %61
+OpStore %304 %303
+OpBranch %392
+%392 = OpLabel
+%305 = OpUGreaterThan %62 %61 %306
+OpSelectionMerge %394 None
+OpBranchConditional %305 %393 %394
+%393 = OpLabel
+%309 = OpAccessChain %67 %8 %89
+%310 = OpLoad %5 %309
+%311 = OpIAdd %5 %310 %96
+%312 = OpFunctionCall %5 %120 %311 %110 %313
+%308 = OpAccessChain %307 %43 %312
+%314 = OpBitcast %5 %276
+%315 = OpShiftLeftLogical %5 %61 %64
+%316 = OpAccessChain %87 %308 %60 %61
+OpStore %316 %314
+OpBranch %394
+%394 = OpLabel
+%317 = OpUGreaterThan %62 %61 %318
+OpSelectionMerge %396 None
+OpBranchConditional %317 %395 %396
+%395 = OpLabel
+%319 = OpBitwiseAnd %5 %61 %91
+%320 = OpBitcast %5 %276
+%321 = OpShiftLeftLogical %5 %61 %64
+%322 = OpIAdd %5 %319 %89
+%324 = OpAccessChain %67 %8 %89
+%325 = OpLoad %5 %324
+%326 = OpIAdd %5 %325 %322
+%327 = OpFunctionCall %5 %120 %326 %110 %328
+%323 = OpAccessChain %307 %43 %327
+%329 = OpAccessChain %87 %323 %60 %61
+OpStore %329 %320
+OpBranch %396
+%396 = OpLabel
+%330 = OpUGreaterThan %62 %61 %331
+OpSelectionMerge %398 None
+OpBranchConditional %330 %397 %398
+%397 = OpLabel
+%334 = OpAccessChain %67 %8 %96
+%335 = OpLoad %5 %334
+%336 = OpIAdd %5 %335 %100
+%337 = OpFunctionCall %5 %120 %336 %64 %204
+%333 = OpAccessChain %332 %47 %337
+%338 = OpLoad %44 %333
+%339 = OpCompositeConstruct %72 %61 %60
+%340 = OpCompositeConstruct %48 %276 %276 %276 %276
+OpImageWrite %338 %339 %340
+OpBranch %398
+%398 = OpLabel
+%341 = OpUGreaterThan %62 %61 %342
+OpSelectionMerge %400 None
+OpBranchConditional %341 %399 %400
+%399 = OpLabel
+%343 = OpBitwiseAnd %5 %61 %91
+%344 = OpIAdd %5 %343 %102
+%346 = OpAccessChain %67 %8 %96
 %347 = OpLoad %5 %346
 %348 = OpIAdd %5 %347 %344
-%349 = OpFunctionCall %5 %114 %348 %92 %350
-%345 = OpAccessChain %55 %47 %349
+%349 = OpFunctionCall %5 %120 %348 %64 %350
+%345 = OpAccessChain %332 %47 %349
 %351 = OpLoad %44 %345
-%352 = OpCompositeConstruct %64 %84 %202
-%353 = OpCompositeConstruct %48 %304 %304 %304 %304
+%352 = OpCompositeConstruct %72 %60 %61
+%353 = OpCompositeConstruct %48 %276 %276 %276 %276
 OpImageWrite %351 %352 %353
-OpBranch %389
-%389 = OpLabel
-%355 = OpAccessChain %354 %165 %84
-%356 = OpAtomicIAdd %5 %355 %83 %84 %83
+OpBranch %400
+%400 = OpLabel
+%355 = OpAccessChain %67 %8 %89
+%356 = OpLoad %5 %355
+%357 = OpFunctionCall %5 %120 %356 %110 %358
+%354 = OpAccessChain %278 %32 %357
+%360 = OpAccessChain %67 %8 %89
+%361 = OpLoad %5 %360
+%362 = OpFunctionCall %5 %120 %361 %288 %363
+%359 = OpAccessChain %283 %38 %60 %362
+%364 = OpLoad %34 %359
+%366 = OpAccessChain %365 %364 %60
+%367 = OpAtomicIAdd %5 %366 %91 %60 %91
 OpReturn
 OpFunctionEnd
-%77 = OpFunction %1 None %69
-%70 = OpFunctionParameter %5
-%71 = OpFunctionParameter %5
-%72 = OpFunctionParameter %5
-%73 = OpFunctionParameter %5
-%74 = OpFunctionParameter %5
-%75 = OpFunctionParameter %5
-%76 = OpFunctionParameter %5
-%78 = OpLabel
-%80 = OpAccessChain %79 %68 %81
-%82 = OpAtomicIAdd %5 %80 %83 %84 %83
-%86 = OpIEqual %85 %82 %84
-OpSelectionMerge %88 None
-OpBranchConditional %86 %87 %88
-%87 = OpLabel
-%89 = OpAccessChain %79 %68 %59
-OpStore %89 %72
-%90 = OpAccessChain %79 %68 %83
-OpStore %90 %71
-%91 = OpAccessChain %79 %68 %92
-OpStore %91 %73
-%93 = OpAccessChain %79 %68 %62
-OpStore %93 %74
-%94 = OpAccessChain %79 %68 %95
-OpStore %94 %75
-%96 = OpAccessChain %79 %68 %97
-OpStore %96 %76
-%101 = OpAccessChain %100 %68 %84
-OpStore %101 %99
-OpMemoryBarrier %83 %102
-%103 = OpAccessChain %79 %68 %104
-OpStore %103 %70
-OpBranch %88
-%88 = OpLabel
+%85 = OpFunction %1 None %77
+%78 = OpFunctionParameter %5
+%79 = OpFunctionParameter %5
+%80 = OpFunctionParameter %5
+%81 = OpFunctionParameter %5
+%82 = OpFunctionParameter %5
+%83 = OpFunctionParameter %5
+%84 = OpFunctionParameter %5
+%86 = OpLabel
+%88 = OpAccessChain %87 %76 %89
+%90 = OpAtomicIAdd %5 %88 %91 %60 %91
+%92 = OpIEqual %62 %90 %60
+OpSelectionMerge %94 None
+OpBranchConditional %92 %93 %94
+%93 = OpLabel
+%95 = OpAccessChain %87 %76 %96
+OpStore %95 %80
+%97 = OpAccessChain %87 %76 %91
+OpStore %97 %79
+%98 = OpAccessChain %87 %76 %64
+OpStore %98 %81
+%99 = OpAccessChain %87 %76 %100
+OpStore %99 %82
+%101 = OpAccessChain %87 %76 %102
+OpStore %101 %83
+%103 = OpAccessChain %87 %76 %69
+OpStore %103 %84
+%107 = OpAccessChain %106 %76 %60
+OpStore %107 %105
+OpMemoryBarrier %91 %108
+%109 = OpAccessChain %87 %76 %110
+OpStore %109 %78
+OpBranch %94
+%94 = OpLabel
 OpReturn
 OpFunctionEnd
-%114 = OpFunction %5 None %110
-%111 = OpFunctionParameter %5
-%112 = OpFunctionParameter %5
-%113 = OpFunctionParameter %5
-%115 = OpLabel
-%116 = OpAccessChain %79 %109 %84
-%117 = OpLoad %5 %116
-%118 = OpAccessChain %79 %109 %83
-%119 = OpLoad %5 %118
-%120 = OpAccessChain %100 %109 %92 %111
-%121 = OpLoad %64 %120
-%122 = OpCompositeExtract %5 %121 0
-%124 = OpShiftRightLogical %5 %122 %97
-%125 = OpBitwiseAnd %5 %122 %126
-%123 = OpCompositeExtract %5 %121 1
-%127 = OpAccessChain %79 %68 %128 %124
-%129 = OpLoad %5 %127
-%130 = OpShiftLeftLogical %5 %83 %125
-%131 = OpBitwiseAnd %5 %129 %130
-%132 = OpINotEqual %85 %131 %84
-%133 = OpBitwiseAnd %5 %123 %112
-%134 = OpIEqual %85 %133 %112
-%135 = OpUGreaterThanEqual %85 %111 %117
-%136 = OpSelect %5 %135 %83 %84
-%137 = OpSelect %5 %134 %84 %92
-%138 = OpSelect %5 %132 %84 %81
-%139 = OpBitwiseOr %5 %136 %137
-%140 = OpBitwiseOr %5 %139 %138
-%141 = OpINotEqual %85 %140 %84
-OpSelectionMerge %143 None
-OpBranchConditional %141 %142 %143
-%142 = OpLabel
-%144 = OpFunctionCall %1 %77 %140 %111 %122 %119 %112 %123 %113
+%120 = OpFunction %5 None %116
+%117 = OpFunctionParameter %5
+%118 = OpFunctionParameter %5
+%119 = OpFunctionParameter %5
+%121 = OpLabel
+%122 = OpAccessChain %87 %115 %60
+%123 = OpLoad %5 %122
+%124 = OpAccessChain %87 %115 %91
+%125 = OpLoad %5 %124
+%126 = OpAccessChain %106 %115 %64 %117
+%127 = OpLoad %72 %126
+%128 = OpCompositeExtract %5 %127 0
+%130 = OpShiftRightLogical %5 %128 %69
+%131 = OpBitwiseAnd %5 %128 %132
+%129 = OpCompositeExtract %5 %127 1
+%133 = OpAccessChain %87 %76 %134 %130
+%135 = OpLoad %5 %133
+%136 = OpShiftLeftLogical %5 %91 %131
+%137 = OpBitwiseAnd %5 %135 %136
+%138 = OpINotEqual %62 %137 %60
+%139 = OpBitwiseAnd %5 %129 %118
+%140 = OpIEqual %62 %139 %118
+%141 = OpUGreaterThanEqual %62 %117 %123
+%142 = OpSelect %5 %141 %91 %60
+%143 = OpSelect %5 %140 %60 %64
+%144 = OpSelect %5 %138 %60 %89
+%145 = OpBitwiseOr %5 %142 %143
+%146 = OpBitwiseOr %5 %145 %144
+%147 = OpINotEqual %62 %146 %60
+OpSelectionMerge %149 None
+OpBranchConditional %147 %148 %149
+%148 = OpLabel
+%150 = OpFunctionCall %1 %85 %146 %117 %128 %125 %118 %129 %119
+OpReturnValue %123
+%149 = OpLabel
 OpReturnValue %117
-%143 = OpLabel
-OpReturnValue %111
 OpFunctionEnd
 #endif

--- a/reference/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
@@ -1,0 +1,385 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 2, binding = 0) uniform sampler _17[];
+
+layout(location = 0) in vec2 UV;
+layout(location = 0) out vec4 SV_Target;
+bool discard_state;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _59 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_59 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _93 = QAHeapData.descriptor_count;
+    uint _95 = QAHeapData.heap_index;
+    uvec2 _97 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _105 = QAGlobalData.live_status_table[_97.x >> 5u];
+    uint _116 = (uint(heap_offset >= _93) | (((_97.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_105 & (1u << (_97.x & 31u))) != 0u) ? 0u : 4u);
+    if (_116 != 0u)
+    {
+        descriptor_qa_report_fault(_116, heap_offset, _97.x, _95, descriptor_type_mask, _97.y, instruction);
+        return _93;
+    }
+    return heap_offset;
+}
+
+void discard_exit()
+{
+    if (discard_state)
+    {
+        discard;
+    }
+}
+
+void main()
+{
+    discard_state = false;
+    uint _40 = descriptor_qa_check(registers._m0, 1u, 1u);
+    if (UV.x < 0.0)
+    {
+        discard_state = true;
+    }
+    vec4 _141 = texture(sampler2D(_13[_40], _17[registers._m2]), vec2(UV.x, UV.y));
+    SV_Target.x = _141.x;
+    SV_Target.y = _141.y;
+    SV_Target.z = _141.z;
+    SV_Target.w = _141.w;
+    discard_exit();
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 164
+; Schema: 0
+OpCapability Shader
+OpCapability RuntimeDescriptorArray
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Fragment %3 "main" %20 %23 %27
+OpExecutionMode %3 OriginUpperLeft
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %20 "UV"
+OpName %23 "SV_Target"
+OpName %43 "DescriptorHeapGlobalQAData"
+OpMemberName %43 0 "failed_shader_hash"
+OpMemberName %43 1 "failed_offset"
+OpMemberName %43 2 "failed_heap"
+OpMemberName %43 3 "failed_cookie"
+OpMemberName %43 4 "fault_atomic"
+OpMemberName %43 5 "failed_instruction"
+OpMemberName %43 6 "failed_descriptor_type_mask"
+OpMemberName %43 7 "actual_descriptor_type_mask"
+OpMemberName %43 8 "fault_type"
+OpMemberName %43 9 "live_status_table"
+OpName %45 "QAGlobalData"
+OpName %54 "descriptor_qa_report_fault"
+OpName %47 "fault_type"
+OpName %48 "heap_offset"
+OpName %49 "cookie"
+OpName %50 "heap_index"
+OpName %51 "descriptor_type"
+OpName %52 "actual_descriptor_type"
+OpName %53 "instruction"
+OpName %83 "DescriptorHeapQAData"
+OpMemberName %83 0 "descriptor_count"
+OpMemberName %83 1 "heap_index"
+OpMemberName %83 2 "cookies_descriptor_info"
+OpName %85 "QAHeapData"
+OpName %90 "descriptor_qa_check"
+OpName %87 "heap_offset"
+OpName %88 "descriptor_type_mask"
+OpName %89 "instruction"
+OpName %137 "discard_state"
+OpName %156 "discard_exit"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 2
+OpDecorate %17 Binding 0
+OpDecorate %20 Location 0
+OpDecorate %23 Location 0
+OpDecorate %27 BuiltIn SampleMask
+OpDecorate %42 ArrayStride 4
+OpMemberDecorate %43 0 Offset 0
+OpMemberDecorate %43 1 Offset 8
+OpMemberDecorate %43 2 Offset 12
+OpMemberDecorate %43 3 Offset 16
+OpMemberDecorate %43 4 Offset 20
+OpMemberDecorate %43 5 Offset 24
+OpMemberDecorate %43 6 Offset 28
+OpMemberDecorate %43 7 Offset 32
+OpMemberDecorate %43 8 Offset 36
+OpMemberDecorate %43 9 Offset 40
+OpDecorate %43 Block
+OpDecorate %45 DescriptorSet 10
+OpDecorate %45 Binding 10
+OpDecorate %82 ArrayStride 8
+OpMemberDecorate %83 0 Offset 0
+OpMemberDecorate %83 1 Offset 4
+OpMemberDecorate %83 2 Offset 8
+OpDecorate %83 Block
+OpDecorate %85 DescriptorSet 10
+OpDecorate %85 Binding 11
+OpDecorate %85 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeSampler
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeVector %9 2
+%19 = OpTypePointer Input %18
+%20 = OpVariable %19 Input
+%21 = OpTypeVector %9 4
+%22 = OpTypePointer Output %21
+%23 = OpVariable %22 Output
+%24 = OpConstant %5 1
+%25 = OpTypeArray %5 %24
+%26 = OpTypePointer Input %25
+%27 = OpVariable %26 Input
+%28 = OpTypePointer Input %5
+%30 = OpConstant %5 0
+%32 = OpTypeBool
+%35 = OpTypePointer UniformConstant %10
+%37 = OpTypePointer PushConstant %5
+%41 = OpTypeVector %5 2
+%42 = OpTypeRuntimeArray %5
+%43 = OpTypeStruct %41 %5 %5 %5 %5 %5 %5 %5 %5 %42
+%44 = OpTypePointer StorageBuffer %43
+%45 = OpVariable %44 StorageBuffer
+%46 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%56 = OpTypePointer StorageBuffer %5
+%58 = OpConstant %5 4
+%64 = OpConstant %5 3
+%67 = OpConstant %5 2
+%69 = OpConstant %5 6
+%71 = OpConstant %5 7
+%73 = OpConstant %5 5
+%74 = OpConstant %5 3735928559
+%75 = OpConstantComposite %41 %74 %30
+%76 = OpTypePointer StorageBuffer %41
+%78 = OpConstant %5 72
+%80 = OpConstant %5 8
+%82 = OpTypeRuntimeArray %41
+%83 = OpTypeStruct %5 %5 %82
+%84 = OpTypePointer StorageBuffer %83
+%85 = OpVariable %84 StorageBuffer
+%86 = OpTypeFunction %5 %5 %5 %5
+%102 = OpConstant %5 31
+%104 = OpConstant %5 9
+%124 = OpTypePointer UniformConstant %14
+%129 = OpTypePointer Input %9
+%135 = OpConstant %9 0
+%136 = OpTypePointer Private %32
+%137 = OpVariable %136 Private
+%138 = OpConstantFalse %32
+%139 = OpTypeSampledImage %10
+%147 = OpTypePointer Output %9
+%155 = OpConstantTrue %32
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpStore %137 %138
+OpBranch %152
+%152 = OpLabel
+%29 = OpAccessChain %28 %27 %30
+%31 = OpLoad %5 %29
+%33 = OpIEqual %32 %30 %31
+%34 = OpSelect %5 %33 %24 %30
+%38 = OpAccessChain %37 %8 %30
+%39 = OpLoad %5 %38
+%40 = OpFunctionCall %5 %90 %39 %24 %24
+%36 = OpAccessChain %35 %13 %40
+%123 = OpLoad %10 %36
+%126 = OpAccessChain %37 %8 %67
+%127 = OpLoad %5 %126
+%125 = OpAccessChain %124 %17 %127
+%128 = OpLoad %14 %125
+%130 = OpAccessChain %129 %20 %30
+%131 = OpLoad %9 %130
+%132 = OpAccessChain %129 %20 %24
+%133 = OpLoad %9 %132
+%134 = OpFOrdLessThan %32 %131 %135
+OpSelectionMerge %154 None
+OpBranchConditional %134 %153 %154
+%153 = OpLabel
+OpStore %137 %155
+OpBranch %154
+%154 = OpLabel
+%140 = OpSampledImage %139 %123 %128
+%142 = OpCompositeConstruct %18 %131 %133
+%141 = OpImageSampleImplicitLod %21 %140 %142 None
+%143 = OpCompositeExtract %9 %141 0
+%144 = OpCompositeExtract %9 %141 1
+%145 = OpCompositeExtract %9 %141 2
+%146 = OpCompositeExtract %9 %141 3
+%148 = OpAccessChain %147 %23 %30
+OpStore %148 %143
+%149 = OpAccessChain %147 %23 %24
+OpStore %149 %144
+%150 = OpAccessChain %147 %23 %67
+OpStore %150 %145
+%151 = OpAccessChain %147 %23 %64
+OpStore %151 %146
+%162 = OpFunctionCall %1 %156
+OpReturn
+OpFunctionEnd
+%54 = OpFunction %1 None %46
+%47 = OpFunctionParameter %5
+%48 = OpFunctionParameter %5
+%49 = OpFunctionParameter %5
+%50 = OpFunctionParameter %5
+%51 = OpFunctionParameter %5
+%52 = OpFunctionParameter %5
+%53 = OpFunctionParameter %5
+%55 = OpLabel
+%57 = OpAccessChain %56 %45 %58
+%59 = OpAtomicExchange %5 %57 %24 %30 %24
+%60 = OpIEqual %32 %59 %30
+OpSelectionMerge %62 None
+OpBranchConditional %60 %61 %62
+%61 = OpLabel
+%63 = OpAccessChain %56 %45 %64
+OpStore %63 %49
+%65 = OpAccessChain %56 %45 %24
+OpStore %65 %48
+%66 = OpAccessChain %56 %45 %67
+OpStore %66 %50
+%68 = OpAccessChain %56 %45 %69
+OpStore %68 %51
+%70 = OpAccessChain %56 %45 %71
+OpStore %70 %52
+%72 = OpAccessChain %56 %45 %73
+OpStore %72 %53
+%77 = OpAccessChain %76 %45 %30
+OpStore %77 %75
+OpMemoryBarrier %24 %78
+%79 = OpAccessChain %56 %45 %80
+OpStore %79 %47
+OpBranch %62
+%62 = OpLabel
+OpReturn
+OpFunctionEnd
+%90 = OpFunction %5 None %86
+%87 = OpFunctionParameter %5
+%88 = OpFunctionParameter %5
+%89 = OpFunctionParameter %5
+%91 = OpLabel
+%92 = OpAccessChain %56 %85 %30
+%93 = OpLoad %5 %92
+%94 = OpAccessChain %56 %85 %24
+%95 = OpLoad %5 %94
+%96 = OpAccessChain %76 %85 %67 %87
+%97 = OpLoad %41 %96
+%98 = OpCompositeExtract %5 %97 0
+%100 = OpShiftRightLogical %5 %98 %73
+%101 = OpBitwiseAnd %5 %98 %102
+%99 = OpCompositeExtract %5 %97 1
+%103 = OpAccessChain %56 %45 %104 %100
+%105 = OpLoad %5 %103
+%106 = OpShiftLeftLogical %5 %24 %101
+%107 = OpBitwiseAnd %5 %105 %106
+%108 = OpINotEqual %32 %107 %30
+%109 = OpBitwiseAnd %5 %99 %88
+%110 = OpIEqual %32 %109 %88
+%111 = OpUGreaterThanEqual %32 %87 %93
+%112 = OpSelect %5 %111 %24 %30
+%113 = OpSelect %5 %110 %30 %67
+%114 = OpSelect %5 %108 %30 %58
+%115 = OpBitwiseOr %5 %112 %113
+%116 = OpBitwiseOr %5 %115 %114
+%117 = OpINotEqual %32 %116 %30
+OpSelectionMerge %119 None
+OpBranchConditional %117 %118 %119
+%118 = OpLabel
+%120 = OpFunctionCall %1 %54 %116 %87 %98 %95 %88 %99 %89
+OpReturnValue %93
+%119 = OpLabel
+OpReturnValue %87
+OpFunctionEnd
+%156 = OpFunction %1 None %2
+%157 = OpLabel
+%160 = OpLoad %32 %137
+OpSelectionMerge %159 None
+OpBranchConditional %160 %158 %159
+%158 = OpLabel
+OpKill
+%159 = OpLabel
+OpReturn
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
@@ -44,7 +44,7 @@ bool discard_state;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _59 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _59 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_59 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -309,7 +309,7 @@ OpFunctionEnd
 %53 = OpFunctionParameter %5
 %55 = OpLabel
 %57 = OpAccessChain %56 %45 %58
-%59 = OpAtomicExchange %5 %57 %24 %30 %24
+%59 = OpAtomicIAdd %5 %57 %24 %30 %24
 %60 = OpIEqual %32 %59 %30
 OpSelectionMerge %62 None
 OpBranchConditional %60 %61 %62

--- a/reference/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
@@ -44,8 +44,8 @@ bool discard_state;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _59 = atomicAdd(QAGlobalData.fault_atomic, 1u);
-    if (_59 == 0u)
+    uint _69 = atomicAdd(QAGlobalData.fault_atomic, 1u);
+    if (_69 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
         QAGlobalData.failed_offset = heap_offset;
@@ -61,15 +61,15 @@ void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, 
 
 uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
 {
-    uint _93 = QAHeapData.descriptor_count;
-    uint _95 = QAHeapData.heap_index;
-    uvec2 _97 = QAHeapData.cookies_descriptor_info[heap_offset];
-    uint _105 = QAGlobalData.live_status_table[_97.x >> 5u];
-    uint _116 = (uint(heap_offset >= _93) | (((_97.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_105 & (1u << (_97.x & 31u))) != 0u) ? 0u : 4u);
-    if (_116 != 0u)
+    uint _103 = QAHeapData.descriptor_count;
+    uint _105 = QAHeapData.heap_index;
+    uvec2 _107 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _115 = QAGlobalData.live_status_table[_107.x >> 5u];
+    uint _126 = (uint(heap_offset >= _103) | (((_107.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_115 & (1u << (_107.x & 31u))) != 0u) ? 0u : 4u);
+    if (_126 != 0u)
     {
-        descriptor_qa_report_fault(_116, heap_offset, _97.x, _95, descriptor_type_mask, _97.y, instruction);
-        return _93;
+        descriptor_qa_report_fault(_126, heap_offset, _107.x, _105, descriptor_type_mask, _107.y, instruction);
+        return _103;
     }
     return heap_offset;
 }
@@ -85,12 +85,12 @@ void discard_exit()
 void main()
 {
     discard_state = false;
-    uint _40 = descriptor_qa_check(registers._m0, 1u, 1u);
     if (UV.x < 0.0)
     {
         discard_state = true;
     }
-    vec4 _141 = texture(sampler2D(_13[_40], _17[registers._m2]), vec2(UV.x, UV.y));
+    uint _50 = descriptor_qa_check(registers._m0, 1u, 1u);
+    vec4 _141 = texture(sampler2D(_13[_50], _17[registers._m2]), vec2(UV.x, UV.y));
     SV_Target.x = _141.x;
     SV_Target.y = _141.y;
     SV_Target.z = _141.z;
@@ -119,36 +119,36 @@ OpName %6 "RootConstants"
 OpName %8 "registers"
 OpName %20 "UV"
 OpName %23 "SV_Target"
-OpName %43 "DescriptorHeapGlobalQAData"
-OpMemberName %43 0 "failed_shader_hash"
-OpMemberName %43 1 "failed_offset"
-OpMemberName %43 2 "failed_heap"
-OpMemberName %43 3 "failed_cookie"
-OpMemberName %43 4 "fault_atomic"
-OpMemberName %43 5 "failed_instruction"
-OpMemberName %43 6 "failed_descriptor_type_mask"
-OpMemberName %43 7 "actual_descriptor_type_mask"
-OpMemberName %43 8 "fault_type"
-OpMemberName %43 9 "live_status_table"
-OpName %45 "QAGlobalData"
-OpName %54 "descriptor_qa_report_fault"
-OpName %47 "fault_type"
-OpName %48 "heap_offset"
-OpName %49 "cookie"
-OpName %50 "heap_index"
-OpName %51 "descriptor_type"
-OpName %52 "actual_descriptor_type"
-OpName %53 "instruction"
-OpName %83 "DescriptorHeapQAData"
-OpMemberName %83 0 "descriptor_count"
-OpMemberName %83 1 "heap_index"
-OpMemberName %83 2 "cookies_descriptor_info"
-OpName %85 "QAHeapData"
-OpName %90 "descriptor_qa_check"
-OpName %87 "heap_offset"
-OpName %88 "descriptor_type_mask"
-OpName %89 "instruction"
-OpName %137 "discard_state"
+OpName %43 "discard_state"
+OpName %53 "DescriptorHeapGlobalQAData"
+OpMemberName %53 0 "failed_shader_hash"
+OpMemberName %53 1 "failed_offset"
+OpMemberName %53 2 "failed_heap"
+OpMemberName %53 3 "failed_cookie"
+OpMemberName %53 4 "fault_atomic"
+OpMemberName %53 5 "failed_instruction"
+OpMemberName %53 6 "failed_descriptor_type_mask"
+OpMemberName %53 7 "actual_descriptor_type_mask"
+OpMemberName %53 8 "fault_type"
+OpMemberName %53 9 "live_status_table"
+OpName %55 "QAGlobalData"
+OpName %64 "descriptor_qa_report_fault"
+OpName %57 "fault_type"
+OpName %58 "heap_offset"
+OpName %59 "cookie"
+OpName %60 "heap_index"
+OpName %61 "descriptor_type"
+OpName %62 "actual_descriptor_type"
+OpName %63 "instruction"
+OpName %93 "DescriptorHeapQAData"
+OpMemberName %93 0 "descriptor_count"
+OpMemberName %93 1 "heap_index"
+OpMemberName %93 2 "cookies_descriptor_info"
+OpName %95 "QAHeapData"
+OpName %100 "descriptor_qa_check"
+OpName %97 "heap_offset"
+OpName %98 "descriptor_type_mask"
+OpName %99 "instruction"
 OpName %156 "discard_exit"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
@@ -166,28 +166,28 @@ OpDecorate %17 Binding 0
 OpDecorate %20 Location 0
 OpDecorate %23 Location 0
 OpDecorate %27 BuiltIn SampleMask
-OpDecorate %42 ArrayStride 4
-OpMemberDecorate %43 0 Offset 0
-OpMemberDecorate %43 1 Offset 8
-OpMemberDecorate %43 2 Offset 12
-OpMemberDecorate %43 3 Offset 16
-OpMemberDecorate %43 4 Offset 20
-OpMemberDecorate %43 5 Offset 24
-OpMemberDecorate %43 6 Offset 28
-OpMemberDecorate %43 7 Offset 32
-OpMemberDecorate %43 8 Offset 36
-OpMemberDecorate %43 9 Offset 40
-OpDecorate %43 Block
-OpDecorate %45 DescriptorSet 10
-OpDecorate %45 Binding 10
-OpDecorate %82 ArrayStride 8
-OpMemberDecorate %83 0 Offset 0
-OpMemberDecorate %83 1 Offset 4
-OpMemberDecorate %83 2 Offset 8
-OpDecorate %83 Block
-OpDecorate %85 DescriptorSet 10
-OpDecorate %85 Binding 11
-OpDecorate %85 NonWritable
+OpDecorate %52 ArrayStride 4
+OpMemberDecorate %53 0 Offset 0
+OpMemberDecorate %53 1 Offset 8
+OpMemberDecorate %53 2 Offset 12
+OpMemberDecorate %53 3 Offset 16
+OpMemberDecorate %53 4 Offset 20
+OpMemberDecorate %53 5 Offset 24
+OpMemberDecorate %53 6 Offset 28
+OpMemberDecorate %53 7 Offset 32
+OpMemberDecorate %53 8 Offset 36
+OpMemberDecorate %53 9 Offset 40
+OpDecorate %53 Block
+OpDecorate %55 DescriptorSet 10
+OpDecorate %55 Binding 10
+OpDecorate %92 ArrayStride 8
+OpMemberDecorate %93 0 Offset 0
+OpMemberDecorate %93 1 Offset 4
+OpMemberDecorate %93 2 Offset 8
+OpDecorate %93 Block
+OpDecorate %95 DescriptorSet 10
+OpDecorate %95 Binding 11
+OpDecorate %95 NonWritable
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -216,73 +216,73 @@ OpDecorate %85 NonWritable
 %28 = OpTypePointer Input %5
 %30 = OpConstant %5 0
 %32 = OpTypeBool
-%35 = OpTypePointer UniformConstant %10
-%37 = OpTypePointer PushConstant %5
-%41 = OpTypeVector %5 2
-%42 = OpTypeRuntimeArray %5
-%43 = OpTypeStruct %41 %5 %5 %5 %5 %5 %5 %5 %5 %42
-%44 = OpTypePointer StorageBuffer %43
-%45 = OpVariable %44 StorageBuffer
-%46 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
-%56 = OpTypePointer StorageBuffer %5
-%58 = OpConstant %5 4
-%64 = OpConstant %5 3
-%67 = OpConstant %5 2
-%69 = OpConstant %5 6
-%71 = OpConstant %5 7
-%73 = OpConstant %5 5
-%74 = OpConstant %5 3735928559
-%75 = OpConstantComposite %41 %74 %30
-%76 = OpTypePointer StorageBuffer %41
-%78 = OpConstant %5 72
-%80 = OpConstant %5 8
-%82 = OpTypeRuntimeArray %41
-%83 = OpTypeStruct %5 %5 %82
-%84 = OpTypePointer StorageBuffer %83
-%85 = OpVariable %84 StorageBuffer
-%86 = OpTypeFunction %5 %5 %5 %5
-%102 = OpConstant %5 31
-%104 = OpConstant %5 9
-%124 = OpTypePointer UniformConstant %14
-%129 = OpTypePointer Input %9
-%135 = OpConstant %9 0
-%136 = OpTypePointer Private %32
-%137 = OpVariable %136 Private
-%138 = OpConstantFalse %32
+%35 = OpTypePointer Input %9
+%41 = OpConstant %9 0
+%42 = OpTypePointer Private %32
+%43 = OpVariable %42 Private
+%44 = OpConstantFalse %32
+%45 = OpTypePointer UniformConstant %10
+%47 = OpTypePointer PushConstant %5
+%51 = OpTypeVector %5 2
+%52 = OpTypeRuntimeArray %5
+%53 = OpTypeStruct %51 %5 %5 %5 %5 %5 %5 %5 %5 %52
+%54 = OpTypePointer StorageBuffer %53
+%55 = OpVariable %54 StorageBuffer
+%56 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%66 = OpTypePointer StorageBuffer %5
+%68 = OpConstant %5 4
+%74 = OpConstant %5 3
+%77 = OpConstant %5 2
+%79 = OpConstant %5 6
+%81 = OpConstant %5 7
+%83 = OpConstant %5 5
+%84 = OpConstant %5 3735928559
+%85 = OpConstantComposite %51 %84 %30
+%86 = OpTypePointer StorageBuffer %51
+%88 = OpConstant %5 72
+%90 = OpConstant %5 8
+%92 = OpTypeRuntimeArray %51
+%93 = OpTypeStruct %5 %5 %92
+%94 = OpTypePointer StorageBuffer %93
+%95 = OpVariable %94 StorageBuffer
+%96 = OpTypeFunction %5 %5 %5 %5
+%112 = OpConstant %5 31
+%114 = OpConstant %5 9
+%134 = OpTypePointer UniformConstant %14
 %139 = OpTypeSampledImage %10
 %147 = OpTypePointer Output %9
 %155 = OpConstantTrue %32
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpStore %137 %138
+OpStore %43 %44
 OpBranch %152
 %152 = OpLabel
 %29 = OpAccessChain %28 %27 %30
 %31 = OpLoad %5 %29
 %33 = OpIEqual %32 %30 %31
 %34 = OpSelect %5 %33 %24 %30
-%38 = OpAccessChain %37 %8 %30
-%39 = OpLoad %5 %38
-%40 = OpFunctionCall %5 %90 %39 %24 %24
-%36 = OpAccessChain %35 %13 %40
-%123 = OpLoad %10 %36
-%126 = OpAccessChain %37 %8 %67
-%127 = OpLoad %5 %126
-%125 = OpAccessChain %124 %17 %127
-%128 = OpLoad %14 %125
-%130 = OpAccessChain %129 %20 %30
-%131 = OpLoad %9 %130
-%132 = OpAccessChain %129 %20 %24
-%133 = OpLoad %9 %132
-%134 = OpFOrdLessThan %32 %131 %135
+%36 = OpAccessChain %35 %20 %30
+%37 = OpLoad %9 %36
+%38 = OpAccessChain %35 %20 %24
+%39 = OpLoad %9 %38
+%40 = OpFOrdLessThan %32 %37 %41
 OpSelectionMerge %154 None
-OpBranchConditional %134 %153 %154
+OpBranchConditional %40 %153 %154
 %153 = OpLabel
-OpStore %137 %155
+OpStore %43 %155
 OpBranch %154
 %154 = OpLabel
-%140 = OpSampledImage %139 %123 %128
-%142 = OpCompositeConstruct %18 %131 %133
+%48 = OpAccessChain %47 %8 %30
+%49 = OpLoad %5 %48
+%50 = OpFunctionCall %5 %100 %49 %24 %24
+%46 = OpAccessChain %45 %13 %50
+%133 = OpLoad %10 %46
+%136 = OpAccessChain %47 %8 %77
+%137 = OpLoad %5 %136
+%135 = OpAccessChain %134 %17 %137
+%138 = OpLoad %14 %135
+%140 = OpSampledImage %139 %133 %138
+%142 = OpCompositeConstruct %18 %37 %39
 %141 = OpImageSampleImplicitLod %21 %140 %142 None
 %143 = OpCompositeExtract %9 %141 0
 %144 = OpCompositeExtract %9 %141 1
@@ -292,89 +292,89 @@ OpBranch %154
 OpStore %148 %143
 %149 = OpAccessChain %147 %23 %24
 OpStore %149 %144
-%150 = OpAccessChain %147 %23 %67
+%150 = OpAccessChain %147 %23 %77
 OpStore %150 %145
-%151 = OpAccessChain %147 %23 %64
+%151 = OpAccessChain %147 %23 %74
 OpStore %151 %146
 %162 = OpFunctionCall %1 %156
 OpReturn
 OpFunctionEnd
-%54 = OpFunction %1 None %46
-%47 = OpFunctionParameter %5
-%48 = OpFunctionParameter %5
-%49 = OpFunctionParameter %5
-%50 = OpFunctionParameter %5
-%51 = OpFunctionParameter %5
-%52 = OpFunctionParameter %5
-%53 = OpFunctionParameter %5
-%55 = OpLabel
-%57 = OpAccessChain %56 %45 %58
-%59 = OpAtomicIAdd %5 %57 %24 %30 %24
-%60 = OpIEqual %32 %59 %30
-OpSelectionMerge %62 None
-OpBranchConditional %60 %61 %62
-%61 = OpLabel
-%63 = OpAccessChain %56 %45 %64
-OpStore %63 %49
-%65 = OpAccessChain %56 %45 %24
-OpStore %65 %48
-%66 = OpAccessChain %56 %45 %67
-OpStore %66 %50
-%68 = OpAccessChain %56 %45 %69
-OpStore %68 %51
-%70 = OpAccessChain %56 %45 %71
-OpStore %70 %52
-%72 = OpAccessChain %56 %45 %73
-OpStore %72 %53
-%77 = OpAccessChain %76 %45 %30
-OpStore %77 %75
-OpMemoryBarrier %24 %78
-%79 = OpAccessChain %56 %45 %80
-OpStore %79 %47
-OpBranch %62
-%62 = OpLabel
+%64 = OpFunction %1 None %56
+%57 = OpFunctionParameter %5
+%58 = OpFunctionParameter %5
+%59 = OpFunctionParameter %5
+%60 = OpFunctionParameter %5
+%61 = OpFunctionParameter %5
+%62 = OpFunctionParameter %5
+%63 = OpFunctionParameter %5
+%65 = OpLabel
+%67 = OpAccessChain %66 %55 %68
+%69 = OpAtomicIAdd %5 %67 %24 %30 %24
+%70 = OpIEqual %32 %69 %30
+OpSelectionMerge %72 None
+OpBranchConditional %70 %71 %72
+%71 = OpLabel
+%73 = OpAccessChain %66 %55 %74
+OpStore %73 %59
+%75 = OpAccessChain %66 %55 %24
+OpStore %75 %58
+%76 = OpAccessChain %66 %55 %77
+OpStore %76 %60
+%78 = OpAccessChain %66 %55 %79
+OpStore %78 %61
+%80 = OpAccessChain %66 %55 %81
+OpStore %80 %62
+%82 = OpAccessChain %66 %55 %83
+OpStore %82 %63
+%87 = OpAccessChain %86 %55 %30
+OpStore %87 %85
+OpMemoryBarrier %24 %88
+%89 = OpAccessChain %66 %55 %90
+OpStore %89 %57
+OpBranch %72
+%72 = OpLabel
 OpReturn
 OpFunctionEnd
-%90 = OpFunction %5 None %86
-%87 = OpFunctionParameter %5
-%88 = OpFunctionParameter %5
-%89 = OpFunctionParameter %5
-%91 = OpLabel
-%92 = OpAccessChain %56 %85 %30
-%93 = OpLoad %5 %92
-%94 = OpAccessChain %56 %85 %24
-%95 = OpLoad %5 %94
-%96 = OpAccessChain %76 %85 %67 %87
-%97 = OpLoad %41 %96
-%98 = OpCompositeExtract %5 %97 0
-%100 = OpShiftRightLogical %5 %98 %73
-%101 = OpBitwiseAnd %5 %98 %102
-%99 = OpCompositeExtract %5 %97 1
-%103 = OpAccessChain %56 %45 %104 %100
-%105 = OpLoad %5 %103
-%106 = OpShiftLeftLogical %5 %24 %101
-%107 = OpBitwiseAnd %5 %105 %106
-%108 = OpINotEqual %32 %107 %30
-%109 = OpBitwiseAnd %5 %99 %88
-%110 = OpIEqual %32 %109 %88
-%111 = OpUGreaterThanEqual %32 %87 %93
-%112 = OpSelect %5 %111 %24 %30
-%113 = OpSelect %5 %110 %30 %67
-%114 = OpSelect %5 %108 %30 %58
-%115 = OpBitwiseOr %5 %112 %113
-%116 = OpBitwiseOr %5 %115 %114
-%117 = OpINotEqual %32 %116 %30
-OpSelectionMerge %119 None
-OpBranchConditional %117 %118 %119
-%118 = OpLabel
-%120 = OpFunctionCall %1 %54 %116 %87 %98 %95 %88 %99 %89
-OpReturnValue %93
-%119 = OpLabel
-OpReturnValue %87
+%100 = OpFunction %5 None %96
+%97 = OpFunctionParameter %5
+%98 = OpFunctionParameter %5
+%99 = OpFunctionParameter %5
+%101 = OpLabel
+%102 = OpAccessChain %66 %95 %30
+%103 = OpLoad %5 %102
+%104 = OpAccessChain %66 %95 %24
+%105 = OpLoad %5 %104
+%106 = OpAccessChain %86 %95 %77 %97
+%107 = OpLoad %51 %106
+%108 = OpCompositeExtract %5 %107 0
+%110 = OpShiftRightLogical %5 %108 %83
+%111 = OpBitwiseAnd %5 %108 %112
+%109 = OpCompositeExtract %5 %107 1
+%113 = OpAccessChain %66 %55 %114 %110
+%115 = OpLoad %5 %113
+%116 = OpShiftLeftLogical %5 %24 %111
+%117 = OpBitwiseAnd %5 %115 %116
+%118 = OpINotEqual %32 %117 %30
+%119 = OpBitwiseAnd %5 %109 %98
+%120 = OpIEqual %32 %119 %98
+%121 = OpUGreaterThanEqual %32 %97 %103
+%122 = OpSelect %5 %121 %24 %30
+%123 = OpSelect %5 %120 %30 %77
+%124 = OpSelect %5 %118 %30 %68
+%125 = OpBitwiseOr %5 %122 %123
+%126 = OpBitwiseOr %5 %125 %124
+%127 = OpINotEqual %32 %126 %30
+OpSelectionMerge %129 None
+OpBranchConditional %127 %128 %129
+%128 = OpLabel
+%130 = OpFunctionCall %1 %64 %126 %97 %108 %105 %98 %109 %99
+OpReturnValue %103
+%129 = OpLabel
+OpReturnValue %97
 OpFunctionEnd
 %156 = OpFunction %1 None %2
 %157 = OpLabel
-%160 = OpLoad %32 %137
+%160 = OpLoad %32 %43
 OpSelectionMerge %159 None
 OpBranchConditional %160 %158 %159
 %158 = OpLabel

--- a/reference/shaders/descriptor_qa/early-3.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-3.bindless.descriptor-qa.frag
@@ -1,0 +1,343 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 2, binding = 0) uniform sampler _17[];
+
+layout(location = 0) in vec2 UV;
+layout(location = 0) out vec4 SV_Target;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _51 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_51 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _87 = QAHeapData.descriptor_count;
+    uint _89 = QAHeapData.heap_index;
+    uvec2 _91 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _99 = QAGlobalData.live_status_table[_91.x >> 5u];
+    uint _110 = (uint(heap_offset >= _87) | (((_91.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_99 & (1u << (_91.x & 31u))) != 0u) ? 0u : 4u);
+    if (_110 != 0u)
+    {
+        descriptor_qa_report_fault(_110, heap_offset, _91.x, _89, descriptor_type_mask, _91.y, instruction);
+        return _87;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _32 = descriptor_qa_check(registers._m0, 1u, 1u);
+    vec4 _131 = texture(sampler2D(_13[_32], _17[registers._m2]), vec2(UV.x, UV.y));
+    SV_Target.x = _131.x;
+    SV_Target.y = _131.y;
+    SV_Target.z = _131.z;
+    SV_Target.w = _131.w;
+    gl_FragDepth = 0.5;
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 144
+; Schema: 0
+OpCapability Shader
+OpCapability RuntimeDescriptorArray
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Fragment %3 "main" %20 %23 %25
+OpExecutionMode %3 OriginUpperLeft
+OpExecutionMode %3 DepthReplacing
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %20 "UV"
+OpName %23 "SV_Target"
+OpName %25 "SV_Depth"
+OpName %35 "DescriptorHeapGlobalQAData"
+OpMemberName %35 0 "failed_shader_hash"
+OpMemberName %35 1 "failed_offset"
+OpMemberName %35 2 "failed_heap"
+OpMemberName %35 3 "failed_cookie"
+OpMemberName %35 4 "fault_atomic"
+OpMemberName %35 5 "failed_instruction"
+OpMemberName %35 6 "failed_descriptor_type_mask"
+OpMemberName %35 7 "actual_descriptor_type_mask"
+OpMemberName %35 8 "fault_type"
+OpMemberName %35 9 "live_status_table"
+OpName %37 "QAGlobalData"
+OpName %46 "descriptor_qa_report_fault"
+OpName %39 "fault_type"
+OpName %40 "heap_offset"
+OpName %41 "cookie"
+OpName %42 "heap_index"
+OpName %43 "descriptor_type"
+OpName %44 "actual_descriptor_type"
+OpName %45 "instruction"
+OpName %77 "DescriptorHeapQAData"
+OpMemberName %77 0 "descriptor_count"
+OpMemberName %77 1 "heap_index"
+OpMemberName %77 2 "cookies_descriptor_info"
+OpName %79 "QAHeapData"
+OpName %84 "descriptor_qa_check"
+OpName %81 "heap_offset"
+OpName %82 "descriptor_type_mask"
+OpName %83 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 2
+OpDecorate %17 Binding 0
+OpDecorate %20 Location 0
+OpDecorate %23 Location 0
+OpDecorate %25 BuiltIn FragDepth
+OpDecorate %34 ArrayStride 4
+OpMemberDecorate %35 0 Offset 0
+OpMemberDecorate %35 1 Offset 8
+OpMemberDecorate %35 2 Offset 12
+OpMemberDecorate %35 3 Offset 16
+OpMemberDecorate %35 4 Offset 20
+OpMemberDecorate %35 5 Offset 24
+OpMemberDecorate %35 6 Offset 28
+OpMemberDecorate %35 7 Offset 32
+OpMemberDecorate %35 8 Offset 36
+OpMemberDecorate %35 9 Offset 40
+OpDecorate %35 Block
+OpDecorate %37 DescriptorSet 10
+OpDecorate %37 Binding 10
+OpDecorate %76 ArrayStride 8
+OpMemberDecorate %77 0 Offset 0
+OpMemberDecorate %77 1 Offset 4
+OpMemberDecorate %77 2 Offset 8
+OpDecorate %77 Block
+OpDecorate %79 DescriptorSet 10
+OpDecorate %79 Binding 11
+OpDecorate %79 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeSampler
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeVector %9 2
+%19 = OpTypePointer Input %18
+%20 = OpVariable %19 Input
+%21 = OpTypeVector %9 4
+%22 = OpTypePointer Output %21
+%23 = OpVariable %22 Output
+%24 = OpTypePointer Output %9
+%25 = OpVariable %24 Output
+%26 = OpTypePointer UniformConstant %10
+%28 = OpTypePointer PushConstant %5
+%30 = OpConstant %5 0
+%33 = OpTypeVector %5 2
+%34 = OpTypeRuntimeArray %5
+%35 = OpTypeStruct %33 %5 %5 %5 %5 %5 %5 %5 %5 %34
+%36 = OpTypePointer StorageBuffer %35
+%37 = OpVariable %36 StorageBuffer
+%38 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%48 = OpTypePointer StorageBuffer %5
+%50 = OpConstant %5 4
+%52 = OpConstant %5 1
+%53 = OpTypeBool
+%58 = OpConstant %5 3
+%61 = OpConstant %5 2
+%63 = OpConstant %5 6
+%65 = OpConstant %5 7
+%67 = OpConstant %5 5
+%68 = OpConstant %5 3735928559
+%69 = OpConstantComposite %33 %68 %30
+%70 = OpTypePointer StorageBuffer %33
+%72 = OpConstant %5 72
+%74 = OpConstant %5 8
+%76 = OpTypeRuntimeArray %33
+%77 = OpTypeStruct %5 %5 %76
+%78 = OpTypePointer StorageBuffer %77
+%79 = OpVariable %78 StorageBuffer
+%80 = OpTypeFunction %5 %5 %5 %5
+%96 = OpConstant %5 31
+%98 = OpConstant %5 9
+%118 = OpTypePointer UniformConstant %14
+%123 = OpTypePointer Input %9
+%128 = OpTypeSampledImage %10
+%130 = OpConstant %9 0
+%141 = OpConstant %9 0.5
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %142
+%142 = OpLabel
+%29 = OpAccessChain %28 %8 %30
+%31 = OpLoad %5 %29
+%32 = OpFunctionCall %5 %84 %31 %52 %52
+%27 = OpAccessChain %26 %13 %32
+%117 = OpLoad %10 %27
+%120 = OpAccessChain %28 %8 %61
+%121 = OpLoad %5 %120
+%119 = OpAccessChain %118 %17 %121
+%122 = OpLoad %14 %119
+%124 = OpAccessChain %123 %20 %30
+%125 = OpLoad %9 %124
+%126 = OpAccessChain %123 %20 %52
+%127 = OpLoad %9 %126
+%129 = OpSampledImage %128 %117 %122
+%132 = OpCompositeConstruct %18 %125 %127
+%131 = OpImageSampleImplicitLod %21 %129 %132 None
+%133 = OpCompositeExtract %9 %131 0
+%134 = OpCompositeExtract %9 %131 1
+%135 = OpCompositeExtract %9 %131 2
+%136 = OpCompositeExtract %9 %131 3
+%137 = OpAccessChain %24 %23 %30
+OpStore %137 %133
+%138 = OpAccessChain %24 %23 %52
+OpStore %138 %134
+%139 = OpAccessChain %24 %23 %61
+OpStore %139 %135
+%140 = OpAccessChain %24 %23 %58
+OpStore %140 %136
+OpStore %25 %141
+OpReturn
+OpFunctionEnd
+%46 = OpFunction %1 None %38
+%39 = OpFunctionParameter %5
+%40 = OpFunctionParameter %5
+%41 = OpFunctionParameter %5
+%42 = OpFunctionParameter %5
+%43 = OpFunctionParameter %5
+%44 = OpFunctionParameter %5
+%45 = OpFunctionParameter %5
+%47 = OpLabel
+%49 = OpAccessChain %48 %37 %50
+%51 = OpAtomicExchange %5 %49 %52 %30 %52
+%54 = OpIEqual %53 %51 %30
+OpSelectionMerge %56 None
+OpBranchConditional %54 %55 %56
+%55 = OpLabel
+%57 = OpAccessChain %48 %37 %58
+OpStore %57 %41
+%59 = OpAccessChain %48 %37 %52
+OpStore %59 %40
+%60 = OpAccessChain %48 %37 %61
+OpStore %60 %42
+%62 = OpAccessChain %48 %37 %63
+OpStore %62 %43
+%64 = OpAccessChain %48 %37 %65
+OpStore %64 %44
+%66 = OpAccessChain %48 %37 %67
+OpStore %66 %45
+%71 = OpAccessChain %70 %37 %30
+OpStore %71 %69
+OpMemoryBarrier %52 %72
+%73 = OpAccessChain %48 %37 %74
+OpStore %73 %39
+OpBranch %56
+%56 = OpLabel
+OpReturn
+OpFunctionEnd
+%84 = OpFunction %5 None %80
+%81 = OpFunctionParameter %5
+%82 = OpFunctionParameter %5
+%83 = OpFunctionParameter %5
+%85 = OpLabel
+%86 = OpAccessChain %48 %79 %30
+%87 = OpLoad %5 %86
+%88 = OpAccessChain %48 %79 %52
+%89 = OpLoad %5 %88
+%90 = OpAccessChain %70 %79 %61 %81
+%91 = OpLoad %33 %90
+%92 = OpCompositeExtract %5 %91 0
+%94 = OpShiftRightLogical %5 %92 %67
+%95 = OpBitwiseAnd %5 %92 %96
+%93 = OpCompositeExtract %5 %91 1
+%97 = OpAccessChain %48 %37 %98 %94
+%99 = OpLoad %5 %97
+%100 = OpShiftLeftLogical %5 %52 %95
+%101 = OpBitwiseAnd %5 %99 %100
+%102 = OpINotEqual %53 %101 %30
+%103 = OpBitwiseAnd %5 %93 %82
+%104 = OpIEqual %53 %103 %82
+%105 = OpUGreaterThanEqual %53 %81 %87
+%106 = OpSelect %5 %105 %52 %30
+%107 = OpSelect %5 %104 %30 %61
+%108 = OpSelect %5 %102 %30 %50
+%109 = OpBitwiseOr %5 %106 %107
+%110 = OpBitwiseOr %5 %109 %108
+%111 = OpINotEqual %53 %110 %30
+OpSelectionMerge %113 None
+OpBranchConditional %111 %112 %113
+%112 = OpLabel
+%114 = OpFunctionCall %1 %46 %110 %81 %92 %89 %82 %93 %83
+OpReturnValue %87
+%113 = OpLabel
+OpReturnValue %81
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/early-3.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-3.bindless.descriptor-qa.frag
@@ -43,7 +43,7 @@ layout(location = 0) out vec4 SV_Target;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _51 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _51 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_51 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -277,7 +277,7 @@ OpFunctionEnd
 %45 = OpFunctionParameter %5
 %47 = OpLabel
 %49 = OpAccessChain %48 %37 %50
-%51 = OpAtomicExchange %5 %49 %52 %30 %52
+%51 = OpAtomicIAdd %5 %49 %52 %30 %52
 %54 = OpIEqual %53 %51 %30
 OpSelectionMerge %56 None
 OpBranchConditional %54 %55 %56

--- a/reference/shaders/descriptor_qa/early-4.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-4.bindless.descriptor-qa.frag
@@ -1,0 +1,345 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 2, binding = 0) uniform sampler _17[];
+
+layout(location = 0) in vec2 UV;
+layout(location = 0) out vec4 SV_Target;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _53 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_53 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _88 = QAHeapData.descriptor_count;
+    uint _90 = QAHeapData.heap_index;
+    uvec2 _92 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _100 = QAGlobalData.live_status_table[_92.x >> 5u];
+    uint _111 = (uint(heap_offset >= _88) | (((_92.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_100 & (1u << (_92.x & 31u))) != 0u) ? 0u : 4u);
+    if (_111 != 0u)
+    {
+        descriptor_qa_report_fault(_111, heap_offset, _92.x, _90, descriptor_type_mask, _92.y, instruction);
+        return _88;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _34 = descriptor_qa_check(registers._m0, 1u, 1u);
+    vec4 _132 = texture(sampler2D(_13[_34], _17[registers._m2]), vec2(UV.x, UV.y));
+    SV_Target.x = _132.x;
+    SV_Target.y = _132.y;
+    SV_Target.z = _132.z;
+    SV_Target.w = _132.w;
+    gl_SampleMask[0u] = int(3u);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 147
+; Schema: 0
+OpCapability Shader
+OpCapability RuntimeDescriptorArray
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Fragment %3 "main" %20 %23 %27
+OpExecutionMode %3 OriginUpperLeft
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %20 "UV"
+OpName %23 "SV_Target"
+OpName %27 "SV_Coverage"
+OpName %37 "DescriptorHeapGlobalQAData"
+OpMemberName %37 0 "failed_shader_hash"
+OpMemberName %37 1 "failed_offset"
+OpMemberName %37 2 "failed_heap"
+OpMemberName %37 3 "failed_cookie"
+OpMemberName %37 4 "fault_atomic"
+OpMemberName %37 5 "failed_instruction"
+OpMemberName %37 6 "failed_descriptor_type_mask"
+OpMemberName %37 7 "actual_descriptor_type_mask"
+OpMemberName %37 8 "fault_type"
+OpMemberName %37 9 "live_status_table"
+OpName %39 "QAGlobalData"
+OpName %48 "descriptor_qa_report_fault"
+OpName %41 "fault_type"
+OpName %42 "heap_offset"
+OpName %43 "cookie"
+OpName %44 "heap_index"
+OpName %45 "descriptor_type"
+OpName %46 "actual_descriptor_type"
+OpName %47 "instruction"
+OpName %78 "DescriptorHeapQAData"
+OpMemberName %78 0 "descriptor_count"
+OpMemberName %78 1 "heap_index"
+OpMemberName %78 2 "cookies_descriptor_info"
+OpName %80 "QAHeapData"
+OpName %85 "descriptor_qa_check"
+OpName %82 "heap_offset"
+OpName %83 "descriptor_type_mask"
+OpName %84 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 2
+OpDecorate %17 Binding 0
+OpDecorate %20 Location 0
+OpDecorate %23 Location 0
+OpDecorate %27 BuiltIn SampleMask
+OpDecorate %36 ArrayStride 4
+OpMemberDecorate %37 0 Offset 0
+OpMemberDecorate %37 1 Offset 8
+OpMemberDecorate %37 2 Offset 12
+OpMemberDecorate %37 3 Offset 16
+OpMemberDecorate %37 4 Offset 20
+OpMemberDecorate %37 5 Offset 24
+OpMemberDecorate %37 6 Offset 28
+OpMemberDecorate %37 7 Offset 32
+OpMemberDecorate %37 8 Offset 36
+OpMemberDecorate %37 9 Offset 40
+OpDecorate %37 Block
+OpDecorate %39 DescriptorSet 10
+OpDecorate %39 Binding 10
+OpDecorate %77 ArrayStride 8
+OpMemberDecorate %78 0 Offset 0
+OpMemberDecorate %78 1 Offset 4
+OpMemberDecorate %78 2 Offset 8
+OpDecorate %78 Block
+OpDecorate %80 DescriptorSet 10
+OpDecorate %80 Binding 11
+OpDecorate %80 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeSampler
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeVector %9 2
+%19 = OpTypePointer Input %18
+%20 = OpVariable %19 Input
+%21 = OpTypeVector %9 4
+%22 = OpTypePointer Output %21
+%23 = OpVariable %22 Output
+%24 = OpConstant %5 1
+%25 = OpTypeArray %5 %24
+%26 = OpTypePointer Output %25
+%27 = OpVariable %26 Output
+%28 = OpTypePointer UniformConstant %10
+%30 = OpTypePointer PushConstant %5
+%32 = OpConstant %5 0
+%35 = OpTypeVector %5 2
+%36 = OpTypeRuntimeArray %5
+%37 = OpTypeStruct %35 %5 %5 %5 %5 %5 %5 %5 %5 %36
+%38 = OpTypePointer StorageBuffer %37
+%39 = OpVariable %38 StorageBuffer
+%40 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%50 = OpTypePointer StorageBuffer %5
+%52 = OpConstant %5 4
+%54 = OpTypeBool
+%59 = OpConstant %5 3
+%62 = OpConstant %5 2
+%64 = OpConstant %5 6
+%66 = OpConstant %5 7
+%68 = OpConstant %5 5
+%69 = OpConstant %5 3735928559
+%70 = OpConstantComposite %35 %69 %32
+%71 = OpTypePointer StorageBuffer %35
+%73 = OpConstant %5 72
+%75 = OpConstant %5 8
+%77 = OpTypeRuntimeArray %35
+%78 = OpTypeStruct %5 %5 %77
+%79 = OpTypePointer StorageBuffer %78
+%80 = OpVariable %79 StorageBuffer
+%81 = OpTypeFunction %5 %5 %5 %5
+%97 = OpConstant %5 31
+%99 = OpConstant %5 9
+%119 = OpTypePointer UniformConstant %14
+%124 = OpTypePointer Input %9
+%129 = OpTypeSampledImage %10
+%131 = OpConstant %9 0
+%138 = OpTypePointer Output %9
+%143 = OpTypePointer Output %5
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %145
+%145 = OpLabel
+%31 = OpAccessChain %30 %8 %32
+%33 = OpLoad %5 %31
+%34 = OpFunctionCall %5 %85 %33 %24 %24
+%29 = OpAccessChain %28 %13 %34
+%118 = OpLoad %10 %29
+%121 = OpAccessChain %30 %8 %62
+%122 = OpLoad %5 %121
+%120 = OpAccessChain %119 %17 %122
+%123 = OpLoad %14 %120
+%125 = OpAccessChain %124 %20 %32
+%126 = OpLoad %9 %125
+%127 = OpAccessChain %124 %20 %24
+%128 = OpLoad %9 %127
+%130 = OpSampledImage %129 %118 %123
+%133 = OpCompositeConstruct %18 %126 %128
+%132 = OpImageSampleImplicitLod %21 %130 %133 None
+%134 = OpCompositeExtract %9 %132 0
+%135 = OpCompositeExtract %9 %132 1
+%136 = OpCompositeExtract %9 %132 2
+%137 = OpCompositeExtract %9 %132 3
+%139 = OpAccessChain %138 %23 %32
+OpStore %139 %134
+%140 = OpAccessChain %138 %23 %24
+OpStore %140 %135
+%141 = OpAccessChain %138 %23 %62
+OpStore %141 %136
+%142 = OpAccessChain %138 %23 %59
+OpStore %142 %137
+%144 = OpAccessChain %143 %27 %32
+OpStore %144 %59
+OpReturn
+OpFunctionEnd
+%48 = OpFunction %1 None %40
+%41 = OpFunctionParameter %5
+%42 = OpFunctionParameter %5
+%43 = OpFunctionParameter %5
+%44 = OpFunctionParameter %5
+%45 = OpFunctionParameter %5
+%46 = OpFunctionParameter %5
+%47 = OpFunctionParameter %5
+%49 = OpLabel
+%51 = OpAccessChain %50 %39 %52
+%53 = OpAtomicExchange %5 %51 %24 %32 %24
+%55 = OpIEqual %54 %53 %32
+OpSelectionMerge %57 None
+OpBranchConditional %55 %56 %57
+%56 = OpLabel
+%58 = OpAccessChain %50 %39 %59
+OpStore %58 %43
+%60 = OpAccessChain %50 %39 %24
+OpStore %60 %42
+%61 = OpAccessChain %50 %39 %62
+OpStore %61 %44
+%63 = OpAccessChain %50 %39 %64
+OpStore %63 %45
+%65 = OpAccessChain %50 %39 %66
+OpStore %65 %46
+%67 = OpAccessChain %50 %39 %68
+OpStore %67 %47
+%72 = OpAccessChain %71 %39 %32
+OpStore %72 %70
+OpMemoryBarrier %24 %73
+%74 = OpAccessChain %50 %39 %75
+OpStore %74 %41
+OpBranch %57
+%57 = OpLabel
+OpReturn
+OpFunctionEnd
+%85 = OpFunction %5 None %81
+%82 = OpFunctionParameter %5
+%83 = OpFunctionParameter %5
+%84 = OpFunctionParameter %5
+%86 = OpLabel
+%87 = OpAccessChain %50 %80 %32
+%88 = OpLoad %5 %87
+%89 = OpAccessChain %50 %80 %24
+%90 = OpLoad %5 %89
+%91 = OpAccessChain %71 %80 %62 %82
+%92 = OpLoad %35 %91
+%93 = OpCompositeExtract %5 %92 0
+%95 = OpShiftRightLogical %5 %93 %68
+%96 = OpBitwiseAnd %5 %93 %97
+%94 = OpCompositeExtract %5 %92 1
+%98 = OpAccessChain %50 %39 %99 %95
+%100 = OpLoad %5 %98
+%101 = OpShiftLeftLogical %5 %24 %96
+%102 = OpBitwiseAnd %5 %100 %101
+%103 = OpINotEqual %54 %102 %32
+%104 = OpBitwiseAnd %5 %94 %83
+%105 = OpIEqual %54 %104 %83
+%106 = OpUGreaterThanEqual %54 %82 %88
+%107 = OpSelect %5 %106 %24 %32
+%108 = OpSelect %5 %105 %32 %62
+%109 = OpSelect %5 %103 %32 %52
+%110 = OpBitwiseOr %5 %107 %108
+%111 = OpBitwiseOr %5 %110 %109
+%112 = OpINotEqual %54 %111 %32
+OpSelectionMerge %114 None
+OpBranchConditional %112 %113 %114
+%113 = OpLabel
+%115 = OpFunctionCall %1 %48 %111 %82 %93 %90 %83 %94 %84
+OpReturnValue %88
+%114 = OpLabel
+OpReturnValue %82
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/early-4.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-4.bindless.descriptor-qa.frag
@@ -43,7 +43,7 @@ layout(location = 0) out vec4 SV_Target;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _53 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _53 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_53 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -279,7 +279,7 @@ OpFunctionEnd
 %47 = OpFunctionParameter %5
 %49 = OpLabel
 %51 = OpAccessChain %50 %39 %52
-%53 = OpAtomicExchange %5 %51 %24 %32 %24
+%53 = OpAtomicIAdd %5 %51 %24 %32 %24
 %55 = OpIEqual %54 %53 %32
 OpSelectionMerge %57 None
 OpBranchConditional %55 %56 %57

--- a/reference/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
@@ -44,8 +44,8 @@ layout(location = 0) out vec4 SV_Target;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _53 = atomicAdd(QAGlobalData.fault_atomic, 1u);
-    if (_53 == 0u)
+    uint _63 = atomicAdd(QAGlobalData.fault_atomic, 1u);
+    if (_63 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
         QAGlobalData.failed_offset = heap_offset;
@@ -61,28 +61,28 @@ void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, 
 
 uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
 {
-    uint _89 = QAHeapData.descriptor_count;
-    uint _91 = QAHeapData.heap_index;
-    uvec2 _93 = QAHeapData.cookies_descriptor_info[heap_offset];
-    uint _101 = QAGlobalData.live_status_table[_93.x >> 5u];
-    uint _112 = (uint(heap_offset >= _89) | (((_93.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_101 & (1u << (_93.x & 31u))) != 0u) ? 0u : 4u);
-    if (_112 != 0u)
+    uint _96 = QAHeapData.descriptor_count;
+    uint _98 = QAHeapData.heap_index;
+    uvec2 _100 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _108 = QAGlobalData.live_status_table[_100.x >> 5u];
+    uint _119 = (uint(heap_offset >= _96) | (((_100.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_108 & (1u << (_100.x & 31u))) != 0u) ? 0u : 4u);
+    if (_119 != 0u)
     {
-        descriptor_qa_report_fault(_112, heap_offset, _93.x, _91, descriptor_type_mask, _93.y, instruction);
-        return _89;
+        descriptor_qa_report_fault(_119, heap_offset, _100.x, _98, descriptor_type_mask, _100.y, instruction);
+        return _96;
     }
     return heap_offset;
 }
 
 void main()
 {
-    uint _34 = descriptor_qa_check(registers._m3, 2u, 1u);
-    uint _124 = descriptor_qa_check(registers._m0, 1u, 2u);
     if (UV.x < 0.0)
     {
-        imageStore(_17[_34], ivec2(uvec2(uint(int(UV.x)), uint(int(UV.y)))), vec4(2.0));
+        uint _44 = descriptor_qa_check(registers._m3, 2u, 1u);
+        imageStore(_17[_44], ivec2(uvec2(uint(int(UV.x)), uint(int(UV.y)))), vec4(2.0));
     }
-    vec4 _145 = texture(sampler2D(_13[_124], _21[registers._m2]), vec2(UV.x, UV.y));
+    uint _136 = descriptor_qa_check(registers._m0, 1u, 2u);
+    vec4 _145 = texture(sampler2D(_13[_136], _21[registers._m2]), vec2(UV.x, UV.y));
     SV_Target.x = _145.x;
     SV_Target.y = _145.y;
     SV_Target.z = _145.z;
@@ -111,35 +111,35 @@ OpName %6 "RootConstants"
 OpName %8 "registers"
 OpName %24 "UV"
 OpName %27 "SV_Target"
-OpName %37 "DescriptorHeapGlobalQAData"
-OpMemberName %37 0 "failed_shader_hash"
-OpMemberName %37 1 "failed_offset"
-OpMemberName %37 2 "failed_heap"
-OpMemberName %37 3 "failed_cookie"
-OpMemberName %37 4 "fault_atomic"
-OpMemberName %37 5 "failed_instruction"
-OpMemberName %37 6 "failed_descriptor_type_mask"
-OpMemberName %37 7 "actual_descriptor_type_mask"
-OpMemberName %37 8 "fault_type"
-OpMemberName %37 9 "live_status_table"
-OpName %39 "QAGlobalData"
-OpName %48 "descriptor_qa_report_fault"
-OpName %41 "fault_type"
-OpName %42 "heap_offset"
-OpName %43 "cookie"
-OpName %44 "heap_index"
-OpName %45 "descriptor_type"
-OpName %46 "actual_descriptor_type"
-OpName %47 "instruction"
-OpName %79 "DescriptorHeapQAData"
-OpMemberName %79 0 "descriptor_count"
-OpMemberName %79 1 "heap_index"
-OpMemberName %79 2 "cookies_descriptor_info"
-OpName %81 "QAHeapData"
-OpName %86 "descriptor_qa_check"
-OpName %83 "heap_offset"
-OpName %84 "descriptor_type_mask"
-OpName %85 "instruction"
+OpName %47 "DescriptorHeapGlobalQAData"
+OpMemberName %47 0 "failed_shader_hash"
+OpMemberName %47 1 "failed_offset"
+OpMemberName %47 2 "failed_heap"
+OpMemberName %47 3 "failed_cookie"
+OpMemberName %47 4 "fault_atomic"
+OpMemberName %47 5 "failed_instruction"
+OpMemberName %47 6 "failed_descriptor_type_mask"
+OpMemberName %47 7 "actual_descriptor_type_mask"
+OpMemberName %47 8 "fault_type"
+OpMemberName %47 9 "live_status_table"
+OpName %49 "QAGlobalData"
+OpName %58 "descriptor_qa_report_fault"
+OpName %51 "fault_type"
+OpName %52 "heap_offset"
+OpName %53 "cookie"
+OpName %54 "heap_index"
+OpName %55 "descriptor_type"
+OpName %56 "actual_descriptor_type"
+OpName %57 "instruction"
+OpName %86 "DescriptorHeapQAData"
+OpMemberName %86 0 "descriptor_count"
+OpMemberName %86 1 "heap_index"
+OpMemberName %86 2 "cookies_descriptor_info"
+OpName %88 "QAHeapData"
+OpName %93 "descriptor_qa_check"
+OpName %90 "heap_offset"
+OpName %91 "descriptor_type_mask"
+OpName %92 "instruction"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 4
@@ -158,28 +158,28 @@ OpDecorate %21 DescriptorSet 2
 OpDecorate %21 Binding 0
 OpDecorate %24 Location 0
 OpDecorate %27 Location 0
-OpDecorate %36 ArrayStride 4
-OpMemberDecorate %37 0 Offset 0
-OpMemberDecorate %37 1 Offset 8
-OpMemberDecorate %37 2 Offset 12
-OpMemberDecorate %37 3 Offset 16
-OpMemberDecorate %37 4 Offset 20
-OpMemberDecorate %37 5 Offset 24
-OpMemberDecorate %37 6 Offset 28
-OpMemberDecorate %37 7 Offset 32
-OpMemberDecorate %37 8 Offset 36
-OpMemberDecorate %37 9 Offset 40
-OpDecorate %37 Block
-OpDecorate %39 DescriptorSet 10
-OpDecorate %39 Binding 10
-OpDecorate %78 ArrayStride 8
-OpMemberDecorate %79 0 Offset 0
-OpMemberDecorate %79 1 Offset 4
-OpMemberDecorate %79 2 Offset 8
-OpDecorate %79 Block
-OpDecorate %81 DescriptorSet 10
-OpDecorate %81 Binding 11
-OpDecorate %81 NonWritable
+OpDecorate %46 ArrayStride 4
+OpMemberDecorate %47 0 Offset 0
+OpMemberDecorate %47 1 Offset 8
+OpMemberDecorate %47 2 Offset 12
+OpMemberDecorate %47 3 Offset 16
+OpMemberDecorate %47 4 Offset 20
+OpMemberDecorate %47 5 Offset 24
+OpMemberDecorate %47 6 Offset 28
+OpMemberDecorate %47 7 Offset 32
+OpMemberDecorate %47 8 Offset 36
+OpMemberDecorate %47 9 Offset 40
+OpDecorate %47 Block
+OpDecorate %49 DescriptorSet 10
+OpDecorate %49 Binding 10
+OpDecorate %85 ArrayStride 8
+OpMemberDecorate %86 0 Offset 0
+OpMemberDecorate %86 1 Offset 4
+OpMemberDecorate %86 2 Offset 8
+OpDecorate %86 Block
+OpDecorate %88 DescriptorSet 10
+OpDecorate %88 Binding 11
+OpDecorate %88 NonWritable
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -205,164 +205,164 @@ OpDecorate %81 NonWritable
 %25 = OpTypeVector %9 4
 %26 = OpTypePointer Output %25
 %27 = OpVariable %26 Output
-%28 = OpTypePointer UniformConstant %14
-%30 = OpTypePointer PushConstant %5
-%32 = OpConstant %5 3
-%35 = OpTypeVector %5 2
-%36 = OpTypeRuntimeArray %5
-%37 = OpTypeStruct %35 %5 %5 %5 %5 %5 %5 %5 %5 %36
-%38 = OpTypePointer StorageBuffer %37
-%39 = OpVariable %38 StorageBuffer
-%40 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
-%50 = OpTypePointer StorageBuffer %5
-%52 = OpConstant %5 4
-%54 = OpConstant %5 1
-%55 = OpConstant %5 0
-%56 = OpTypeBool
-%63 = OpConstant %5 2
-%65 = OpConstant %5 6
-%67 = OpConstant %5 7
-%69 = OpConstant %5 5
-%70 = OpConstant %5 3735928559
-%71 = OpConstantComposite %35 %70 %55
-%72 = OpTypePointer StorageBuffer %35
-%74 = OpConstant %5 72
-%76 = OpConstant %5 8
-%78 = OpTypeRuntimeArray %35
-%79 = OpTypeStruct %5 %5 %78
-%80 = OpTypePointer StorageBuffer %79
-%81 = OpVariable %80 StorageBuffer
-%82 = OpTypeFunction %5 %5 %5 %5
-%98 = OpConstant %5 31
-%100 = OpConstant %5 9
-%120 = OpTypePointer UniformConstant %10
-%126 = OpTypePointer UniformConstant %18
-%131 = OpTypePointer Input %9
-%137 = OpConstant %9 0
-%140 = OpConstant %9 2
+%28 = OpTypePointer Input %9
+%30 = OpConstant %5 0
+%33 = OpConstant %5 1
+%35 = OpTypeBool
+%37 = OpConstant %9 0
+%38 = OpTypePointer UniformConstant %14
+%40 = OpTypePointer PushConstant %5
+%42 = OpConstant %5 3
+%45 = OpTypeVector %5 2
+%46 = OpTypeRuntimeArray %5
+%47 = OpTypeStruct %45 %5 %5 %5 %5 %5 %5 %5 %5 %46
+%48 = OpTypePointer StorageBuffer %47
+%49 = OpVariable %48 StorageBuffer
+%50 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%60 = OpTypePointer StorageBuffer %5
+%62 = OpConstant %5 4
+%70 = OpConstant %5 2
+%72 = OpConstant %5 6
+%74 = OpConstant %5 7
+%76 = OpConstant %5 5
+%77 = OpConstant %5 3735928559
+%78 = OpConstantComposite %45 %77 %30
+%79 = OpTypePointer StorageBuffer %45
+%81 = OpConstant %5 72
+%83 = OpConstant %5 8
+%85 = OpTypeRuntimeArray %45
+%86 = OpTypeStruct %5 %5 %85
+%87 = OpTypePointer StorageBuffer %86
+%88 = OpVariable %87 StorageBuffer
+%89 = OpTypeFunction %5 %5 %5 %5
+%105 = OpConstant %5 31
+%107 = OpConstant %5 9
+%129 = OpConstant %9 2
+%132 = OpTypePointer UniformConstant %10
+%138 = OpTypePointer UniformConstant %18
 %143 = OpTypeSampledImage %10
 %151 = OpTypePointer Output %9
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 OpBranch %156
 %156 = OpLabel
-%31 = OpAccessChain %30 %8 %32
-%33 = OpLoad %5 %31
-%34 = OpFunctionCall %5 %86 %33 %63 %54
-%29 = OpAccessChain %28 %17 %34
-%119 = OpLoad %14 %29
-%122 = OpAccessChain %30 %8 %55
-%123 = OpLoad %5 %122
-%124 = OpFunctionCall %5 %86 %123 %54 %63
-%121 = OpAccessChain %120 %13 %124
-%125 = OpLoad %10 %121
-%128 = OpAccessChain %30 %8 %63
-%129 = OpLoad %5 %128
-%127 = OpAccessChain %126 %21 %129
-%130 = OpLoad %18 %127
-%132 = OpAccessChain %131 %24 %55
-%133 = OpLoad %9 %132
-%134 = OpAccessChain %131 %24 %54
-%135 = OpLoad %9 %134
-%136 = OpFOrdLessThan %56 %133 %137
+%29 = OpAccessChain %28 %24 %30
+%31 = OpLoad %9 %29
+%32 = OpAccessChain %28 %24 %33
+%34 = OpLoad %9 %32
+%36 = OpFOrdLessThan %35 %31 %37
 OpSelectionMerge %158 None
-OpBranchConditional %136 %157 %158
+OpBranchConditional %36 %157 %158
 %157 = OpLabel
-%138 = OpConvertFToS %5 %133
-%139 = OpConvertFToS %5 %135
-%141 = OpCompositeConstruct %35 %138 %139
-%142 = OpCompositeConstruct %25 %140 %140 %140 %140
-OpImageWrite %119 %141 %142
+%41 = OpAccessChain %40 %8 %42
+%43 = OpLoad %5 %41
+%44 = OpFunctionCall %5 %93 %43 %70 %33
+%39 = OpAccessChain %38 %17 %44
+%126 = OpLoad %14 %39
+%127 = OpConvertFToS %5 %31
+%128 = OpConvertFToS %5 %34
+%130 = OpCompositeConstruct %45 %127 %128
+%131 = OpCompositeConstruct %25 %129 %129 %129 %129
+OpImageWrite %126 %130 %131
 OpBranch %158
 %158 = OpLabel
-%144 = OpSampledImage %143 %125 %130
-%146 = OpCompositeConstruct %22 %133 %135
+%134 = OpAccessChain %40 %8 %30
+%135 = OpLoad %5 %134
+%136 = OpFunctionCall %5 %93 %135 %33 %70
+%133 = OpAccessChain %132 %13 %136
+%137 = OpLoad %10 %133
+%140 = OpAccessChain %40 %8 %70
+%141 = OpLoad %5 %140
+%139 = OpAccessChain %138 %21 %141
+%142 = OpLoad %18 %139
+%144 = OpSampledImage %143 %137 %142
+%146 = OpCompositeConstruct %22 %31 %34
 %145 = OpImageSampleImplicitLod %25 %144 %146 None
 %147 = OpCompositeExtract %9 %145 0
 %148 = OpCompositeExtract %9 %145 1
 %149 = OpCompositeExtract %9 %145 2
 %150 = OpCompositeExtract %9 %145 3
-%152 = OpAccessChain %151 %27 %55
+%152 = OpAccessChain %151 %27 %30
 OpStore %152 %147
-%153 = OpAccessChain %151 %27 %54
+%153 = OpAccessChain %151 %27 %33
 OpStore %153 %148
-%154 = OpAccessChain %151 %27 %63
+%154 = OpAccessChain %151 %27 %70
 OpStore %154 %149
-%155 = OpAccessChain %151 %27 %32
+%155 = OpAccessChain %151 %27 %42
 OpStore %155 %150
 OpReturn
 OpFunctionEnd
-%48 = OpFunction %1 None %40
-%41 = OpFunctionParameter %5
-%42 = OpFunctionParameter %5
-%43 = OpFunctionParameter %5
-%44 = OpFunctionParameter %5
-%45 = OpFunctionParameter %5
-%46 = OpFunctionParameter %5
-%47 = OpFunctionParameter %5
-%49 = OpLabel
-%51 = OpAccessChain %50 %39 %52
-%53 = OpAtomicIAdd %5 %51 %54 %55 %54
-%57 = OpIEqual %56 %53 %55
-OpSelectionMerge %59 None
-OpBranchConditional %57 %58 %59
-%58 = OpLabel
-%60 = OpAccessChain %50 %39 %32
-OpStore %60 %43
-%61 = OpAccessChain %50 %39 %54
-OpStore %61 %42
-%62 = OpAccessChain %50 %39 %63
-OpStore %62 %44
-%64 = OpAccessChain %50 %39 %65
-OpStore %64 %45
-%66 = OpAccessChain %50 %39 %67
-OpStore %66 %46
-%68 = OpAccessChain %50 %39 %69
-OpStore %68 %47
-%73 = OpAccessChain %72 %39 %55
-OpStore %73 %71
-OpMemoryBarrier %54 %74
-%75 = OpAccessChain %50 %39 %76
-OpStore %75 %41
-OpBranch %59
+%58 = OpFunction %1 None %50
+%51 = OpFunctionParameter %5
+%52 = OpFunctionParameter %5
+%53 = OpFunctionParameter %5
+%54 = OpFunctionParameter %5
+%55 = OpFunctionParameter %5
+%56 = OpFunctionParameter %5
+%57 = OpFunctionParameter %5
 %59 = OpLabel
+%61 = OpAccessChain %60 %49 %62
+%63 = OpAtomicIAdd %5 %61 %33 %30 %33
+%64 = OpIEqual %35 %63 %30
+OpSelectionMerge %66 None
+OpBranchConditional %64 %65 %66
+%65 = OpLabel
+%67 = OpAccessChain %60 %49 %42
+OpStore %67 %53
+%68 = OpAccessChain %60 %49 %33
+OpStore %68 %52
+%69 = OpAccessChain %60 %49 %70
+OpStore %69 %54
+%71 = OpAccessChain %60 %49 %72
+OpStore %71 %55
+%73 = OpAccessChain %60 %49 %74
+OpStore %73 %56
+%75 = OpAccessChain %60 %49 %76
+OpStore %75 %57
+%80 = OpAccessChain %79 %49 %30
+OpStore %80 %78
+OpMemoryBarrier %33 %81
+%82 = OpAccessChain %60 %49 %83
+OpStore %82 %51
+OpBranch %66
+%66 = OpLabel
 OpReturn
 OpFunctionEnd
-%86 = OpFunction %5 None %82
-%83 = OpFunctionParameter %5
-%84 = OpFunctionParameter %5
-%85 = OpFunctionParameter %5
-%87 = OpLabel
-%88 = OpAccessChain %50 %81 %55
-%89 = OpLoad %5 %88
-%90 = OpAccessChain %50 %81 %54
-%91 = OpLoad %5 %90
-%92 = OpAccessChain %72 %81 %63 %83
-%93 = OpLoad %35 %92
-%94 = OpCompositeExtract %5 %93 0
-%96 = OpShiftRightLogical %5 %94 %69
-%97 = OpBitwiseAnd %5 %94 %98
-%95 = OpCompositeExtract %5 %93 1
-%99 = OpAccessChain %50 %39 %100 %96
-%101 = OpLoad %5 %99
-%102 = OpShiftLeftLogical %5 %54 %97
-%103 = OpBitwiseAnd %5 %101 %102
-%104 = OpINotEqual %56 %103 %55
-%105 = OpBitwiseAnd %5 %95 %84
-%106 = OpIEqual %56 %105 %84
-%107 = OpUGreaterThanEqual %56 %83 %89
-%108 = OpSelect %5 %107 %54 %55
-%109 = OpSelect %5 %106 %55 %63
-%110 = OpSelect %5 %104 %55 %52
-%111 = OpBitwiseOr %5 %108 %109
-%112 = OpBitwiseOr %5 %111 %110
-%113 = OpINotEqual %56 %112 %55
-OpSelectionMerge %115 None
-OpBranchConditional %113 %114 %115
-%114 = OpLabel
-%116 = OpFunctionCall %1 %48 %112 %83 %94 %91 %84 %95 %85
-OpReturnValue %89
-%115 = OpLabel
-OpReturnValue %83
+%93 = OpFunction %5 None %89
+%90 = OpFunctionParameter %5
+%91 = OpFunctionParameter %5
+%92 = OpFunctionParameter %5
+%94 = OpLabel
+%95 = OpAccessChain %60 %88 %30
+%96 = OpLoad %5 %95
+%97 = OpAccessChain %60 %88 %33
+%98 = OpLoad %5 %97
+%99 = OpAccessChain %79 %88 %70 %90
+%100 = OpLoad %45 %99
+%101 = OpCompositeExtract %5 %100 0
+%103 = OpShiftRightLogical %5 %101 %76
+%104 = OpBitwiseAnd %5 %101 %105
+%102 = OpCompositeExtract %5 %100 1
+%106 = OpAccessChain %60 %49 %107 %103
+%108 = OpLoad %5 %106
+%109 = OpShiftLeftLogical %5 %33 %104
+%110 = OpBitwiseAnd %5 %108 %109
+%111 = OpINotEqual %35 %110 %30
+%112 = OpBitwiseAnd %5 %102 %91
+%113 = OpIEqual %35 %112 %91
+%114 = OpUGreaterThanEqual %35 %90 %96
+%115 = OpSelect %5 %114 %33 %30
+%116 = OpSelect %5 %113 %30 %70
+%117 = OpSelect %5 %111 %30 %62
+%118 = OpBitwiseOr %5 %115 %116
+%119 = OpBitwiseOr %5 %118 %117
+%120 = OpINotEqual %35 %119 %30
+OpSelectionMerge %122 None
+OpBranchConditional %120 %121 %122
+%121 = OpLabel
+%123 = OpFunctionCall %1 %58 %119 %90 %101 %98 %91 %102 %92
+OpReturnValue %96
+%122 = OpLabel
+OpReturnValue %90
 OpFunctionEnd
 #endif

--- a/reference/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
@@ -1,0 +1,368 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 3, binding = 0) uniform writeonly image2D _17[];
+layout(set = 2, binding = 0) uniform sampler _21[];
+
+layout(location = 0) in vec2 UV;
+layout(location = 0) out vec4 SV_Target;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _53 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_53 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _89 = QAHeapData.descriptor_count;
+    uint _91 = QAHeapData.heap_index;
+    uvec2 _93 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _101 = QAGlobalData.live_status_table[_93.x >> 5u];
+    uint _112 = (uint(heap_offset >= _89) | (((_93.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_101 & (1u << (_93.x & 31u))) != 0u) ? 0u : 4u);
+    if (_112 != 0u)
+    {
+        descriptor_qa_report_fault(_112, heap_offset, _93.x, _91, descriptor_type_mask, _93.y, instruction);
+        return _89;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _34 = descriptor_qa_check(registers._m3, 2u, 1u);
+    uint _124 = descriptor_qa_check(registers._m0, 1u, 2u);
+    if (UV.x < 0.0)
+    {
+        imageStore(_17[_34], ivec2(uvec2(uint(int(UV.x)), uint(int(UV.y)))), vec4(2.0));
+    }
+    vec4 _145 = texture(sampler2D(_13[_124], _21[registers._m2]), vec2(UV.x, UV.y));
+    SV_Target.x = _145.x;
+    SV_Target.y = _145.y;
+    SV_Target.z = _145.z;
+    SV_Target.w = _145.w;
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 160
+; Schema: 0
+OpCapability Shader
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RuntimeDescriptorArray
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Fragment %3 "main" %24 %27
+OpExecutionMode %3 OriginUpperLeft
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %24 "UV"
+OpName %27 "SV_Target"
+OpName %37 "DescriptorHeapGlobalQAData"
+OpMemberName %37 0 "failed_shader_hash"
+OpMemberName %37 1 "failed_offset"
+OpMemberName %37 2 "failed_heap"
+OpMemberName %37 3 "failed_cookie"
+OpMemberName %37 4 "fault_atomic"
+OpMemberName %37 5 "failed_instruction"
+OpMemberName %37 6 "failed_descriptor_type_mask"
+OpMemberName %37 7 "actual_descriptor_type_mask"
+OpMemberName %37 8 "fault_type"
+OpMemberName %37 9 "live_status_table"
+OpName %39 "QAGlobalData"
+OpName %48 "descriptor_qa_report_fault"
+OpName %41 "fault_type"
+OpName %42 "heap_offset"
+OpName %43 "cookie"
+OpName %44 "heap_index"
+OpName %45 "descriptor_type"
+OpName %46 "actual_descriptor_type"
+OpName %47 "instruction"
+OpName %79 "DescriptorHeapQAData"
+OpMemberName %79 0 "descriptor_count"
+OpMemberName %79 1 "heap_index"
+OpMemberName %79 2 "cookies_descriptor_info"
+OpName %81 "QAHeapData"
+OpName %86 "descriptor_qa_check"
+OpName %83 "heap_offset"
+OpName %84 "descriptor_type_mask"
+OpName %85 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 3
+OpDecorate %17 Binding 0
+OpDecorate %17 NonReadable
+OpDecorate %21 DescriptorSet 2
+OpDecorate %21 Binding 0
+OpDecorate %24 Location 0
+OpDecorate %27 Location 0
+OpDecorate %36 ArrayStride 4
+OpMemberDecorate %37 0 Offset 0
+OpMemberDecorate %37 1 Offset 8
+OpMemberDecorate %37 2 Offset 12
+OpMemberDecorate %37 3 Offset 16
+OpMemberDecorate %37 4 Offset 20
+OpMemberDecorate %37 5 Offset 24
+OpMemberDecorate %37 6 Offset 28
+OpMemberDecorate %37 7 Offset 32
+OpMemberDecorate %37 8 Offset 36
+OpMemberDecorate %37 9 Offset 40
+OpDecorate %37 Block
+OpDecorate %39 DescriptorSet 10
+OpDecorate %39 Binding 10
+OpDecorate %78 ArrayStride 8
+OpMemberDecorate %79 0 Offset 0
+OpMemberDecorate %79 1 Offset 4
+OpMemberDecorate %79 2 Offset 8
+OpDecorate %79 Block
+OpDecorate %81 DescriptorSet 10
+OpDecorate %81 Binding 11
+OpDecorate %81 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeSampler
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypePointer UniformConstant %19
+%21 = OpVariable %20 UniformConstant
+%22 = OpTypeVector %9 2
+%23 = OpTypePointer Input %22
+%24 = OpVariable %23 Input
+%25 = OpTypeVector %9 4
+%26 = OpTypePointer Output %25
+%27 = OpVariable %26 Output
+%28 = OpTypePointer UniformConstant %14
+%30 = OpTypePointer PushConstant %5
+%32 = OpConstant %5 3
+%35 = OpTypeVector %5 2
+%36 = OpTypeRuntimeArray %5
+%37 = OpTypeStruct %35 %5 %5 %5 %5 %5 %5 %5 %5 %36
+%38 = OpTypePointer StorageBuffer %37
+%39 = OpVariable %38 StorageBuffer
+%40 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%50 = OpTypePointer StorageBuffer %5
+%52 = OpConstant %5 4
+%54 = OpConstant %5 1
+%55 = OpConstant %5 0
+%56 = OpTypeBool
+%63 = OpConstant %5 2
+%65 = OpConstant %5 6
+%67 = OpConstant %5 7
+%69 = OpConstant %5 5
+%70 = OpConstant %5 3735928559
+%71 = OpConstantComposite %35 %70 %55
+%72 = OpTypePointer StorageBuffer %35
+%74 = OpConstant %5 72
+%76 = OpConstant %5 8
+%78 = OpTypeRuntimeArray %35
+%79 = OpTypeStruct %5 %5 %78
+%80 = OpTypePointer StorageBuffer %79
+%81 = OpVariable %80 StorageBuffer
+%82 = OpTypeFunction %5 %5 %5 %5
+%98 = OpConstant %5 31
+%100 = OpConstant %5 9
+%120 = OpTypePointer UniformConstant %10
+%126 = OpTypePointer UniformConstant %18
+%131 = OpTypePointer Input %9
+%137 = OpConstant %9 0
+%140 = OpConstant %9 2
+%143 = OpTypeSampledImage %10
+%151 = OpTypePointer Output %9
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %156
+%156 = OpLabel
+%31 = OpAccessChain %30 %8 %32
+%33 = OpLoad %5 %31
+%34 = OpFunctionCall %5 %86 %33 %63 %54
+%29 = OpAccessChain %28 %17 %34
+%119 = OpLoad %14 %29
+%122 = OpAccessChain %30 %8 %55
+%123 = OpLoad %5 %122
+%124 = OpFunctionCall %5 %86 %123 %54 %63
+%121 = OpAccessChain %120 %13 %124
+%125 = OpLoad %10 %121
+%128 = OpAccessChain %30 %8 %63
+%129 = OpLoad %5 %128
+%127 = OpAccessChain %126 %21 %129
+%130 = OpLoad %18 %127
+%132 = OpAccessChain %131 %24 %55
+%133 = OpLoad %9 %132
+%134 = OpAccessChain %131 %24 %54
+%135 = OpLoad %9 %134
+%136 = OpFOrdLessThan %56 %133 %137
+OpSelectionMerge %158 None
+OpBranchConditional %136 %157 %158
+%157 = OpLabel
+%138 = OpConvertFToS %5 %133
+%139 = OpConvertFToS %5 %135
+%141 = OpCompositeConstruct %35 %138 %139
+%142 = OpCompositeConstruct %25 %140 %140 %140 %140
+OpImageWrite %119 %141 %142
+OpBranch %158
+%158 = OpLabel
+%144 = OpSampledImage %143 %125 %130
+%146 = OpCompositeConstruct %22 %133 %135
+%145 = OpImageSampleImplicitLod %25 %144 %146 None
+%147 = OpCompositeExtract %9 %145 0
+%148 = OpCompositeExtract %9 %145 1
+%149 = OpCompositeExtract %9 %145 2
+%150 = OpCompositeExtract %9 %145 3
+%152 = OpAccessChain %151 %27 %55
+OpStore %152 %147
+%153 = OpAccessChain %151 %27 %54
+OpStore %153 %148
+%154 = OpAccessChain %151 %27 %63
+OpStore %154 %149
+%155 = OpAccessChain %151 %27 %32
+OpStore %155 %150
+OpReturn
+OpFunctionEnd
+%48 = OpFunction %1 None %40
+%41 = OpFunctionParameter %5
+%42 = OpFunctionParameter %5
+%43 = OpFunctionParameter %5
+%44 = OpFunctionParameter %5
+%45 = OpFunctionParameter %5
+%46 = OpFunctionParameter %5
+%47 = OpFunctionParameter %5
+%49 = OpLabel
+%51 = OpAccessChain %50 %39 %52
+%53 = OpAtomicExchange %5 %51 %54 %55 %54
+%57 = OpIEqual %56 %53 %55
+OpSelectionMerge %59 None
+OpBranchConditional %57 %58 %59
+%58 = OpLabel
+%60 = OpAccessChain %50 %39 %32
+OpStore %60 %43
+%61 = OpAccessChain %50 %39 %54
+OpStore %61 %42
+%62 = OpAccessChain %50 %39 %63
+OpStore %62 %44
+%64 = OpAccessChain %50 %39 %65
+OpStore %64 %45
+%66 = OpAccessChain %50 %39 %67
+OpStore %66 %46
+%68 = OpAccessChain %50 %39 %69
+OpStore %68 %47
+%73 = OpAccessChain %72 %39 %55
+OpStore %73 %71
+OpMemoryBarrier %54 %74
+%75 = OpAccessChain %50 %39 %76
+OpStore %75 %41
+OpBranch %59
+%59 = OpLabel
+OpReturn
+OpFunctionEnd
+%86 = OpFunction %5 None %82
+%83 = OpFunctionParameter %5
+%84 = OpFunctionParameter %5
+%85 = OpFunctionParameter %5
+%87 = OpLabel
+%88 = OpAccessChain %50 %81 %55
+%89 = OpLoad %5 %88
+%90 = OpAccessChain %50 %81 %54
+%91 = OpLoad %5 %90
+%92 = OpAccessChain %72 %81 %63 %83
+%93 = OpLoad %35 %92
+%94 = OpCompositeExtract %5 %93 0
+%96 = OpShiftRightLogical %5 %94 %69
+%97 = OpBitwiseAnd %5 %94 %98
+%95 = OpCompositeExtract %5 %93 1
+%99 = OpAccessChain %50 %39 %100 %96
+%101 = OpLoad %5 %99
+%102 = OpShiftLeftLogical %5 %54 %97
+%103 = OpBitwiseAnd %5 %101 %102
+%104 = OpINotEqual %56 %103 %55
+%105 = OpBitwiseAnd %5 %95 %84
+%106 = OpIEqual %56 %105 %84
+%107 = OpUGreaterThanEqual %56 %83 %89
+%108 = OpSelect %5 %107 %54 %55
+%109 = OpSelect %5 %106 %55 %63
+%110 = OpSelect %5 %104 %55 %52
+%111 = OpBitwiseOr %5 %108 %109
+%112 = OpBitwiseOr %5 %111 %110
+%113 = OpINotEqual %56 %112 %55
+OpSelectionMerge %115 None
+OpBranchConditional %113 %114 %115
+%114 = OpLabel
+%116 = OpFunctionCall %1 %48 %112 %83 %94 %91 %84 %95 %85
+OpReturnValue %89
+%115 = OpLabel
+OpReturnValue %83
+OpFunctionEnd
+#endif

--- a/reference/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
@@ -44,7 +44,7 @@ layout(location = 0) out vec4 SV_Target;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _53 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _53 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_53 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -302,7 +302,7 @@ OpFunctionEnd
 %47 = OpFunctionParameter %5
 %49 = OpLabel
 %51 = OpAccessChain %50 %39 %52
-%53 = OpAtomicExchange %5 %51 %54 %55 %54
+%53 = OpAtomicIAdd %5 %51 %54 %55 %54
 %57 = OpIEqual %56 %53 %55
 OpSelectionMerge %59 None
 OpBranchConditional %57 %58 %59

--- a/reference/shaders/descriptor_qa/early.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early.bindless.descriptor-qa.frag
@@ -44,7 +44,7 @@ layout(location = 0) out vec4 SV_Target;
 
 void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
 {
-    uint _49 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    uint _49 = atomicAdd(QAGlobalData.fault_atomic, 1u);
     if (_49 == 0u)
     {
         QAGlobalData.failed_cookie = cookie;
@@ -272,7 +272,7 @@ OpFunctionEnd
 %43 = OpFunctionParameter %5
 %45 = OpLabel
 %47 = OpAccessChain %46 %35 %48
-%49 = OpAtomicExchange %5 %47 %50 %28 %50
+%49 = OpAtomicIAdd %5 %47 %50 %28 %50
 %52 = OpIEqual %51 %49 %28
 OpSelectionMerge %54 None
 OpBranchConditional %52 %53 %54

--- a/reference/shaders/descriptor_qa/early.bindless.descriptor-qa.frag
+++ b/reference/shaders/descriptor_qa/early.bindless.descriptor-qa.frag
@@ -1,0 +1,338 @@
+#version 460
+#extension GL_EXT_buffer_reference : require
+#extension GL_EXT_nonuniform_qualifier : require
+layout(early_fragment_tests) in;
+
+layout(set = 10, binding = 10, std430) buffer DescriptorHeapGlobalQAData
+{
+    uvec2 failed_shader_hash;
+    uint failed_offset;
+    uint failed_heap;
+    uint failed_cookie;
+    uint fault_atomic;
+    uint failed_instruction;
+    uint failed_descriptor_type_mask;
+    uint actual_descriptor_type_mask;
+    uint fault_type;
+    uint live_status_table[];
+} QAGlobalData;
+
+layout(set = 10, binding = 11, std430) readonly buffer DescriptorHeapQAData
+{
+    uint descriptor_count;
+    uint heap_index;
+    uvec2 cookies_descriptor_info[];
+} QAHeapData;
+
+layout(push_constant, std430) uniform RootConstants
+{
+    uint _m0;
+    uint _m1;
+    uint _m2;
+    uint _m3;
+    uint _m4;
+    uint _m5;
+    uint _m6;
+    uint _m7;
+} registers;
+
+layout(set = 0, binding = 0) uniform texture2D _13[];
+layout(set = 2, binding = 0) uniform sampler _17[];
+
+layout(location = 0) in vec2 UV;
+layout(location = 0) out vec4 SV_Target;
+
+void descriptor_qa_report_fault(uint fault_type, uint heap_offset, uint cookie, uint heap_index, uint descriptor_type, uint actual_descriptor_type, uint instruction)
+{
+    uint _49 = atomicExchange(QAGlobalData.fault_atomic, 1u);
+    if (_49 == 0u)
+    {
+        QAGlobalData.failed_cookie = cookie;
+        QAGlobalData.failed_offset = heap_offset;
+        QAGlobalData.failed_heap = heap_index;
+        QAGlobalData.failed_descriptor_type_mask = descriptor_type;
+        QAGlobalData.actual_descriptor_type_mask = actual_descriptor_type;
+        QAGlobalData.failed_instruction = instruction;
+        QAGlobalData.failed_shader_hash = uvec2(3735928559u, 0u);
+        memoryBarrierBuffer();
+        QAGlobalData.fault_type = fault_type;
+    }
+}
+
+uint descriptor_qa_check(uint heap_offset, uint descriptor_type_mask, uint instruction)
+{
+    uint _85 = QAHeapData.descriptor_count;
+    uint _87 = QAHeapData.heap_index;
+    uvec2 _89 = QAHeapData.cookies_descriptor_info[heap_offset];
+    uint _97 = QAGlobalData.live_status_table[_89.x >> 5u];
+    uint _108 = (uint(heap_offset >= _85) | (((_89.y & descriptor_type_mask) == descriptor_type_mask) ? 0u : 2u)) | (((_97 & (1u << (_89.x & 31u))) != 0u) ? 0u : 4u);
+    if (_108 != 0u)
+    {
+        descriptor_qa_report_fault(_108, heap_offset, _89.x, _87, descriptor_type_mask, _89.y, instruction);
+        return _85;
+    }
+    return heap_offset;
+}
+
+void main()
+{
+    uint _30 = descriptor_qa_check(registers._m0, 1u, 1u);
+    vec4 _129 = texture(sampler2D(_13[_30], _17[registers._m2]), vec2(UV.x, UV.y));
+    SV_Target.x = _129.x;
+    SV_Target.y = _129.y;
+    SV_Target.z = _129.z;
+    SV_Target.w = _129.w;
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 142
+; Schema: 0
+OpCapability Shader
+OpCapability RuntimeDescriptorArray
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Fragment %3 "main" %20 %23
+OpExecutionMode %3 OriginUpperLeft
+OpExecutionMode %3 EarlyFragmentTests
+OpName %3 "main"
+OpName %6 "RootConstants"
+OpName %8 "registers"
+OpName %20 "UV"
+OpName %23 "SV_Target"
+OpName %33 "DescriptorHeapGlobalQAData"
+OpMemberName %33 0 "failed_shader_hash"
+OpMemberName %33 1 "failed_offset"
+OpMemberName %33 2 "failed_heap"
+OpMemberName %33 3 "failed_cookie"
+OpMemberName %33 4 "fault_atomic"
+OpMemberName %33 5 "failed_instruction"
+OpMemberName %33 6 "failed_descriptor_type_mask"
+OpMemberName %33 7 "actual_descriptor_type_mask"
+OpMemberName %33 8 "fault_type"
+OpMemberName %33 9 "live_status_table"
+OpName %35 "QAGlobalData"
+OpName %44 "descriptor_qa_report_fault"
+OpName %37 "fault_type"
+OpName %38 "heap_offset"
+OpName %39 "cookie"
+OpName %40 "heap_index"
+OpName %41 "descriptor_type"
+OpName %42 "actual_descriptor_type"
+OpName %43 "instruction"
+OpName %75 "DescriptorHeapQAData"
+OpMemberName %75 0 "descriptor_count"
+OpMemberName %75 1 "heap_index"
+OpMemberName %75 2 "cookies_descriptor_info"
+OpName %77 "QAHeapData"
+OpName %82 "descriptor_qa_check"
+OpName %79 "heap_offset"
+OpName %80 "descriptor_type_mask"
+OpName %81 "instruction"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpMemberDecorate %6 1 Offset 4
+OpMemberDecorate %6 2 Offset 8
+OpMemberDecorate %6 3 Offset 12
+OpMemberDecorate %6 4 Offset 16
+OpMemberDecorate %6 5 Offset 20
+OpMemberDecorate %6 6 Offset 24
+OpMemberDecorate %6 7 Offset 28
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 0
+OpDecorate %17 DescriptorSet 2
+OpDecorate %17 Binding 0
+OpDecorate %20 Location 0
+OpDecorate %23 Location 0
+OpDecorate %32 ArrayStride 4
+OpMemberDecorate %33 0 Offset 0
+OpMemberDecorate %33 1 Offset 8
+OpMemberDecorate %33 2 Offset 12
+OpMemberDecorate %33 3 Offset 16
+OpMemberDecorate %33 4 Offset 20
+OpMemberDecorate %33 5 Offset 24
+OpMemberDecorate %33 6 Offset 28
+OpMemberDecorate %33 7 Offset 32
+OpMemberDecorate %33 8 Offset 36
+OpMemberDecorate %33 9 Offset 40
+OpDecorate %33 Block
+OpDecorate %35 DescriptorSet 10
+OpDecorate %35 Binding 10
+OpDecorate %74 ArrayStride 8
+OpMemberDecorate %75 0 Offset 0
+OpMemberDecorate %75 1 Offset 4
+OpMemberDecorate %75 2 Offset 8
+OpDecorate %75 Block
+OpDecorate %77 DescriptorSet 10
+OpDecorate %77 Binding 11
+OpDecorate %77 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeStruct %5 %5 %5 %5 %5 %5 %5 %5
+%7 = OpTypePointer PushConstant %6
+%8 = OpVariable %7 PushConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypePointer UniformConstant %11
+%13 = OpVariable %12 UniformConstant
+%14 = OpTypeSampler
+%15 = OpTypeRuntimeArray %14
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeVector %9 2
+%19 = OpTypePointer Input %18
+%20 = OpVariable %19 Input
+%21 = OpTypeVector %9 4
+%22 = OpTypePointer Output %21
+%23 = OpVariable %22 Output
+%24 = OpTypePointer UniformConstant %10
+%26 = OpTypePointer PushConstant %5
+%28 = OpConstant %5 0
+%31 = OpTypeVector %5 2
+%32 = OpTypeRuntimeArray %5
+%33 = OpTypeStruct %31 %5 %5 %5 %5 %5 %5 %5 %5 %32
+%34 = OpTypePointer StorageBuffer %33
+%35 = OpVariable %34 StorageBuffer
+%36 = OpTypeFunction %1 %5 %5 %5 %5 %5 %5 %5
+%46 = OpTypePointer StorageBuffer %5
+%48 = OpConstant %5 4
+%50 = OpConstant %5 1
+%51 = OpTypeBool
+%56 = OpConstant %5 3
+%59 = OpConstant %5 2
+%61 = OpConstant %5 6
+%63 = OpConstant %5 7
+%65 = OpConstant %5 5
+%66 = OpConstant %5 3735928559
+%67 = OpConstantComposite %31 %66 %28
+%68 = OpTypePointer StorageBuffer %31
+%70 = OpConstant %5 72
+%72 = OpConstant %5 8
+%74 = OpTypeRuntimeArray %31
+%75 = OpTypeStruct %5 %5 %74
+%76 = OpTypePointer StorageBuffer %75
+%77 = OpVariable %76 StorageBuffer
+%78 = OpTypeFunction %5 %5 %5 %5
+%94 = OpConstant %5 31
+%96 = OpConstant %5 9
+%116 = OpTypePointer UniformConstant %14
+%121 = OpTypePointer Input %9
+%126 = OpTypeSampledImage %10
+%128 = OpConstant %9 0
+%135 = OpTypePointer Output %9
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %140
+%140 = OpLabel
+%27 = OpAccessChain %26 %8 %28
+%29 = OpLoad %5 %27
+%30 = OpFunctionCall %5 %82 %29 %50 %50
+%25 = OpAccessChain %24 %13 %30
+%115 = OpLoad %10 %25
+%118 = OpAccessChain %26 %8 %59
+%119 = OpLoad %5 %118
+%117 = OpAccessChain %116 %17 %119
+%120 = OpLoad %14 %117
+%122 = OpAccessChain %121 %20 %28
+%123 = OpLoad %9 %122
+%124 = OpAccessChain %121 %20 %50
+%125 = OpLoad %9 %124
+%127 = OpSampledImage %126 %115 %120
+%130 = OpCompositeConstruct %18 %123 %125
+%129 = OpImageSampleImplicitLod %21 %127 %130 None
+%131 = OpCompositeExtract %9 %129 0
+%132 = OpCompositeExtract %9 %129 1
+%133 = OpCompositeExtract %9 %129 2
+%134 = OpCompositeExtract %9 %129 3
+%136 = OpAccessChain %135 %23 %28
+OpStore %136 %131
+%137 = OpAccessChain %135 %23 %50
+OpStore %137 %132
+%138 = OpAccessChain %135 %23 %59
+OpStore %138 %133
+%139 = OpAccessChain %135 %23 %56
+OpStore %139 %134
+OpReturn
+OpFunctionEnd
+%44 = OpFunction %1 None %36
+%37 = OpFunctionParameter %5
+%38 = OpFunctionParameter %5
+%39 = OpFunctionParameter %5
+%40 = OpFunctionParameter %5
+%41 = OpFunctionParameter %5
+%42 = OpFunctionParameter %5
+%43 = OpFunctionParameter %5
+%45 = OpLabel
+%47 = OpAccessChain %46 %35 %48
+%49 = OpAtomicExchange %5 %47 %50 %28 %50
+%52 = OpIEqual %51 %49 %28
+OpSelectionMerge %54 None
+OpBranchConditional %52 %53 %54
+%53 = OpLabel
+%55 = OpAccessChain %46 %35 %56
+OpStore %55 %39
+%57 = OpAccessChain %46 %35 %50
+OpStore %57 %38
+%58 = OpAccessChain %46 %35 %59
+OpStore %58 %40
+%60 = OpAccessChain %46 %35 %61
+OpStore %60 %41
+%62 = OpAccessChain %46 %35 %63
+OpStore %62 %42
+%64 = OpAccessChain %46 %35 %65
+OpStore %64 %43
+%69 = OpAccessChain %68 %35 %28
+OpStore %69 %67
+OpMemoryBarrier %50 %70
+%71 = OpAccessChain %46 %35 %72
+OpStore %71 %37
+OpBranch %54
+%54 = OpLabel
+OpReturn
+OpFunctionEnd
+%82 = OpFunction %5 None %78
+%79 = OpFunctionParameter %5
+%80 = OpFunctionParameter %5
+%81 = OpFunctionParameter %5
+%83 = OpLabel
+%84 = OpAccessChain %46 %77 %28
+%85 = OpLoad %5 %84
+%86 = OpAccessChain %46 %77 %50
+%87 = OpLoad %5 %86
+%88 = OpAccessChain %68 %77 %59 %79
+%89 = OpLoad %31 %88
+%90 = OpCompositeExtract %5 %89 0
+%92 = OpShiftRightLogical %5 %90 %65
+%93 = OpBitwiseAnd %5 %90 %94
+%91 = OpCompositeExtract %5 %89 1
+%95 = OpAccessChain %46 %35 %96 %92
+%97 = OpLoad %5 %95
+%98 = OpShiftLeftLogical %5 %50 %93
+%99 = OpBitwiseAnd %5 %97 %98
+%100 = OpINotEqual %51 %99 %28
+%101 = OpBitwiseAnd %5 %91 %80
+%102 = OpIEqual %51 %101 %80
+%103 = OpUGreaterThanEqual %51 %79 %85
+%104 = OpSelect %5 %103 %50 %28
+%105 = OpSelect %5 %102 %28 %59
+%106 = OpSelect %5 %100 %28 %48
+%107 = OpBitwiseOr %5 %104 %105
+%108 = OpBitwiseOr %5 %107 %106
+%109 = OpINotEqual %51 %108 %28
+OpSelectionMerge %111 None
+OpBranchConditional %109 %110 %111
+%110 = OpLabel
+%112 = OpFunctionCall %1 %44 %108 %79 %90 %87 %80 %91 %81
+OpReturnValue %85
+%111 = OpLabel
+OpReturnValue %79
+OpFunctionEnd
+#endif

--- a/shaders/descriptor_qa/acceleration-structure.bindless.descriptor-qa.rgen
+++ b/shaders/descriptor_qa/acceleration-structure.bindless.descriptor-qa.rgen
@@ -1,0 +1,24 @@
+struct Payload
+{
+	float4 color;
+};
+
+RaytracingAccelerationStructure AS_Plain : register(t3, space0);
+RaytracingAccelerationStructure AS[] : register(t100, space1);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload p;
+	p.color = float4(1, 2, 3, 4);
+	TraceRay(AS[10], RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+	TraceRay(AS_Plain, RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+	TraceRay(AS[NonUniformResourceIndex(int(p.color.w))], RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+}
+

--- a/shaders/descriptor_qa/acceleration-structure.bindless.ssbo-rtas.local-root-signature.descriptor-qa.rgen
+++ b/shaders/descriptor_qa/acceleration-structure.bindless.ssbo-rtas.local-root-signature.descriptor-qa.rgen
@@ -1,0 +1,26 @@
+struct Payload
+{
+	float4 color;
+};
+
+RaytracingAccelerationStructure AS_Plain : register(t3, space1);
+RaytracingAccelerationStructure AS[] : register(t100, space1);
+RaytracingAccelerationStructure AS_Local[] : register(t3, space15);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload p;
+	p.color = float4(1, 2, 3, 4);
+	TraceRay(AS[10], RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+	TraceRay(AS_Plain, RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+	TraceRay(AS[NonUniformResourceIndex(int(p.color.w))], RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+	TraceRay(AS_Local[200], RAY_FLAG_NONE, 0, 0, 0, 0, ray, p);
+}
+

--- a/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
+++ b/shaders/descriptor_qa/descriptor_qa.bindless.cbv-as-ssbo.descriptor-qa.comp
@@ -1,0 +1,62 @@
+struct C { float v; };
+ConstantBuffer<C> c : register(b0, space0);
+ConstantBuffer<C> carr[2] : register(b1, space0);
+
+Texture2D<float> tex : register(t0, space0);
+Texture2D<float> texarr[2] : register(t1, space0);
+Buffer<float> typedbuf : register(t3, space0);
+Buffer<float> typedbufarr[2] : register(t4, space0);
+StructuredBuffer<float> buf : register(t6, space0);
+StructuredBuffer<float> bufarr[2] : register(t7, space0);
+ByteAddressBuffer rawbuf : register(t9, space0);
+ByteAddressBuffer rawbufarr[2] : register(t10, space0);
+
+RWStructuredBuffer<float> rwbuf : register(u0, space0);
+RWStructuredBuffer<float> rwbufarr[2] : register(u1, space0);
+RWByteAddressBuffer rwrawbuf : register(u3, space0);
+RWByteAddressBuffer rwrawbufarr[2] : register(u4, space0);
+RWTexture2D<float> rwtex : register(u6, space0);
+RWTexture2D<float> rwtexarr[2] : register(u7, space0);
+RWBuffer<float> rwtypedbuf : register(u9, space0);
+RWBuffer<float> rwtypedbufarr[2] : register(u10, space0);
+
+[numthreads(1, 1, 1)]
+void main(uint index : SV_DispatchThreadID)
+{
+	float value = 0.0;
+	if (index > 2)
+		value += c.v;
+	if (index > 3)
+		value += carr[index].v;
+	if (index > 4)
+		value += tex[int2(index, 0)];
+	if (index > 5)
+		value += texarr[index & 1][int2(0, index)];
+	if (index > 6)
+		value += typedbuf[index];
+	if (index > 7)
+		value += typedbufarr[index & 1][index];
+	if (index > 8)
+		value += buf[index];
+	if (index > 9)
+		value += bufarr[index & 1][index];
+	if (index > 10)
+		value += asfloat(rawbuf.Load(4 * index));
+	if (index > 11)
+		value += asfloat(rawbufarr[index & 1].Load(index));
+
+	if (index > 1)
+		rwbuf[index] = value;
+	if (index > 30)
+		rwbufarr[index & 1][index] = value;
+	if (index > 40)
+		rwrawbuf.Store(4 * index, asuint(value));
+	if (index > 50)
+		rwrawbufarr[index & 1].Store(4 * index, asuint(value));
+	if (index > 80)
+		rwtex[int2(index, 0)] = value;
+	if (index > 90)
+		rwtexarr[index & 1][int2(0, index)] = value;
+
+	rwbuf.IncrementCounter();
+}

--- a/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
+++ b/shaders/descriptor_qa/descriptor_qa.bindless.descriptor-qa.comp
@@ -1,0 +1,64 @@
+struct C { float v; };
+ConstantBuffer<C> c : register(b0, space0);
+ConstantBuffer<C> carr[2] : register(b1, space0);
+
+Texture2D<float> tex : register(t0, space0);
+Texture2D<float> texarr[2] : register(t1, space0);
+Buffer<float> typedbuf : register(t3, space0);
+Buffer<float> typedbufarr[2] : register(t4, space0);
+StructuredBuffer<float> buf : register(t6, space0);
+StructuredBuffer<float> bufarr[2] : register(t7, space0);
+ByteAddressBuffer rawbuf : register(t9, space0);
+ByteAddressBuffer rawbufarr[2] : register(t10, space0);
+
+RWStructuredBuffer<float> rwbuf : register(u0, space0);
+RWStructuredBuffer<float> rwbufarr[2] : register(u1, space0);
+RWByteAddressBuffer rwrawbuf : register(u3, space0);
+RWByteAddressBuffer rwrawbufarr[2] : register(u4, space0);
+RWTexture2D<float> rwtex : register(u6, space0);
+RWTexture2D<float> rwtexarr[2] : register(u7, space0);
+RWBuffer<float> rwtypedbuf : register(u9, space0);
+RWBuffer<float> rwtypedbufarr[2] : register(u10, space0);
+
+SamplerState samp : register(s0, space0);
+
+[numthreads(1, 1, 1)]
+void main(uint index : SV_DispatchThreadID)
+{
+	float value = 0.0;
+	if (index > 2)
+		value += c.v;
+	if (index > 3)
+		value += carr[index].v;
+	if (index > 4)
+		value += tex.SampleLevel(samp, float2(0.5, 0.5), 0.0);
+	if (index > 5)
+		value += texarr[index & 1][int2(0, index)];
+	if (index > 6)
+		value += typedbuf[index];
+	if (index > 7)
+		value += typedbufarr[index & 1][index];
+	if (index > 8)
+		value += buf[index];
+	if (index > 9)
+		value += bufarr[index & 1][index];
+	if (index > 10)
+		value += asfloat(rawbuf.Load(4 * index));
+	if (index > 11)
+		value += asfloat(rawbufarr[index & 1].Load(index));
+
+	if (index > 1)
+		rwbuf[index] = value;
+	if (index > 30)
+		rwbufarr[index & 1][index] = value;
+	if (index > 40)
+		rwrawbuf.Store(4 * index, asuint(value));
+	if (index > 50)
+		rwrawbufarr[index & 1].Store(4 * index, asuint(value));
+	if (index > 80)
+		rwtex[int2(index, 0)] = value;
+	if (index > 90)
+		rwtexarr[index & 1][int2(0, index)] = value;
+
+	rwbuf.IncrementCounter();
+}

--- a/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
+++ b/shaders/descriptor_qa/descriptor_qa.bindless.ssbo.descriptor-qa.comp
@@ -1,0 +1,62 @@
+struct C { float v; };
+ConstantBuffer<C> c : register(b0, space0);
+ConstantBuffer<C> carr[2] : register(b1, space0);
+
+Texture2D<float> tex : register(t0, space0);
+Texture2D<float> texarr[2] : register(t1, space0);
+Buffer<float> typedbuf : register(t3, space0);
+Buffer<float> typedbufarr[2] : register(t4, space0);
+StructuredBuffer<float> buf : register(t6, space0);
+StructuredBuffer<float> bufarr[2] : register(t7, space0);
+ByteAddressBuffer rawbuf : register(t9, space0);
+ByteAddressBuffer rawbufarr[2] : register(t10, space0);
+
+RWStructuredBuffer<float> rwbuf : register(u0, space0);
+RWStructuredBuffer<float> rwbufarr[2] : register(u1, space0);
+RWByteAddressBuffer rwrawbuf : register(u3, space0);
+RWByteAddressBuffer rwrawbufarr[2] : register(u4, space0);
+RWTexture2D<float> rwtex : register(u6, space0);
+RWTexture2D<float> rwtexarr[2] : register(u7, space0);
+RWBuffer<float> rwtypedbuf : register(u9, space0);
+RWBuffer<float> rwtypedbufarr[2] : register(u10, space0);
+
+[numthreads(1, 1, 1)]
+void main(uint index : SV_DispatchThreadID)
+{
+	float value = 0.0;
+	if (index > 2)
+		value += c.v;
+	if (index > 3)
+		value += carr[index].v;
+	if (index > 4)
+		value += tex[int2(index, 0)];
+	if (index > 5)
+		value += texarr[index & 1][int2(0, index)];
+	if (index > 6)
+		value += typedbuf[index];
+	if (index > 7)
+		value += typedbufarr[index & 1][index];
+	if (index > 8)
+		value += buf[index];
+	if (index > 9)
+		value += bufarr[index & 1][index];
+	if (index > 10)
+		value += asfloat(rawbuf.Load(4 * index));
+	if (index > 11)
+		value += asfloat(rawbufarr[index & 1].Load(index));
+
+	if (index > 1)
+		rwbuf[index] = value;
+	if (index > 30)
+		rwbufarr[index & 1][index] = value;
+	if (index > 40)
+		rwrawbuf.Store(4 * index, asuint(value));
+	if (index > 50)
+		rwrawbufarr[index & 1].Store(4 * index, asuint(value));
+	if (index > 80)
+		rwtex[int2(index, 0)] = value;
+	if (index > 90)
+		rwtexarr[index & 1][int2(0, index)] = value;
+
+	rwbuf.IncrementCounter();
+}

--- a/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
+++ b/shaders/descriptor_qa/early-2.bindless.descriptor-qa.frag
@@ -1,0 +1,9 @@
+Texture2D<float4> T : register(t0);
+SamplerState S : register(s0);
+
+float4 main(float2 uv : UV) : SV_Target
+{
+	if (uv.x < 0.0)
+		discard;
+	return T.Sample(S, uv);
+}

--- a/shaders/descriptor_qa/early-3.bindless.descriptor-qa.frag
+++ b/shaders/descriptor_qa/early-3.bindless.descriptor-qa.frag
@@ -1,0 +1,12 @@
+Texture2D<float4> T : register(t0);
+SamplerState S : register(s0);
+
+struct Out { float4 col : SV_Target; float d : SV_Depth; };
+
+Out main(float2 uv : UV)
+{
+	Out o;
+	o.col = T.Sample(S, uv);
+	o.d = 0.5;
+	return o;
+}

--- a/shaders/descriptor_qa/early-4.bindless.descriptor-qa.frag
+++ b/shaders/descriptor_qa/early-4.bindless.descriptor-qa.frag
@@ -1,0 +1,12 @@
+Texture2D<float4> T : register(t0);
+SamplerState S : register(s0);
+
+struct Out { float4 col : SV_Target; uint d : SV_Coverage; };
+
+Out main(float2 uv : UV)
+{
+	Out o;
+	o.col = T.Sample(S, uv);
+	o.d = 3;
+	return o;
+}

--- a/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
+++ b/shaders/descriptor_qa/early-5.bindless.descriptor-qa.frag
@@ -1,0 +1,10 @@
+Texture2D<float4> T : register(t0);
+SamplerState S : register(s0);
+RWTexture2D<float4> U : register(u0);
+
+float4 main(float2 uv : UV) : SV_Target
+{
+	if (uv.x < 0.0)
+		U[int2(uv)] = 2.0.xxxx;
+	return T.Sample(S, uv);
+}

--- a/shaders/descriptor_qa/early.bindless.descriptor-qa.frag
+++ b/shaders/descriptor_qa/early.bindless.descriptor-qa.frag
@@ -1,0 +1,7 @@
+Texture2D<float4> T : register(t0);
+SamplerState S : register(s0);
+
+float4 main(float2 uv : UV) : SV_Target
+{
+	return T.Sample(S, uv);
+}

--- a/spirv_module.hpp
+++ b/spirv_module.hpp
@@ -21,6 +21,7 @@
 #include "thread_local_allocator.hpp"
 #include "cfg_structurizer.hpp"
 #include "ir.hpp"
+#include "descriptor_qa.hpp"
 #include <memory>
 
 namespace spv
@@ -34,6 +35,11 @@ namespace dxil_spv
 {
 struct CFGNode;
 class CFGNodePool;
+
+enum class HelperCall
+{
+	DescriptorQACheck
+};
 
 class SPIRVModule
 {
@@ -69,6 +75,10 @@ public:
 	spv::Id create_variable(spv::StorageClass storage, spv::Id type, const char *name = nullptr);
 	spv::Id create_variable_with_initializer(spv::StorageClass storage, spv::Id type, spv::Id initializer,
 	                                         const char *name = nullptr);
+
+	spv::Id get_helper_call_id(HelperCall call);
+	void set_descriptor_qa_info(const DescriptorQAInfo &info);
+	const DescriptorQAInfo &get_descriptor_qa_info() const;
 
 	DXIL_SPV_OVERRIDE_NEW_DELETE
 

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -187,6 +187,8 @@ def cross_compile_dxil(shader, args, paths, is_asm):
         hlsl_cmd += ['--debug-all-entry-points']
     if '.16bit-io.' in shader:
         hlsl_cmd += ['--storage-input-output-16bit']
+    if '.descriptor-qa.' in shader:
+        hlsl_cmd += ['--descriptor-qa', '10', '10', 'deadbeef']
 
     subprocess.check_call(hlsl_cmd)
     if is_asm:


### PR DESCRIPTION
Allows host to pass down two SSBOs which maintain information
about the CBV_SRV_UAV heap, and allows faults to be signalled to host.

Allows us to check if:
- Heap index is out of bounds
- The resource in question is destroyed
- Descriptor is accessed with wrong type

On a fault, a fallback heap index is returned, which should point to a null
descriptor.