### PR TITLE
Update DXC for Test Suite

### DIFF
--- a/checkout_dxc.sh
+++ b/checkout_dxc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DXC_REV=d0e9147ab86c8cb29a5fd81bd758e44d440c332c
+# Commit before GatherCmp regression
+DXC_REV=19360a8fa63ee29925f59328c261c1c920402bfd
 
 if [ -z $PROTOCOL ]; then
 	PROTOCOL=git

--- a/reference/shaders/control-flow/dual-inner-loop-early-return.comp
+++ b/reference/shaders/control-flow/dual-inner-loop-early-return.comp
@@ -128,8 +128,8 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %21 = OpConstant %5 2
 %30 = OpTypeBool
 %32 = OpConstant %5 10
-%34 = OpConstant %5 50
-%35 = OpConstant %5 70
+%34 = OpConstant %5 70
+%35 = OpConstant %5 50
 %38 = OpConstant %5 80
 %39 = OpTypeVector %5 4
 %42 = OpConstant %5 20
@@ -182,7 +182,7 @@ OpBranchConditional %41 %54 %60
 %60 = OpLabel
 %44 = OpPhi %30 %45 %57 %46 %58 %46 %59
 %48 = OpPhi %5 %26 %57 %19 %58 %19 %59
-%49 = OpPhi %5 %50 %57 %35 %58 %34 %59
+%49 = OpPhi %5 %50 %57 %34 %58 %35 %59
 OpSelectionMerge %61 None
 OpBranchConditional %44 %63 %61
 %61 = OpLabel

--- a/reference/shaders/dxil-builtin/call-shader.rgen
+++ b/reference/shaders/dxil-builtin/call-shader.rgen
@@ -15,11 +15,11 @@ layout(location = 3) callableDataEXT _10 _15;
 
 void main()
 {
-    executeCallableEXT(0u, 3);
-    executeCallableEXT(1u, 2);
-    executeCallableEXT(2u, 1);
-    executeCallableEXT(3u, 0);
-    imageStore(IMG, ivec2(uvec2(gl_LaunchIDEXT.x, gl_LaunchIDEXT.y)), vec4(((_14._m0.x + _15._m0.x) + _13._m0.x) + _12._m0.x, ((_14._m0.y + _15._m0.y) + _13._m0.y) + _12._m0.y, ((_14._m0.z + _15._m0.z) + _13._m0.z) + _12._m0.z, ((_14._m0.w + _15._m0.w) + _13._m0.w) + _12._m0.w));
+    executeCallableEXT(0u, 0);
+    executeCallableEXT(1u, 1);
+    executeCallableEXT(2u, 2);
+    executeCallableEXT(3u, 3);
+    imageStore(IMG, ivec2(uvec2(gl_LaunchIDEXT.x, gl_LaunchIDEXT.y)), vec4(((_13._m0.x + _12._m0.x) + _14._m0.x) + _15._m0.x, ((_13._m0.y + _12._m0.y) + _14._m0.y) + _15._m0.y, ((_13._m0.z + _12._m0.z) + _14._m0.z) + _15._m0.z, ((_13._m0.w + _12._m0.w) + _14._m0.w) + _15._m0.w));
 }
 
 
@@ -68,10 +68,10 @@ OpDecorate %60 BuiltIn LaunchIdNV
 %15 = OpVariable %11 CallableDataNV
 %16 = OpTypeInt 32 0
 %17 = OpConstant %16 0
-%18 = OpTypePointer CallableDataNV %9
-%25 = OpConstant %16 1
-%32 = OpConstant %16 2
-%39 = OpConstant %16 3
+%18 = OpConstant %16 1
+%19 = OpConstant %16 2
+%20 = OpConstant %16 3
+%21 = OpTypePointer CallableDataNV %9
 %58 = OpTypeVector %16 3
 %59 = OpTypePointer Input %58
 %60 = OpVariable %59 Input
@@ -81,53 +81,53 @@ OpDecorate %60 BuiltIn LaunchIdNV
 %4 = OpLabel
 OpBranch %70
 %70 = OpLabel
-OpExecuteCallableKHR %17 %15
-%19 = OpInBoundsAccessChain %18 %15 %17
-%20 = OpLoad %9 %19
-%21 = OpCompositeExtract %5 %20 0
-%22 = OpCompositeExtract %5 %20 1
-%23 = OpCompositeExtract %5 %20 2
-%24 = OpCompositeExtract %5 %20 3
-OpExecuteCallableKHR %25 %14
-%26 = OpInBoundsAccessChain %18 %14 %17
-%27 = OpLoad %9 %26
-%28 = OpCompositeExtract %5 %27 0
-%29 = OpCompositeExtract %5 %27 1
-%30 = OpCompositeExtract %5 %27 2
-%31 = OpCompositeExtract %5 %27 3
-OpExecuteCallableKHR %32 %13
-%33 = OpInBoundsAccessChain %18 %13 %17
-%34 = OpLoad %9 %33
-%35 = OpCompositeExtract %5 %34 0
-%36 = OpCompositeExtract %5 %34 1
-%37 = OpCompositeExtract %5 %34 2
-%38 = OpCompositeExtract %5 %34 3
-OpExecuteCallableKHR %39 %12
-%40 = OpInBoundsAccessChain %18 %12 %17
-%41 = OpLoad %9 %40
-%42 = OpCompositeExtract %5 %41 0
-%43 = OpCompositeExtract %5 %41 1
-%44 = OpCompositeExtract %5 %41 2
-%45 = OpCompositeExtract %5 %41 3
-%46 = OpFAdd %5 %28 %21
-%47 = OpFAdd %5 %29 %22
-%48 = OpFAdd %5 %30 %23
-%49 = OpFAdd %5 %31 %24
-%50 = OpFAdd %5 %46 %35
-%51 = OpFAdd %5 %47 %36
-%52 = OpFAdd %5 %48 %37
-%53 = OpFAdd %5 %49 %38
-%54 = OpFAdd %5 %50 %42
-%55 = OpFAdd %5 %51 %43
-%56 = OpFAdd %5 %52 %44
-%57 = OpFAdd %5 %53 %45
+OpExecuteCallableKHR %17 %12
+OpExecuteCallableKHR %18 %13
+OpExecuteCallableKHR %19 %14
+OpExecuteCallableKHR %20 %15
+%22 = OpInBoundsAccessChain %21 %12 %17
+%23 = OpLoad %9 %22
+%24 = OpCompositeExtract %5 %23 0
+%25 = OpCompositeExtract %5 %23 1
+%26 = OpCompositeExtract %5 %23 2
+%27 = OpCompositeExtract %5 %23 3
+%28 = OpInBoundsAccessChain %21 %13 %17
+%29 = OpLoad %9 %28
+%30 = OpCompositeExtract %5 %29 0
+%31 = OpFAdd %5 %30 %24
+%32 = OpCompositeExtract %5 %29 1
+%33 = OpFAdd %5 %32 %25
+%34 = OpCompositeExtract %5 %29 2
+%35 = OpFAdd %5 %34 %26
+%36 = OpCompositeExtract %5 %29 3
+%37 = OpFAdd %5 %36 %27
+%38 = OpInBoundsAccessChain %21 %14 %17
+%39 = OpLoad %9 %38
+%40 = OpCompositeExtract %5 %39 0
+%41 = OpFAdd %5 %31 %40
+%42 = OpCompositeExtract %5 %39 1
+%43 = OpFAdd %5 %33 %42
+%44 = OpCompositeExtract %5 %39 2
+%45 = OpFAdd %5 %35 %44
+%46 = OpCompositeExtract %5 %39 3
+%47 = OpFAdd %5 %37 %46
+%48 = OpInBoundsAccessChain %21 %15 %17
+%49 = OpLoad %9 %48
+%50 = OpCompositeExtract %5 %49 0
+%51 = OpFAdd %5 %41 %50
+%52 = OpCompositeExtract %5 %49 1
+%53 = OpFAdd %5 %43 %52
+%54 = OpCompositeExtract %5 %49 2
+%55 = OpFAdd %5 %45 %54
+%56 = OpCompositeExtract %5 %49 3
+%57 = OpFAdd %5 %47 %56
 %62 = OpAccessChain %61 %60 %17
 %63 = OpLoad %16 %62
-%64 = OpAccessChain %61 %60 %25
+%64 = OpAccessChain %61 %60 %18
 %65 = OpLoad %16 %64
 %66 = OpLoad %6 %8
 %68 = OpCompositeConstruct %67 %63 %65
-%69 = OpCompositeConstruct %9 %54 %55 %56 %57
+%69 = OpCompositeConstruct %9 %51 %53 %55 %57
 OpImageWrite %66 %68 %69
 OpReturn
 OpFunctionEnd

--- a/reference/shaders/dxil-builtin/clip.demote-to-helper.frag
+++ b/reference/shaders/dxil-builtin/clip.demote-to-helper.frag
@@ -3,9 +3,9 @@
 
 layout(location = 0) in vec2 TEXCOORD;
 
-void demote_cond(bool _27)
+void demote_cond(bool _37)
 {
-    if (_27)
+    if (_37)
     {
         demote;
     }
@@ -13,8 +13,10 @@ void demote_cond(bool _27)
 
 void main()
 {
-    demote_cond((TEXCOORD.x + (-10.0)) < 0.0);
-    demote_cond((TEXCOORD.y + (-20.0)) < 0.0);
+    bool _28 = (TEXCOORD.x + (-10.0)) < 0.0;
+    demote_cond(_28);
+    bool _33 = (TEXCOORD.y + (-20.0)) < 0.0;
+    demote_cond(_33);
 }
 
 
@@ -23,58 +25,69 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 36
+; Bound: 46
 ; Schema: 0
 OpCapability Shader
 OpCapability DemoteToHelperInvocationEXT
 OpExtension "SPV_EXT_demote_to_helper_invocation"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %8
+OpEntryPoint Fragment %3 "main" %8 %13
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %8 "TEXCOORD"
-OpName %28 "demote_cond"
+OpName %38 "demote_cond"
 OpDecorate %8 Location 0
+OpDecorate %13 BuiltIn SampleMask
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeFloat 32
 %6 = OpTypeVector %5 2
 %7 = OpTypePointer Input %6
 %8 = OpVariable %7 Input
-%9 = OpTypePointer Input %5
-%11 = OpTypeInt 32 0
-%12 = OpConstant %11 0
-%15 = OpConstant %11 1
-%18 = OpConstant %5 -10
-%19 = OpTypeBool
-%21 = OpConstant %5 0
-%23 = OpConstant %5 -20
-%26 = OpTypeFunction %1 %19
+%9 = OpTypeInt 32 0
+%10 = OpConstant %9 1
+%11 = OpTypeArray %9 %10
+%12 = OpTypePointer Input %11
+%13 = OpVariable %12 Input
+%14 = OpTypePointer Input %9
+%16 = OpConstant %9 0
+%18 = OpTypeBool
+%21 = OpTypePointer Input %5
+%27 = OpConstant %5 -10
+%29 = OpConstant %5 0
+%32 = OpConstant %5 -20
+%36 = OpTypeFunction %1 %18
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %25
-%25 = OpLabel
-%10 = OpAccessChain %9 %8 %12
-%13 = OpLoad %5 %10
-%14 = OpAccessChain %9 %8 %15
-%16 = OpLoad %5 %14
-%17 = OpFAdd %5 %13 %18
-%20 = OpFOrdLessThan %19 %17 %21
-%33 = OpFunctionCall %1 %28 %20
-%22 = OpFAdd %5 %16 %23
-%24 = OpFOrdLessThan %19 %22 %21
-%34 = OpFunctionCall %1 %28 %24
+OpBranch %35
+%35 = OpLabel
+%15 = OpAccessChain %14 %13 %16
+%17 = OpLoad %9 %15
+%19 = OpIEqual %18 %16 %17
+%20 = OpSelect %9 %19 %10 %16
+%22 = OpAccessChain %21 %8 %16
+%23 = OpLoad %5 %22
+%24 = OpAccessChain %21 %8 %10
+%25 = OpLoad %5 %24
+%26 = OpFAdd %5 %23 %27
+%28 = OpFOrdLessThan %18 %26 %29
+%30 = OpSelect %9 %28 %10 %16
+%43 = OpFunctionCall %1 %38 %28
+%31 = OpFAdd %5 %25 %32
+%33 = OpFOrdLessThan %18 %31 %29
+%34 = OpSelect %9 %33 %10 %16
+%44 = OpFunctionCall %1 %38 %33
 OpReturn
 OpFunctionEnd
-%28 = OpFunction %1 None %26
-%27 = OpFunctionParameter %19
-%29 = OpLabel
-OpSelectionMerge %31 None
-OpBranchConditional %27 %30 %31
-%30 = OpLabel
+%38 = OpFunction %1 None %36
+%37 = OpFunctionParameter %18
+%39 = OpLabel
+OpSelectionMerge %41 None
+OpBranchConditional %37 %40 %41
+%40 = OpLabel
 OpDemoteToHelperInvocationEXT
-OpBranch %31
-%31 = OpLabel
+OpBranch %41
+%41 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/dxil-builtin/clip.frag
+++ b/reference/shaders/dxil-builtin/clip.frag
@@ -3,9 +3,9 @@
 layout(location = 0) in vec2 TEXCOORD;
 bool discard_state;
 
-void discard_cond(bool _30)
+void discard_cond(bool _40)
 {
-    if (_30)
+    if (_40)
     {
         discard_state = true;
     }
@@ -22,8 +22,10 @@ void discard_exit()
 void main()
 {
     discard_state = false;
-    discard_cond((TEXCOORD.x + (-10.0)) < 0.0);
-    discard_cond((TEXCOORD.y + (-20.0)) < 0.0);
+    bool _28 = (TEXCOORD.x + (-10.0)) < 0.0;
+    discard_cond(_28);
+    bool _36 = (TEXCOORD.y + (-20.0)) < 0.0;
+    discard_cond(_36);
     discard_exit();
 }
 
@@ -33,74 +35,85 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 47
+; Bound: 57
 ; Schema: 0
 OpCapability Shader
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %8
+OpEntryPoint Fragment %3 "main" %8 %13
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %8 "TEXCOORD"
-OpName %23 "discard_state"
-OpName %31 "discard_cond"
-OpName %39 "discard_exit"
+OpName %32 "discard_state"
+OpName %41 "discard_cond"
+OpName %49 "discard_exit"
 OpDecorate %8 Location 0
+OpDecorate %13 BuiltIn SampleMask
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeFloat 32
 %6 = OpTypeVector %5 2
 %7 = OpTypePointer Input %6
 %8 = OpVariable %7 Input
-%9 = OpTypePointer Input %5
-%11 = OpTypeInt 32 0
-%12 = OpConstant %11 0
-%15 = OpConstant %11 1
-%18 = OpConstant %5 -10
-%19 = OpTypeBool
-%21 = OpConstant %5 0
-%22 = OpTypePointer Private %19
-%23 = OpVariable %22 Private
-%24 = OpConstantFalse %19
-%26 = OpConstant %5 -20
-%29 = OpTypeFunction %1 %19
-%35 = OpConstantTrue %19
+%9 = OpTypeInt 32 0
+%10 = OpConstant %9 1
+%11 = OpTypeArray %9 %10
+%12 = OpTypePointer Input %11
+%13 = OpVariable %12 Input
+%14 = OpTypePointer Input %9
+%16 = OpConstant %9 0
+%18 = OpTypeBool
+%21 = OpTypePointer Input %5
+%27 = OpConstant %5 -10
+%29 = OpConstant %5 0
+%31 = OpTypePointer Private %18
+%32 = OpVariable %31 Private
+%33 = OpConstantFalse %18
+%35 = OpConstant %5 -20
+%39 = OpTypeFunction %1 %18
+%45 = OpConstantTrue %18
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpStore %23 %24
-OpBranch %28
-%28 = OpLabel
-%10 = OpAccessChain %9 %8 %12
-%13 = OpLoad %5 %10
-%14 = OpAccessChain %9 %8 %15
-%16 = OpLoad %5 %14
-%17 = OpFAdd %5 %13 %18
-%20 = OpFOrdLessThan %19 %17 %21
-%37 = OpFunctionCall %1 %31 %20
-%25 = OpFAdd %5 %16 %26
-%27 = OpFOrdLessThan %19 %25 %21
-%38 = OpFunctionCall %1 %31 %27
-%45 = OpFunctionCall %1 %39
+OpStore %32 %33
+OpBranch %38
+%38 = OpLabel
+%15 = OpAccessChain %14 %13 %16
+%17 = OpLoad %9 %15
+%19 = OpIEqual %18 %16 %17
+%20 = OpSelect %9 %19 %10 %16
+%22 = OpAccessChain %21 %8 %16
+%23 = OpLoad %5 %22
+%24 = OpAccessChain %21 %8 %10
+%25 = OpLoad %5 %24
+%26 = OpFAdd %5 %23 %27
+%28 = OpFOrdLessThan %18 %26 %29
+%30 = OpSelect %9 %28 %10 %16
+%47 = OpFunctionCall %1 %41 %28
+%34 = OpFAdd %5 %25 %35
+%36 = OpFOrdLessThan %18 %34 %29
+%37 = OpSelect %9 %36 %10 %16
+%48 = OpFunctionCall %1 %41 %36
+%55 = OpFunctionCall %1 %49
 OpReturn
 OpFunctionEnd
-%31 = OpFunction %1 None %29
-%30 = OpFunctionParameter %19
-%32 = OpLabel
-OpSelectionMerge %34 None
-OpBranchConditional %30 %33 %34
-%33 = OpLabel
-OpStore %23 %35
-OpBranch %34
-%34 = OpLabel
-OpReturn
-OpFunctionEnd
-%39 = OpFunction %1 None %2
-%40 = OpLabel
-%43 = OpLoad %19 %23
-OpSelectionMerge %42 None
-OpBranchConditional %43 %41 %42
-%41 = OpLabel
-OpKill
+%41 = OpFunction %1 None %39
+%40 = OpFunctionParameter %18
 %42 = OpLabel
+OpSelectionMerge %44 None
+OpBranchConditional %40 %43 %44
+%43 = OpLabel
+OpStore %32 %45
+OpBranch %44
+%44 = OpLabel
+OpReturn
+OpFunctionEnd
+%49 = OpFunction %1 None %2
+%50 = OpLabel
+%53 = OpLoad %18 %32
+OpSelectionMerge %52 None
+OpBranchConditional %53 %51 %52
+%51 = OpLabel
+OpKill
+%52 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/dxil-builtin/discard.demote-to-helper.frag
+++ b/reference/shaders/dxil-builtin/discard.demote-to-helper.frag
@@ -24,54 +24,63 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 29
+; Bound: 37
 ; Schema: 0
 OpCapability Shader
 OpCapability DemoteToHelperInvocationEXT
 OpExtension "SPV_EXT_demote_to_helper_invocation"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %8
+OpEntryPoint Fragment %3 "main" %8 %13
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %8 "TEXCOORD"
 OpDecorate %8 Location 0
+OpDecorate %13 BuiltIn SampleMask
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeFloat 32
 %6 = OpTypeVector %5 2
 %7 = OpTypePointer Input %6
 %8 = OpVariable %7 Input
-%9 = OpTypePointer Input %5
-%11 = OpTypeInt 32 0
-%12 = OpConstant %11 0
-%14 = OpTypeBool
-%16 = OpConstant %5 10
-%18 = OpConstant %11 1
-%21 = OpConstant %5 20
+%9 = OpTypeInt 32 0
+%10 = OpConstant %9 1
+%11 = OpTypeArray %9 %10
+%12 = OpTypePointer Input %11
+%13 = OpVariable %12 Input
+%14 = OpTypePointer Input %9
+%16 = OpConstant %9 0
+%18 = OpTypeBool
+%21 = OpTypePointer Input %5
+%25 = OpConstant %5 10
+%29 = OpConstant %5 20
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %22
-%22 = OpLabel
-%10 = OpAccessChain %9 %8 %12
-%13 = OpLoad %5 %10
-%15 = OpFOrdGreaterThan %14 %13 %16
-OpSelectionMerge %27 None
-OpBranchConditional %15 %26 %23
-%26 = OpLabel
+OpBranch %30
+%30 = OpLabel
+%15 = OpAccessChain %14 %13 %16
+%17 = OpLoad %9 %15
+%19 = OpIEqual %18 %16 %17
+%20 = OpSelect %9 %19 %10 %16
+%22 = OpAccessChain %21 %8 %16
+%23 = OpLoad %5 %22
+%24 = OpFOrdGreaterThan %18 %23 %25
+OpSelectionMerge %35 None
+OpBranchConditional %24 %34 %31
+%34 = OpLabel
 OpDemoteToHelperInvocationEXT
-OpBranch %27
-%23 = OpLabel
-%17 = OpAccessChain %9 %8 %18
-%19 = OpLoad %5 %17
-%20 = OpFOrdGreaterThan %14 %19 %21
-OpSelectionMerge %25 None
-OpBranchConditional %20 %24 %25
-%24 = OpLabel
+OpBranch %35
+%31 = OpLabel
+%26 = OpAccessChain %21 %8 %10
+%27 = OpLoad %5 %26
+%28 = OpFOrdGreaterThan %18 %27 %29
+OpSelectionMerge %33 None
+OpBranchConditional %28 %32 %33
+%32 = OpLabel
 OpDemoteToHelperInvocationEXT
-OpBranch %25
-%25 = OpLabel
-OpBranch %27
-%27 = OpLabel
+OpBranch %33
+%33 = OpLabel
+OpBranch %35
+%35 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/dxil-builtin/discard.frag
+++ b/reference/shaders/dxil-builtin/discard.frag
@@ -34,70 +34,79 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 40
+; Bound: 48
 ; Schema: 0
 OpCapability Shader
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %8
+OpEntryPoint Fragment %3 "main" %8 %13
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %8 "TEXCOORD"
-OpName %18 "discard_state"
-OpName %32 "discard_exit"
+OpName %27 "discard_state"
+OpName %40 "discard_exit"
 OpDecorate %8 Location 0
+OpDecorate %13 BuiltIn SampleMask
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeFloat 32
 %6 = OpTypeVector %5 2
 %7 = OpTypePointer Input %6
 %8 = OpVariable %7 Input
-%9 = OpTypePointer Input %5
-%11 = OpTypeInt 32 0
-%12 = OpConstant %11 0
-%14 = OpTypeBool
-%16 = OpConstant %5 10
-%17 = OpTypePointer Private %14
-%18 = OpVariable %17 Private
-%19 = OpConstantFalse %14
-%21 = OpConstant %11 1
-%24 = OpConstant %5 20
-%31 = OpConstantTrue %14
+%9 = OpTypeInt 32 0
+%10 = OpConstant %9 1
+%11 = OpTypeArray %9 %10
+%12 = OpTypePointer Input %11
+%13 = OpVariable %12 Input
+%14 = OpTypePointer Input %9
+%16 = OpConstant %9 0
+%18 = OpTypeBool
+%21 = OpTypePointer Input %5
+%25 = OpConstant %5 10
+%26 = OpTypePointer Private %18
+%27 = OpVariable %26 Private
+%28 = OpConstantFalse %18
+%32 = OpConstant %5 20
+%39 = OpConstantTrue %18
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpStore %18 %19
-OpBranch %25
-%25 = OpLabel
-%10 = OpAccessChain %9 %8 %12
-%13 = OpLoad %5 %10
-%15 = OpFOrdGreaterThan %14 %13 %16
-OpSelectionMerge %30 None
-OpBranchConditional %15 %29 %26
-%29 = OpLabel
-OpStore %18 %31
-OpBranch %30
-%26 = OpLabel
-%20 = OpAccessChain %9 %8 %21
-%22 = OpLoad %5 %20
-%23 = OpFOrdGreaterThan %14 %22 %24
-OpSelectionMerge %28 None
-OpBranchConditional %23 %27 %28
-%27 = OpLabel
-OpStore %18 %31
-OpBranch %28
-%28 = OpLabel
-OpBranch %30
-%30 = OpLabel
-%38 = OpFunctionCall %1 %32
+OpStore %27 %28
+OpBranch %33
+%33 = OpLabel
+%15 = OpAccessChain %14 %13 %16
+%17 = OpLoad %9 %15
+%19 = OpIEqual %18 %16 %17
+%20 = OpSelect %9 %19 %10 %16
+%22 = OpAccessChain %21 %8 %16
+%23 = OpLoad %5 %22
+%24 = OpFOrdGreaterThan %18 %23 %25
+OpSelectionMerge %38 None
+OpBranchConditional %24 %37 %34
+%37 = OpLabel
+OpStore %27 %39
+OpBranch %38
+%34 = OpLabel
+%29 = OpAccessChain %21 %8 %10
+%30 = OpLoad %5 %29
+%31 = OpFOrdGreaterThan %18 %30 %32
+OpSelectionMerge %36 None
+OpBranchConditional %31 %35 %36
+%35 = OpLabel
+OpStore %27 %39
+OpBranch %36
+%36 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%46 = OpFunctionCall %1 %40
 OpReturn
 OpFunctionEnd
-%32 = OpFunction %1 None %2
-%33 = OpLabel
-%36 = OpLoad %14 %18
-OpSelectionMerge %35 None
-OpBranchConditional %36 %34 %35
-%34 = OpLabel
+%40 = OpFunction %1 None %2
+%41 = OpLabel
+%44 = OpLoad %18 %27
+OpSelectionMerge %43 None
+OpBranchConditional %44 %42 %43
+%42 = OpLabel
 OpKill
-%35 = OpLabel
+%43 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/dxil-builtin/wave-active-ballot-discard.demote-to-helper.frag
+++ b/reference/shaders/dxil-builtin/wave-active-ballot-discard.demote-to-helper.frag
@@ -11,11 +11,11 @@ void main()
     {
         demote;
     }
-    uvec4 _17 = subgroupBallot(INDEX < 100u);
-    SV_Target.x = _17.x;
-    SV_Target.y = _17.y;
-    SV_Target.z = _17.z;
-    SV_Target.w = _17.w;
+    uvec4 _26 = subgroupBallot(INDEX < 100u);
+    SV_Target.x = _26.x;
+    SV_Target.y = _26.y;
+    SV_Target.z = _26.z;
+    SV_Target.w = _26.w;
 }
 
 
@@ -24,14 +24,14 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 35
+; Bound: 42
 ; Schema: 0
 OpCapability Shader
 OpCapability GroupNonUniformBallot
 OpCapability DemoteToHelperInvocationEXT
 OpExtension "SPV_EXT_demote_to_helper_invocation"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %7 %10
+OpEntryPoint Fragment %3 "main" %7 %10 %14
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %7 "INDEX"
@@ -39,6 +39,7 @@ OpName %10 "SV_Target"
 OpDecorate %7 Flat
 OpDecorate %7 Location 0
 OpDecorate %10 Location 0
+OpDecorate %14 BuiltIn SampleMask
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -47,40 +48,47 @@ OpDecorate %10 Location 0
 %8 = OpTypeVector %5 4
 %9 = OpTypePointer Output %8
 %10 = OpVariable %9 Output
-%12 = OpTypeBool
-%14 = OpConstant %5 40
-%16 = OpConstant %5 100
-%18 = OpConstant %5 3
-%23 = OpTypePointer Output %5
-%25 = OpConstant %5 0
-%27 = OpConstant %5 1
-%29 = OpConstant %5 2
+%11 = OpConstant %5 1
+%12 = OpTypeArray %5 %11
+%13 = OpTypePointer Input %12
+%14 = OpVariable %13 Input
+%16 = OpConstant %5 0
+%18 = OpTypeBool
+%23 = OpConstant %5 40
+%25 = OpConstant %5 100
+%27 = OpConstant %5 3
+%32 = OpTypePointer Output %5
+%36 = OpConstant %5 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %31
-%31 = OpLabel
-%11 = OpLoad %5 %7
-%13 = OpIEqual %12 %11 %14
-OpSelectionMerge %33 None
-OpBranchConditional %13 %32 %33
-%32 = OpLabel
+OpBranch %38
+%38 = OpLabel
+%15 = OpAccessChain %6 %14 %16
+%17 = OpLoad %5 %15
+%19 = OpIEqual %18 %16 %17
+%20 = OpSelect %5 %19 %11 %16
+%21 = OpLoad %5 %7
+%22 = OpIEqual %18 %21 %23
+OpSelectionMerge %40 None
+OpBranchConditional %22 %39 %40
+%39 = OpLabel
 OpDemoteToHelperInvocationEXT
-OpBranch %33
-%33 = OpLabel
-%15 = OpULessThan %12 %11 %16
-%17 = OpGroupNonUniformBallot %8 %18 %15
-%19 = OpCompositeExtract %5 %17 0
-%20 = OpCompositeExtract %5 %17 1
-%21 = OpCompositeExtract %5 %17 2
-%22 = OpCompositeExtract %5 %17 3
-%24 = OpAccessChain %23 %10 %25
-OpStore %24 %19
-%26 = OpAccessChain %23 %10 %27
-OpStore %26 %20
-%28 = OpAccessChain %23 %10 %29
-OpStore %28 %21
-%30 = OpAccessChain %23 %10 %18
-OpStore %30 %22
+OpBranch %40
+%40 = OpLabel
+%24 = OpULessThan %18 %21 %25
+%26 = OpGroupNonUniformBallot %8 %27 %24
+%28 = OpCompositeExtract %5 %26 0
+%29 = OpCompositeExtract %5 %26 1
+%30 = OpCompositeExtract %5 %26 2
+%31 = OpCompositeExtract %5 %26 3
+%33 = OpAccessChain %32 %10 %16
+OpStore %33 %28
+%34 = OpAccessChain %32 %10 %11
+OpStore %34 %29
+%35 = OpAccessChain %32 %10 %36
+OpStore %35 %30
+%37 = OpAccessChain %32 %10 %27
+OpStore %37 %31
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/dxil-builtin/wave-active-ballot-discard.frag
+++ b/reference/shaders/dxil-builtin/wave-active-ballot-discard.frag
@@ -20,11 +20,11 @@ void main()
     {
         discard_state = true;
     }
-    uvec4 _20 = subgroupBallot(INDEX < 100u);
-    SV_Target.x = _20.x;
-    SV_Target.y = _20.y;
-    SV_Target.z = _20.z;
-    SV_Target.w = _20.w;
+    uvec4 _29 = subgroupBallot(INDEX < 100u);
+    SV_Target.x = _29.x;
+    SV_Target.y = _29.y;
+    SV_Target.z = _29.z;
+    SV_Target.w = _29.w;
     discard_exit();
 }
 
@@ -34,21 +34,22 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 46
+; Bound: 53
 ; Schema: 0
 OpCapability Shader
 OpCapability GroupNonUniformBallot
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %7 %10
+OpEntryPoint Fragment %3 "main" %7 %10 %14
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %7 "INDEX"
 OpName %10 "SV_Target"
-OpName %16 "discard_state"
-OpName %38 "discard_exit"
+OpName %25 "discard_state"
+OpName %45 "discard_exit"
 OpDecorate %7 Flat
 OpDecorate %7 Location 0
 OpDecorate %10 Location 0
+OpDecorate %14 BuiltIn SampleMask
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -57,56 +58,63 @@ OpDecorate %10 Location 0
 %8 = OpTypeVector %5 4
 %9 = OpTypePointer Output %8
 %10 = OpVariable %9 Output
-%12 = OpTypeBool
-%14 = OpConstant %5 40
-%15 = OpTypePointer Private %12
-%16 = OpVariable %15 Private
-%17 = OpConstantFalse %12
-%19 = OpConstant %5 100
-%21 = OpConstant %5 3
-%26 = OpTypePointer Output %5
-%28 = OpConstant %5 0
-%30 = OpConstant %5 1
-%32 = OpConstant %5 2
-%37 = OpConstantTrue %12
+%11 = OpConstant %5 1
+%12 = OpTypeArray %5 %11
+%13 = OpTypePointer Input %12
+%14 = OpVariable %13 Input
+%16 = OpConstant %5 0
+%18 = OpTypeBool
+%23 = OpConstant %5 40
+%24 = OpTypePointer Private %18
+%25 = OpVariable %24 Private
+%26 = OpConstantFalse %18
+%28 = OpConstant %5 100
+%30 = OpConstant %5 3
+%35 = OpTypePointer Output %5
+%39 = OpConstant %5 2
+%44 = OpConstantTrue %18
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpStore %16 %17
-OpBranch %34
-%34 = OpLabel
-%11 = OpLoad %5 %7
-%13 = OpIEqual %12 %11 %14
-OpSelectionMerge %36 None
-OpBranchConditional %13 %35 %36
-%35 = OpLabel
-OpStore %16 %37
-OpBranch %36
-%36 = OpLabel
-%18 = OpULessThan %12 %11 %19
-%20 = OpGroupNonUniformBallot %8 %21 %18
-%22 = OpCompositeExtract %5 %20 0
-%23 = OpCompositeExtract %5 %20 1
-%24 = OpCompositeExtract %5 %20 2
-%25 = OpCompositeExtract %5 %20 3
-%27 = OpAccessChain %26 %10 %28
-OpStore %27 %22
-%29 = OpAccessChain %26 %10 %30
-OpStore %29 %23
-%31 = OpAccessChain %26 %10 %32
-OpStore %31 %24
-%33 = OpAccessChain %26 %10 %21
-OpStore %33 %25
-%44 = OpFunctionCall %1 %38
+OpStore %25 %26
+OpBranch %41
+%41 = OpLabel
+%15 = OpAccessChain %6 %14 %16
+%17 = OpLoad %5 %15
+%19 = OpIEqual %18 %16 %17
+%20 = OpSelect %5 %19 %11 %16
+%21 = OpLoad %5 %7
+%22 = OpIEqual %18 %21 %23
+OpSelectionMerge %43 None
+OpBranchConditional %22 %42 %43
+%42 = OpLabel
+OpStore %25 %44
+OpBranch %43
+%43 = OpLabel
+%27 = OpULessThan %18 %21 %28
+%29 = OpGroupNonUniformBallot %8 %30 %27
+%31 = OpCompositeExtract %5 %29 0
+%32 = OpCompositeExtract %5 %29 1
+%33 = OpCompositeExtract %5 %29 2
+%34 = OpCompositeExtract %5 %29 3
+%36 = OpAccessChain %35 %10 %16
+OpStore %36 %31
+%37 = OpAccessChain %35 %10 %11
+OpStore %37 %32
+%38 = OpAccessChain %35 %10 %39
+OpStore %38 %33
+%40 = OpAccessChain %35 %10 %30
+OpStore %40 %34
+%51 = OpFunctionCall %1 %45
 OpReturn
 OpFunctionEnd
-%38 = OpFunction %1 None %2
-%39 = OpLabel
-%42 = OpLoad %12 %16
-OpSelectionMerge %41 None
-OpBranchConditional %42 %40 %41
-%40 = OpLabel
+%45 = OpFunction %1 None %2
+%46 = OpLabel
+%49 = OpLoad %18 %25
+OpSelectionMerge %48 None
+OpBranchConditional %49 %47 %48
+%47 = OpLabel
 OpKill
-%41 = OpLabel
+%48 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/llvm-builtin/glitched-integer-width.comp
+++ b/reference/shaders/llvm-builtin/glitched-integer-width.comp
@@ -10,22 +10,23 @@ layout(set = 0, binding = 0) uniform writeonly image2DArray _8;
 
 void main()
 {
-    uint _24;
-    bool _27;
-    for (;;)
+    uint _24 = floatBitsToUint(_15._m0[0u]).x + 4294967295u;
+    bool _38;
+    if (_24 < 11u)
     {
-        _24 = floatBitsToUint(_15._m0[0u]).x + 4294967295u;
-        _27 = _24 < 11u;
-        if (_27)
-        {
-            if (bitfieldExtract((bitfieldExtract(440u, int(0u), int(11u)) >> bitfieldExtract(bitfieldExtract(_24, int(0u), int(11u)), int(0u), int(11u))) & 1u, int(0u), int(11u)) == bitfieldExtract(0u, int(0u), int(11u)))
-            {
-                imageStore(_8, ivec3(uvec3(1u)), vec4(1.0));
-                break;
-            }
-        }
+        _38 = bitfieldExtract((bitfieldExtract(440u, int(0u), int(11u)) >> bitfieldExtract(bitfieldExtract(_24, int(0u), int(11u)), int(0u), int(11u))) & 1u, int(0u), int(11u)) != bitfieldExtract(0u, int(0u), int(11u));
+    }
+    else
+    {
+        _38 = true;
+    }
+    if (_38)
+    {
         imageStore(_8, ivec3(uvec3(1u)), vec4(0.0));
-        break;
+    }
+    else
+    {
+        imageStore(_8, ivec3(uvec3(1u)), vec4(1.0));
     }
 }
 
@@ -72,13 +73,14 @@ OpDecorate %15 Binding 0
 %26 = OpTypeBool
 %28 = OpConstant %9 11
 %31 = OpConstant %9 440
-%38 = OpConstant %5 0
-%39 = OpTypeVector %9 3
-%42 = OpConstant %5 1
+%39 = OpConstantTrue %26
+%40 = OpConstant %5 0
+%41 = OpTypeVector %9 3
+%44 = OpConstant %5 1
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %45
-%45 = OpLabel
+OpBranch %47
+%47 = OpLabel
 %16 = OpLoad %6 %8
 %19 = OpAccessChain %18 %15 %17 %17
 %20 = OpLoad %11 %19
@@ -86,12 +88,9 @@ OpBranch %45
 %23 = OpCompositeExtract %9 %22 0
 %24 = OpIAdd %9 %23 %25
 %27 = OpULessThan %26 %24 %28
-OpLoopMerge %51 %52 None
-OpBranch %46
-%46 = OpLabel
 OpSelectionMerge %49 None
-OpBranchConditional %27 %47 %49
-%47 = OpLabel
+OpBranchConditional %27 %48 %49
+%48 = OpLabel
 %29 = OpBitFieldUExtract %9 %24 %17 %28
 %32 = OpBitFieldUExtract %9 %31 %17 %28
 %33 = OpBitFieldUExtract %9 %29 %17 %28
@@ -99,24 +98,23 @@ OpBranchConditional %27 %47 %49
 %34 = OpBitwiseAnd %9 %30 %10
 %36 = OpBitFieldUExtract %9 %34 %17 %28
 %37 = OpBitFieldUExtract %9 %17 %17 %28
-%35 = OpIEqual %26 %36 %37
-OpSelectionMerge %48 None
-OpBranchConditional %35 %50 %48
-%50 = OpLabel
-%43 = OpCompositeConstruct %39 %10 %10 %10
-%44 = OpCompositeConstruct %11 %42 %42 %42 %42
-OpImageWrite %16 %43 %44
-OpBranch %51
-%48 = OpLabel
+%35 = OpINotEqual %26 %36 %37
 OpBranch %49
 %49 = OpLabel
-%40 = OpCompositeConstruct %39 %10 %10 %10
-%41 = OpCompositeConstruct %11 %38 %38 %38 %38
-OpImageWrite %16 %40 %41
-OpBranch %51
-%52 = OpLabel
-OpBranch %45
+%38 = OpPhi %26 %39 %47 %35 %48
+OpSelectionMerge %52 None
+OpBranchConditional %38 %51 %50
 %51 = OpLabel
+%42 = OpCompositeConstruct %41 %10 %10 %10
+%43 = OpCompositeConstruct %11 %40 %40 %40 %40
+OpImageWrite %16 %42 %43
+OpBranch %52
+%50 = OpLabel
+%45 = OpCompositeConstruct %41 %10 %10 %10
+%46 = OpCompositeConstruct %11 %44 %44 %44 %44
+OpImageWrite %16 %45 %46
+OpBranch %52
+%52 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/acceleration-structure.bindless.rgen
+++ b/reference/shaders/resources/acceleration-structure.bindless.rgen
@@ -22,17 +22,13 @@ layout(push_constant, std430) uniform RootConstants
 
 layout(set = 0, binding = 0) uniform accelerationStructureEXT _12[];
 layout(location = 0) rayPayloadEXT _15 _17;
-layout(location = 1) rayPayloadEXT _15 _18;
-layout(location = 2) rayPayloadEXT _15 _19;
 
 void main()
 {
-    _19._m0 = vec4(1.0, 2.0, 3.0, 4.0);
-    traceRayEXT(_12[(registers._m0 + 100u) + 10u], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 2);
-    _18._m0 = _19._m0;
-    traceRayEXT(_12[registers._m0 + 3u], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
-    _17._m0 = _18._m0;
-    traceRayEXT(_12[nonuniformEXT((registers._m0 + 100u) + uint(int(_18._m0.w)))], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    _17._m0 = vec4(1.0, 2.0, 3.0, 4.0);
+    traceRayEXT(_12[(registers._m0 + 100u) + 10u], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(_12[registers._m0 + 3u], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(_12[nonuniformEXT((registers._m0 + 100u) + uint(int(_17._m0.w)))], 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
 }
 
 
@@ -41,7 +37,7 @@ void main()
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 66
+; Bound: 61
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -59,7 +55,7 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpExtension "SPV_KHR_ray_tracing"
 OpMemoryModel PhysicalStorageBuffer64 GLSL450
-OpEntryPoint RayGenerationNV %3 "main" %8 %12 %17 %18 %19
+OpEntryPoint RayGenerationNV %3 "main" %8 %12 %17
 OpName %3 "main"
 OpName %6 "RootConstants"
 OpName %8 "registers"
@@ -75,8 +71,8 @@ OpMemberDecorate %6 6 Offset 24
 OpMemberDecorate %6 7 Offset 28
 OpDecorate %12 DescriptorSet 0
 OpDecorate %12 Binding 0
-OpDecorate %60 NonUniform
-OpDecorate %61 NonUniform
+OpDecorate %55 NonUniform
+OpDecorate %56 NonUniform
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -92,62 +88,55 @@ OpDecorate %61 NonUniform
 %15 = OpTypeStruct %14
 %16 = OpTypePointer RayPayloadNV %15
 %17 = OpVariable %16 RayPayloadNV
-%18 = OpVariable %16 RayPayloadNV
-%19 = OpVariable %16 RayPayloadNV
-%20 = OpTypePointer RayPayloadNV %14
-%22 = OpConstant %5 0
-%23 = OpConstant %13 1
-%24 = OpConstant %13 2
-%25 = OpConstant %13 3
-%26 = OpConstant %13 4
-%27 = OpConstantComposite %14 %23 %24 %25 %26
-%28 = OpTypePointer UniformConstant %9
-%30 = OpTypePointer PushConstant %5
-%34 = OpConstant %5 100
-%36 = OpConstant %5 10
-%38 = OpConstant %13 0
-%39 = OpTypeVector %13 3
-%48 = OpConstant %5 3
+%18 = OpTypePointer RayPayloadNV %14
+%20 = OpConstant %5 0
+%21 = OpConstant %13 1
+%22 = OpConstant %13 2
+%23 = OpConstant %13 3
+%24 = OpConstant %13 4
+%25 = OpConstantComposite %14 %21 %22 %23 %24
+%26 = OpTypePointer UniformConstant %9
+%28 = OpTypePointer PushConstant %5
+%32 = OpConstant %5 100
+%34 = OpConstant %5 10
+%36 = OpConstant %13 0
+%37 = OpTypeVector %13 3
+%44 = OpConstant %5 3
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %64
-%64 = OpLabel
-%21 = OpInBoundsAccessChain %20 %19 %22
-OpStore %21 %27
-%31 = OpAccessChain %30 %8 %22
-%32 = OpLoad %5 %31
-%33 = OpIAdd %5 %32 %34
-%35 = OpIAdd %5 %33 %36
-%29 = OpAccessChain %28 %12 %35
-%37 = OpLoad %9 %29
-%40 = OpCompositeConstruct %39 %23 %24 %25
-%41 = OpCompositeConstruct %39 %38 %38 %23
-OpTraceRayKHR %37 %22 %22 %22 %22 %22 %40 %23 %41 %26 %19
-%42 = OpLoad %14 %21
-%43 = OpInBoundsAccessChain %20 %18 %22
-OpStore %43 %42
-%45 = OpAccessChain %30 %8 %22
-%46 = OpLoad %5 %45
-%47 = OpIAdd %5 %46 %48
-%44 = OpAccessChain %28 %12 %47
-%49 = OpLoad %9 %44
-%50 = OpCompositeConstruct %39 %23 %24 %25
-%51 = OpCompositeConstruct %39 %38 %38 %23
-OpTraceRayKHR %49 %22 %22 %22 %22 %22 %50 %23 %51 %26 %18
-%52 = OpLoad %14 %43
-%53 = OpInBoundsAccessChain %20 %17 %22
-OpStore %53 %52
-%54 = OpCompositeExtract %13 %52 3
-%55 = OpConvertFToS %5 %54
-%57 = OpAccessChain %30 %8 %22
-%58 = OpLoad %5 %57
-%59 = OpIAdd %5 %58 %34
-%60 = OpIAdd %5 %59 %55
-%56 = OpAccessChain %28 %12 %60
-%61 = OpLoad %9 %56
-%62 = OpCompositeConstruct %39 %23 %24 %25
-%63 = OpCompositeConstruct %39 %38 %38 %23
-OpTraceRayKHR %61 %22 %22 %22 %22 %22 %62 %23 %63 %26 %17
+OpBranch %59
+%59 = OpLabel
+%19 = OpInBoundsAccessChain %18 %17 %20
+OpStore %19 %25
+%29 = OpAccessChain %28 %8 %20
+%30 = OpLoad %5 %29
+%31 = OpIAdd %5 %30 %32
+%33 = OpIAdd %5 %31 %34
+%27 = OpAccessChain %26 %12 %33
+%35 = OpLoad %9 %27
+%38 = OpCompositeConstruct %37 %21 %22 %23
+%39 = OpCompositeConstruct %37 %36 %36 %21
+OpTraceRayKHR %35 %20 %20 %20 %20 %20 %38 %21 %39 %24 %17
+%41 = OpAccessChain %28 %8 %20
+%42 = OpLoad %5 %41
+%43 = OpIAdd %5 %42 %44
+%40 = OpAccessChain %26 %12 %43
+%45 = OpLoad %9 %40
+%46 = OpCompositeConstruct %37 %21 %22 %23
+%47 = OpCompositeConstruct %37 %36 %36 %21
+OpTraceRayKHR %45 %20 %20 %20 %20 %20 %46 %21 %47 %24 %17
+%48 = OpLoad %14 %19
+%49 = OpCompositeExtract %13 %48 3
+%50 = OpConvertFToS %5 %49
+%52 = OpAccessChain %28 %8 %20
+%53 = OpLoad %5 %52
+%54 = OpIAdd %5 %53 %32
+%55 = OpIAdd %5 %54 %50
+%51 = OpAccessChain %26 %12 %55
+%56 = OpLoad %9 %51
+%57 = OpCompositeConstruct %37 %21 %22 %23
+%58 = OpCompositeConstruct %37 %36 %36 %21
+OpTraceRayKHR %56 %20 %20 %20 %20 %20 %57 %21 %58 %24 %17
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/acceleration-structure.bindless.ssbo-rtas.local-root-signature.rgen
+++ b/reference/shaders/resources/acceleration-structure.bindless.ssbo-rtas.local-root-signature.rgen
@@ -42,19 +42,13 @@ layout(push_constant, std430) uniform RootConstants
 } registers;
 
 layout(location = 0) rayPayloadEXT _23 _25;
-layout(location = 1) rayPayloadEXT _23 _26;
-layout(location = 2) rayPayloadEXT _23 _27;
-layout(location = 3) rayPayloadEXT _23 _28;
 
 void main()
 {
-    _28._m0 = vec4(1.0, 2.0, 3.0, 4.0);
-    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst((registers._m0 + 100u) + 10u)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 3);
-    _27._m0 = _28._m0;
-    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst(registers._m0 + 3u)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 2);
-    _26._m0 = _27._m0;
-    traceRayEXT(accelerationStructureEXT(_20._m0[(registers._m0 + 100u) + uint(int(_27._m0.w))]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
-    _25._m0 = _26._m0;
+    _25._m0 = vec4(1.0, 2.0, 3.0, 4.0);
+    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst((registers._m0 + 100u) + 10u)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst(registers._m0 + 3u)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(accelerationStructureEXT(_20._m0[(registers._m0 + 100u) + uint(int(_25._m0.w))]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
     traceRayEXT(accelerationStructureEXT(_20._m0[subgroupBroadcastFirst(((SBT._m7.x >> 6u) + 10u) + 200u)]), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
 }
 
@@ -64,7 +58,7 @@ void main()
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 97
+; Bound: 89
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -83,7 +77,7 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpExtension "SPV_KHR_ray_tracing"
 OpMemoryModel PhysicalStorageBuffer64 GLSL450
-OpEntryPoint RayGenerationNV %3 "main" %8 %16 %20 %25 %26 %27 %28
+OpEntryPoint RayGenerationNV %3 "main" %8 %16 %20 %25
 OpName %3 "main"
 OpName %6 "RootConstants"
 OpName %8 "registers"
@@ -144,87 +138,76 @@ OpDecorate %20 Restrict
 %23 = OpTypeStruct %22
 %24 = OpTypePointer RayPayloadNV %23
 %25 = OpVariable %24 RayPayloadNV
-%26 = OpVariable %24 RayPayloadNV
-%27 = OpVariable %24 RayPayloadNV
-%28 = OpVariable %24 RayPayloadNV
-%29 = OpTypePointer RayPayloadNV %22
-%31 = OpConstant %5 0
-%32 = OpConstant %21 1
-%33 = OpConstant %21 2
-%34 = OpConstant %21 3
-%35 = OpConstant %21 4
-%36 = OpConstantComposite %22 %32 %33 %34 %35
-%37 = OpTypePointer PushConstant %5
-%41 = OpConstant %5 100
-%43 = OpConstant %5 10
-%45 = OpConstant %5 3
-%46 = OpTypePointer StorageBuffer %13
-%49 = OpTypeAccelerationStructureKHR
-%51 = OpConstant %21 0
-%52 = OpTypeVector %21 3
-%81 = OpTypePointer ShaderRecordBufferNV %5
-%83 = OpConstant %5 7
-%88 = OpConstant %5 200
+%26 = OpTypePointer RayPayloadNV %22
+%28 = OpConstant %5 0
+%29 = OpConstant %21 1
+%30 = OpConstant %21 2
+%31 = OpConstant %21 3
+%32 = OpConstant %21 4
+%33 = OpConstantComposite %22 %29 %30 %31 %32
+%34 = OpTypePointer PushConstant %5
+%38 = OpConstant %5 100
+%40 = OpConstant %5 10
+%42 = OpConstant %5 3
+%43 = OpTypePointer StorageBuffer %13
+%46 = OpTypeAccelerationStructureKHR
+%48 = OpConstant %21 0
+%49 = OpTypeVector %21 3
+%73 = OpTypePointer ShaderRecordBufferNV %5
+%75 = OpConstant %5 7
+%80 = OpConstant %5 200
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %95
-%95 = OpLabel
-%30 = OpInBoundsAccessChain %29 %28 %31
-OpStore %30 %36
-%38 = OpAccessChain %37 %8 %31
-%39 = OpLoad %5 %38
-%40 = OpIAdd %5 %39 %41
-%42 = OpIAdd %5 %40 %43
-%44 = OpGroupNonUniformBroadcastFirst %5 %45 %42
-%47 = OpAccessChain %46 %20 %31 %44
-%48 = OpLoad %13 %47
-%50 = OpConvertUToAccelerationStructureKHR %49 %48
-%53 = OpCompositeConstruct %52 %32 %33 %34
-%54 = OpCompositeConstruct %52 %51 %51 %32
-OpTraceRayKHR %50 %31 %31 %31 %31 %31 %53 %32 %54 %35 %28
-%55 = OpLoad %22 %30
-%56 = OpInBoundsAccessChain %29 %27 %31
-OpStore %56 %55
-%57 = OpAccessChain %37 %8 %31
-%58 = OpLoad %5 %57
-%59 = OpIAdd %5 %58 %45
-%60 = OpGroupNonUniformBroadcastFirst %5 %45 %59
-%61 = OpAccessChain %46 %20 %31 %60
-%62 = OpLoad %13 %61
-%63 = OpConvertUToAccelerationStructureKHR %49 %62
-%64 = OpCompositeConstruct %52 %32 %33 %34
-%65 = OpCompositeConstruct %52 %51 %51 %32
-OpTraceRayKHR %63 %31 %31 %31 %31 %31 %64 %32 %65 %35 %27
-%66 = OpLoad %22 %56
-%67 = OpInBoundsAccessChain %29 %26 %31
-OpStore %67 %66
-%68 = OpCompositeExtract %21 %66 3
-%69 = OpConvertFToS %5 %68
-%70 = OpAccessChain %37 %8 %31
-%71 = OpLoad %5 %70
-%72 = OpIAdd %5 %71 %41
-%73 = OpIAdd %5 %72 %69
-%74 = OpAccessChain %46 %20 %31 %73
-%75 = OpLoad %13 %74
-%76 = OpConvertUToAccelerationStructureKHR %49 %75
-%77 = OpCompositeConstruct %52 %32 %33 %34
-%78 = OpCompositeConstruct %52 %51 %51 %32
-OpTraceRayKHR %76 %31 %31 %31 %31 %31 %77 %32 %78 %35 %26
-%79 = OpLoad %22 %67
-%80 = OpInBoundsAccessChain %29 %25 %31
-OpStore %80 %79
-%82 = OpAccessChain %81 %16 %83 %31
-%84 = OpLoad %5 %82
-%85 = OpShiftRightLogical %5 %84 %11
-%86 = OpIAdd %5 %85 %43
-%87 = OpIAdd %5 %86 %88
-%89 = OpGroupNonUniformBroadcastFirst %5 %45 %87
-%90 = OpAccessChain %46 %20 %31 %89
-%91 = OpLoad %13 %90
-%92 = OpConvertUToAccelerationStructureKHR %49 %91
-%93 = OpCompositeConstruct %52 %32 %33 %34
-%94 = OpCompositeConstruct %52 %51 %51 %32
-OpTraceRayKHR %92 %31 %31 %31 %31 %31 %93 %32 %94 %35 %25
+OpBranch %87
+%87 = OpLabel
+%27 = OpInBoundsAccessChain %26 %25 %28
+OpStore %27 %33
+%35 = OpAccessChain %34 %8 %28
+%36 = OpLoad %5 %35
+%37 = OpIAdd %5 %36 %38
+%39 = OpIAdd %5 %37 %40
+%41 = OpGroupNonUniformBroadcastFirst %5 %42 %39
+%44 = OpAccessChain %43 %20 %28 %41
+%45 = OpLoad %13 %44
+%47 = OpConvertUToAccelerationStructureKHR %46 %45
+%50 = OpCompositeConstruct %49 %29 %30 %31
+%51 = OpCompositeConstruct %49 %48 %48 %29
+OpTraceRayKHR %47 %28 %28 %28 %28 %28 %50 %29 %51 %32 %25
+%52 = OpAccessChain %34 %8 %28
+%53 = OpLoad %5 %52
+%54 = OpIAdd %5 %53 %42
+%55 = OpGroupNonUniformBroadcastFirst %5 %42 %54
+%56 = OpAccessChain %43 %20 %28 %55
+%57 = OpLoad %13 %56
+%58 = OpConvertUToAccelerationStructureKHR %46 %57
+%59 = OpCompositeConstruct %49 %29 %30 %31
+%60 = OpCompositeConstruct %49 %48 %48 %29
+OpTraceRayKHR %58 %28 %28 %28 %28 %28 %59 %29 %60 %32 %25
+%61 = OpLoad %22 %27
+%62 = OpCompositeExtract %21 %61 3
+%63 = OpConvertFToS %5 %62
+%64 = OpAccessChain %34 %8 %28
+%65 = OpLoad %5 %64
+%66 = OpIAdd %5 %65 %38
+%67 = OpIAdd %5 %66 %63
+%68 = OpAccessChain %43 %20 %28 %67
+%69 = OpLoad %13 %68
+%70 = OpConvertUToAccelerationStructureKHR %46 %69
+%71 = OpCompositeConstruct %49 %29 %30 %31
+%72 = OpCompositeConstruct %49 %48 %48 %29
+OpTraceRayKHR %70 %28 %28 %28 %28 %28 %71 %29 %72 %32 %25
+%74 = OpAccessChain %73 %16 %75 %28
+%76 = OpLoad %5 %74
+%77 = OpShiftRightLogical %5 %76 %11
+%78 = OpIAdd %5 %77 %40
+%79 = OpIAdd %5 %78 %80
+%81 = OpGroupNonUniformBroadcastFirst %5 %42 %79
+%82 = OpAccessChain %43 %20 %28 %81
+%83 = OpLoad %13 %82
+%84 = OpConvertUToAccelerationStructureKHR %46 %83
+%85 = OpCompositeConstruct %49 %29 %30 %31
+%86 = OpCompositeConstruct %49 %48 %48 %29
+OpTraceRayKHR %84 %28 %28 %28 %28 %28 %85 %29 %86 %32 %25
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/acceleration-structure.local-root-signature.root-descriptor.rgen
+++ b/reference/shaders/resources/acceleration-structure.local-root-signature.root-descriptor.rgen
@@ -33,16 +33,12 @@ layout(push_constant, std430) uniform RootConstants
 
 layout(set = 0, binding = 1) uniform accelerationStructureEXT AS_Plain;
 layout(location = 0) rayPayloadEXT _23 _25;
-layout(location = 1) rayPayloadEXT _23 _26;
-layout(location = 2) rayPayloadEXT _23 _27;
 
 void main()
 {
-    _27._m0 = vec4(1.0, 2.0, 3.0, 4.0);
-    traceRayEXT(accelerationStructureEXT(SBT._m2), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 2);
-    _26._m0 = _27._m0;
-    traceRayEXT(accelerationStructureEXT(registers._m1), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
-    _25._m0 = _26._m0;
+    _25._m0 = vec4(1.0, 2.0, 3.0, 4.0);
+    traceRayEXT(accelerationStructureEXT(SBT._m2), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(accelerationStructureEXT(registers._m1), 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
     traceRayEXT(AS_Plain, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
 }
 
@@ -52,7 +48,7 @@ void main()
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 61
+; Bound: 55
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -70,7 +66,7 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpExtension "SPV_KHR_ray_tracing"
 OpMemoryModel PhysicalStorageBuffer64 GLSL450
-OpEntryPoint RayGenerationNV %3 "main" %9 %16 %20 %25 %26 %27
+OpEntryPoint RayGenerationNV %3 "main" %9 %16 %20 %25
 OpName %3 "main"
 OpName %7 "RootConstants"
 OpName %9 "registers"
@@ -122,49 +118,41 @@ OpDecorate %20 Binding 1
 %23 = OpTypeStruct %22
 %24 = OpTypePointer RayPayloadNV %23
 %25 = OpVariable %24 RayPayloadNV
-%26 = OpVariable %24 RayPayloadNV
-%27 = OpVariable %24 RayPayloadNV
-%28 = OpTypePointer RayPayloadNV %22
-%30 = OpConstant %5 0
-%31 = OpConstant %21 1
-%32 = OpConstant %21 2
-%33 = OpConstant %21 3
-%34 = OpConstant %21 4
-%35 = OpConstantComposite %22 %31 %32 %33 %34
-%36 = OpTypePointer ShaderRecordBufferNV %6
-%38 = OpConstant %5 2
-%41 = OpConstant %21 0
-%42 = OpTypeVector %21 3
-%47 = OpTypePointer PushConstant %6
-%49 = OpConstant %5 1
+%26 = OpTypePointer RayPayloadNV %22
+%28 = OpConstant %5 0
+%29 = OpConstant %21 1
+%30 = OpConstant %21 2
+%31 = OpConstant %21 3
+%32 = OpConstant %21 4
+%33 = OpConstantComposite %22 %29 %30 %31 %32
+%34 = OpTypePointer ShaderRecordBufferNV %6
+%36 = OpConstant %5 2
+%39 = OpConstant %21 0
+%40 = OpTypeVector %21 3
+%43 = OpTypePointer PushConstant %6
+%45 = OpConstant %5 1
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %59
-%59 = OpLabel
-%29 = OpInBoundsAccessChain %28 %27 %30
-OpStore %29 %35
-%37 = OpAccessChain %36 %16 %38
-%39 = OpLoad %6 %37
-%40 = OpConvertUToAccelerationStructureKHR %18 %39
-%43 = OpCompositeConstruct %42 %31 %32 %33
-%44 = OpCompositeConstruct %42 %41 %41 %31
-OpTraceRayKHR %40 %30 %30 %30 %30 %30 %43 %31 %44 %34 %27
-%45 = OpLoad %22 %29
-%46 = OpInBoundsAccessChain %28 %26 %30
-OpStore %46 %45
-%48 = OpAccessChain %47 %9 %49
-%50 = OpLoad %6 %48
-%51 = OpConvertUToAccelerationStructureKHR %18 %50
-%52 = OpCompositeConstruct %42 %31 %32 %33
-%53 = OpCompositeConstruct %42 %41 %41 %31
-OpTraceRayKHR %51 %30 %30 %30 %30 %30 %52 %31 %53 %34 %26
-%54 = OpLoad %22 %46
-%55 = OpInBoundsAccessChain %28 %25 %30
-OpStore %55 %54
-%56 = OpLoad %18 %20
-%57 = OpCompositeConstruct %42 %31 %32 %33
-%58 = OpCompositeConstruct %42 %41 %41 %31
-OpTraceRayKHR %56 %30 %30 %30 %30 %30 %57 %31 %58 %34 %25
+OpBranch %53
+%53 = OpLabel
+%27 = OpInBoundsAccessChain %26 %25 %28
+OpStore %27 %33
+%35 = OpAccessChain %34 %16 %36
+%37 = OpLoad %6 %35
+%38 = OpConvertUToAccelerationStructureKHR %18 %37
+%41 = OpCompositeConstruct %40 %29 %30 %31
+%42 = OpCompositeConstruct %40 %39 %39 %29
+OpTraceRayKHR %38 %28 %28 %28 %28 %28 %41 %29 %42 %32 %25
+%44 = OpAccessChain %43 %9 %45
+%46 = OpLoad %6 %44
+%47 = OpConvertUToAccelerationStructureKHR %18 %46
+%48 = OpCompositeConstruct %40 %29 %30 %31
+%49 = OpCompositeConstruct %40 %39 %39 %29
+OpTraceRayKHR %47 %28 %28 %28 %28 %28 %48 %29 %49 %32 %25
+%50 = OpLoad %18 %20
+%51 = OpCompositeConstruct %40 %29 %30 %31
+%52 = OpCompositeConstruct %40 %39 %39 %29
+OpTraceRayKHR %50 %28 %28 %28 %28 %28 %51 %29 %52 %32 %25
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/cbv-array-nonuniform.frag
+++ b/reference/shaders/resources/cbv-array-nonuniform.frag
@@ -20,10 +20,10 @@ void main()
     uint _27 = INDEX + 0u;
     uint _38 = INDEX & 1u;
     uint _41 = (INDEX ^ 1u) + 0u;
-    SV_Target.x = _19[_41]._m0[_38].x + _13[_27]._m0[_25].x;
-    SV_Target.y = _19[_41]._m0[_38].y + _13[_27]._m0[_25].y;
-    SV_Target.z = _19[_41]._m0[_38].z + _13[_27]._m0[_25].z;
-    SV_Target.w = _19[_41]._m0[_38].w + _13[_27]._m0[_25].w;
+    SV_Target.x = _19[nonuniformEXT(_41)]._m0[_38].x + _13[nonuniformEXT(_27)]._m0[_25].x;
+    SV_Target.y = _19[nonuniformEXT(_41)]._m0[_38].y + _13[nonuniformEXT(_27)]._m0[_25].y;
+    SV_Target.z = _19[nonuniformEXT(_41)]._m0[_38].z + _13[nonuniformEXT(_27)]._m0[_25].z;
+    SV_Target.w = _19[nonuniformEXT(_41)]._m0[_38].w + _13[nonuniformEXT(_27)]._m0[_25].w;
 }
 
 
@@ -37,6 +37,7 @@ void main()
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
 OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
 OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %3 "main" %21 %23
@@ -59,6 +60,10 @@ OpDecorate %19 Binding 0
 OpDecorate %21 Flat
 OpDecorate %21 Location 0
 OpDecorate %23 Location 0
+OpDecorate %30 NonUniform
+OpDecorate %32 NonUniform
+OpDecorate %43 NonUniform
+OpDecorate %44 NonUniform
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0

--- a/reference/shaders/resources/cbv.bindless.root-constant.cbv-as-ssbo.frag
+++ b/reference/shaders/resources/cbv.bindless.root-constant.cbv-as-ssbo.frag
@@ -36,10 +36,10 @@ void main()
     uint _32 = registers._m5 + 5u;
     uint _70 = registers._m5 + (uvec4(registers._m4, registers._m5, registers._m6, registers._m7).x + 4u);
     uint _86 = registers._m5 + (INDEX + 100u);
-    SV_Target.x = ((_16[_32]._m0[0u].x + _16[_27]._m0[0u].x) + _16[_70]._m0[0u].x) + _16[_86]._m0[0u].x;
-    SV_Target.y = ((_16[_32]._m0[0u].y + _16[_27]._m0[0u].y) + _16[_70]._m0[0u].y) + _16[_86]._m0[0u].y;
-    SV_Target.z = ((_16[_32]._m0[0u].z + _16[_27]._m0[0u].z) + _16[_70]._m0[0u].z) + _16[_86]._m0[0u].z;
-    SV_Target.w = ((_16[_32]._m0[0u].w + _16[_27]._m0[0u].w) + _16[_70]._m0[0u].w) + _16[_86]._m0[0u].w;
+    SV_Target.x = ((_16[_32]._m0[0u].x + _16[_27]._m0[0u].x) + _16[_70]._m0[0u].x) + _16[nonuniformEXT(_86)]._m0[0u].x;
+    SV_Target.y = ((_16[_32]._m0[0u].y + _16[_27]._m0[0u].y) + _16[_70]._m0[0u].y) + _16[nonuniformEXT(_86)]._m0[0u].y;
+    SV_Target.z = ((_16[_32]._m0[0u].z + _16[_27]._m0[0u].z) + _16[_70]._m0[0u].z) + _16[nonuniformEXT(_86)]._m0[0u].z;
+    SV_Target.w = ((_16[_32]._m0[0u].w + _16[_27]._m0[0u].w) + _16[_70]._m0[0u].w) + _16[nonuniformEXT(_86)]._m0[0u].w;
 }
 
 
@@ -53,6 +53,7 @@ void main()
 OpCapability Shader
 OpCapability StorageBufferArrayDynamicIndexing
 OpCapability RuntimeDescriptorArray
+OpCapability StorageBufferArrayNonUniformIndexing
 OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
@@ -91,6 +92,8 @@ OpDecorate %16 Binding 0
 OpDecorate %18 Flat
 OpDecorate %18 Location 0
 OpDecorate %20 Location 0
+OpDecorate %83 NonUniform
+OpDecorate %87 NonUniform
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0

--- a/reference/shaders/resources/cbv.bindless.root-constant.frag
+++ b/reference/shaders/resources/cbv.bindless.root-constant.frag
@@ -36,10 +36,10 @@ void main()
     uint _32 = registers._m5 + 5u;
     uint _70 = registers._m5 + (uvec4(registers._m4, registers._m5, registers._m6, registers._m7).x + 4u);
     uint _86 = registers._m5 + (INDEX + 100u);
-    SV_Target.x = ((_16[_32]._m0[0u].x + _16[_27]._m0[0u].x) + _16[_70]._m0[0u].x) + _16[_86]._m0[0u].x;
-    SV_Target.y = ((_16[_32]._m0[0u].y + _16[_27]._m0[0u].y) + _16[_70]._m0[0u].y) + _16[_86]._m0[0u].y;
-    SV_Target.z = ((_16[_32]._m0[0u].z + _16[_27]._m0[0u].z) + _16[_70]._m0[0u].z) + _16[_86]._m0[0u].z;
-    SV_Target.w = ((_16[_32]._m0[0u].w + _16[_27]._m0[0u].w) + _16[_70]._m0[0u].w) + _16[_86]._m0[0u].w;
+    SV_Target.x = ((_16[_32]._m0[0u].x + _16[_27]._m0[0u].x) + _16[_70]._m0[0u].x) + _16[nonuniformEXT(_86)]._m0[0u].x;
+    SV_Target.y = ((_16[_32]._m0[0u].y + _16[_27]._m0[0u].y) + _16[_70]._m0[0u].y) + _16[nonuniformEXT(_86)]._m0[0u].y;
+    SV_Target.z = ((_16[_32]._m0[0u].z + _16[_27]._m0[0u].z) + _16[_70]._m0[0u].z) + _16[nonuniformEXT(_86)]._m0[0u].z;
+    SV_Target.w = ((_16[_32]._m0[0u].w + _16[_27]._m0[0u].w) + _16[_70]._m0[0u].w) + _16[nonuniformEXT(_86)]._m0[0u].w;
 }
 
 
@@ -53,6 +53,7 @@ void main()
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
 OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
 OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_physical_storage_buffer"
@@ -90,6 +91,8 @@ OpDecorate %16 Binding 0
 OpDecorate %18 Flat
 OpDecorate %18 Location 0
 OpDecorate %20 Location 0
+OpDecorate %83 NonUniform
+OpDecorate %87 NonUniform
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0

--- a/reference/shaders/resources/rt-resources.bindless.local-root-signature.rmiss
+++ b/reference/shaders/resources/rt-resources.bindless.local-root-signature.rmiss
@@ -95,14 +95,15 @@ layout(set = 3, binding = 0, r32f) uniform readonly image2D _25[];
 layout(set = 2, binding = 0) uniform sampler _36[];
 layout(location = 0) rayPayloadInEXT _37 payload;
 
-vec4 _429;
-float _444;
+vec4 _425;
+float _440;
 
 void main()
 {
     uint _53 = (SBT._m9.x >> 6u) + 12u;
     uint _58 = payload._m1;
-    vec4 _67 = texelFetch(_21[registers._m0 + (_58 & 1u)], ivec2(uvec2(0u)), int(0u));
+    uint _59 = _58 & 1u;
+    vec4 _67 = texelFetch(_21[registers._m0 + _59], ivec2(uvec2(0u)), int(0u));
     vec4 _80 = texelFetch(_21[registers._m0 + _58], ivec2(uvec2(0u)), int(0u));
     vec4 _99 = texelFetch(_21[((SBT._m7.x >> 6u) + 17u) + _58], ivec2(uvec2(0u)), int(0u));
     vec4 _119 = imageLoad(_25[((SBT._m8.x >> 6u) + 18u) + _58], ivec2(uvec2(0u)));
@@ -112,51 +113,50 @@ void main()
     AddCarry _196;
     _196._m0 = uaddCarry(SBT._m6.x, 1u * 16u, _196._m1);
     PhysicalPointerFloat4NonWrite _203 = PhysicalPointerFloat4NonWrite(uvec2(_196._m0, SBT._m6.y + _196._m1));
-    vec4 _234 = textureLod(nonuniformEXT(sampler2D(_21[registers._m0 + (payload._m1 & 1u)], _36[(SBT._m10.x >> 5u) + 13u])), vec2(0.5), 0.0);
-    vec4 _260 = textureLod(sampler2D(_21[registers._m0 + payload._m1], _36[((SBT._m10.x >> 5u) + 14u) + (payload._m1 ^ 1u)]), vec2(0.5), 0.0);
-    AddCarry _276;
-    _276._m0 = uaddCarry(SBT._m2.x, (payload._m1 * 16u) + 0u, _276._m1);
-    PhysicalPointerFloat4NonWrite _281 = PhysicalPointerFloat4NonWrite(uvec2(_276._m0, SBT._m2.y + _276._m1));
-    AddCarry _299;
-    _299._m0 = uaddCarry(SBT._m4.x, payload._m1 << 2u, _299._m1);
-    float _308 = uintBitsToFloat(PhysicalPointerUintNonWrite(uvec2(_299._m0, SBT._m4.y + _299._m1)).value);
-    AddCarry _318;
-    _318._m0 = uaddCarry(SBT._m4.x, payload._m1 << 3u, _318._m1);
-    PhysicalPointerUint2NonWrite _323 = PhysicalPointerUint2NonWrite(uvec2(_318._m0, SBT._m4.y + _318._m1));
-    float _329 = uintBitsToFloat(_323.value.x);
-    float _330 = uintBitsToFloat(_323.value.y);
-    AddCarry _341;
-    _341._m0 = uaddCarry(SBT._m4.x, payload._m1 * 12u, _341._m1);
-    PhysicalPointerUint3NonWrite _346 = PhysicalPointerUint3NonWrite(uvec2(_341._m0, SBT._m4.y + _341._m1));
-    float _355 = uintBitsToFloat(_346.value.z);
-    uint _360 = payload._m1;
-    AddCarry _366;
-    _366._m0 = uaddCarry(SBT._m4.x, _360 << 4u, _366._m1);
-    PhysicalPointerUint4NonWrite _371 = PhysicalPointerUint4NonWrite(uvec2(_366._m0, SBT._m4.y + _366._m1));
-    AddCarry _395;
-    _395._m0 = uaddCarry(SBT._m3.x, (_360 * 4u) + 0u, _395._m1);
-    PhysicalPointerFloat _400 = PhysicalPointerFloat(uvec2(_395._m0, SBT._m3.y + _395._m1));
-    uint _408 = _360 << 2u;
-    AddCarry _415;
-    _415._m0 = uaddCarry(SBT._m5.x, _408, _415._m1);
-    float _423 = uintBitsToFloat(PhysicalPointerUint(uvec2(_415._m0, SBT._m5.y + _415._m1)).value);
-    float _424 = ((((((((((((((((_67.x + _80.x) + _99.x) + _119.x) + _32[nonuniformEXT(_53)]._m0[0u].x) + _32[nonuniformEXT(_146)]._m0[0u].x) + _169.x) + _182.x) + _203.value.x) + _234.x) + _260.x) + _281.value.x) + _308) + _329) + uintBitsToFloat(_346.value.x)) + uintBitsToFloat(_371.value.x)) + _400.value) + _423;
-    float _425 = ((((((((((((((((_67.y + _80.y) + _99.y) + _119.y) + _32[nonuniformEXT(_53)]._m0[0u].y) + _32[nonuniformEXT(_146)]._m0[0u].y) + _169.y) + _182.y) + _203.value.y) + _234.y) + _260.y) + _281.value.y) + _308) + _330) + uintBitsToFloat(_346.value.y)) + uintBitsToFloat(_371.value.y)) + _400.value) + _423;
-    vec4 _428 = _429;
-    _428.x = _424;
-    vec4 _430 = _428;
-    _430.y = _425;
-    vec4 _431 = _430;
-    _431.z = ((((((((((((((((_67.z + _80.z) + _99.z) + _119.z) + _32[nonuniformEXT(_53)]._m0[0u].z) + _32[nonuniformEXT(_146)]._m0[0u].z) + _169.z) + _182.z) + _203.value.z) + _234.z) + _260.z) + _281.value.z) + _308) + _329) + _355) + uintBitsToFloat(_371.value.z)) + _400.value) + _423;
-    vec4 _432 = _431;
-    _432.w = ((((((((((((((((_67.w + _80.w) + _99.w) + _119.w) + _32[nonuniformEXT(_53)]._m0[0u].w) + _32[nonuniformEXT(_146)]._m0[0u].w) + _169.w) + _182.w) + _203.value.w) + _234.w) + _260.w) + _281.value.w) + _308) + _330) + _355) + uintBitsToFloat(_371.value.w)) + _400.value) + _423;
-    payload._m0 = _432;
-    AddCarry _437;
-    _437._m0 = uaddCarry(SBT._m3.x, (_360 * 4u) + 0u, _437._m1);
-    PhysicalPointerFloat(uvec2(_437._m0, SBT._m3.y + _437._m1)).value = _424;
-    AddCarry _449;
-    _449._m0 = uaddCarry(SBT._m5.x, _408, _449._m1);
-    PhysicalPointerFloat(uvec2(_449._m0, SBT._m5.y + _449._m1)).value = _425;
+    vec4 _232 = textureLod(nonuniformEXT(sampler2D(_21[registers._m0 + _59], _36[(SBT._m10.x >> 5u) + 13u])), vec2(0.5), 0.0);
+    vec4 _258 = textureLod(sampler2D(_21[registers._m0 + _58], _36[((SBT._m10.x >> 5u) + 14u) + (_58 ^ 1u)]), vec2(0.5), 0.0);
+    AddCarry _274;
+    _274._m0 = uaddCarry(SBT._m2.x, (_58 * 16u) + 0u, _274._m1);
+    PhysicalPointerFloat4NonWrite _279 = PhysicalPointerFloat4NonWrite(uvec2(_274._m0, SBT._m2.y + _274._m1));
+    uint _290 = _58 << 2u;
+    AddCarry _297;
+    _297._m0 = uaddCarry(SBT._m4.x, _290, _297._m1);
+    float _306 = uintBitsToFloat(PhysicalPointerUintNonWrite(uvec2(_297._m0, SBT._m4.y + _297._m1)).value);
+    AddCarry _316;
+    _316._m0 = uaddCarry(SBT._m4.x, _58 << 3u, _316._m1);
+    PhysicalPointerUint2NonWrite _321 = PhysicalPointerUint2NonWrite(uvec2(_316._m0, SBT._m4.y + _316._m1));
+    float _327 = uintBitsToFloat(_321.value.x);
+    float _328 = uintBitsToFloat(_321.value.y);
+    AddCarry _339;
+    _339._m0 = uaddCarry(SBT._m4.x, _58 * 12u, _339._m1);
+    PhysicalPointerUint3NonWrite _344 = PhysicalPointerUint3NonWrite(uvec2(_339._m0, SBT._m4.y + _339._m1));
+    float _353 = uintBitsToFloat(_344.value.z);
+    AddCarry _363;
+    _363._m0 = uaddCarry(SBT._m4.x, _58 << 4u, _363._m1);
+    PhysicalPointerUint4NonWrite _368 = PhysicalPointerUint4NonWrite(uvec2(_363._m0, SBT._m4.y + _363._m1));
+    AddCarry _392;
+    _392._m0 = uaddCarry(SBT._m3.x, (_58 * 4u) + 0u, _392._m1);
+    PhysicalPointerFloat _397 = PhysicalPointerFloat(uvec2(_392._m0, SBT._m3.y + _392._m1));
+    AddCarry _411;
+    _411._m0 = uaddCarry(SBT._m5.x, _290, _411._m1);
+    float _419 = uintBitsToFloat(PhysicalPointerUint(uvec2(_411._m0, SBT._m5.y + _411._m1)).value);
+    float _420 = ((((((((((((((((_67.x + _80.x) + _99.x) + _119.x) + _32[nonuniformEXT(_53)]._m0[0u].x) + _32[nonuniformEXT(_146)]._m0[0u].x) + _169.x) + _182.x) + _203.value.x) + _232.x) + _258.x) + _279.value.x) + _306) + _327) + uintBitsToFloat(_344.value.x)) + uintBitsToFloat(_368.value.x)) + _397.value) + _419;
+    float _421 = ((((((((((((((((_67.y + _80.y) + _99.y) + _119.y) + _32[nonuniformEXT(_53)]._m0[0u].y) + _32[nonuniformEXT(_146)]._m0[0u].y) + _169.y) + _182.y) + _203.value.y) + _232.y) + _258.y) + _279.value.y) + _306) + _328) + uintBitsToFloat(_344.value.y)) + uintBitsToFloat(_368.value.y)) + _397.value) + _419;
+    vec4 _424 = _425;
+    _424.x = _420;
+    vec4 _426 = _424;
+    _426.y = _421;
+    vec4 _427 = _426;
+    _427.z = ((((((((((((((((_67.z + _80.z) + _99.z) + _119.z) + _32[nonuniformEXT(_53)]._m0[0u].z) + _32[nonuniformEXT(_146)]._m0[0u].z) + _169.z) + _182.z) + _203.value.z) + _232.z) + _258.z) + _279.value.z) + _306) + _327) + _353) + uintBitsToFloat(_368.value.z)) + _397.value) + _419;
+    vec4 _428 = _427;
+    _428.w = ((((((((((((((((_67.w + _80.w) + _99.w) + _119.w) + _32[nonuniformEXT(_53)]._m0[0u].w) + _32[nonuniformEXT(_146)]._m0[0u].w) + _169.w) + _182.w) + _203.value.w) + _232.w) + _258.w) + _279.value.w) + _306) + _328) + _353) + uintBitsToFloat(_368.value.w)) + _397.value) + _419;
+    payload._m0 = _428;
+    AddCarry _433;
+    _433._m0 = uaddCarry(SBT._m3.x, (_58 * 4u) + 0u, _433._m1);
+    PhysicalPointerFloat(uvec2(_433._m0, SBT._m3.y + _433._m1)).value = _420;
+    AddCarry _445;
+    _445._m0 = uaddCarry(SBT._m5.x, _290, _445._m1);
+    PhysicalPointerFloat(uvec2(_445._m0, SBT._m5.y + _445._m1)).value = _421;
 }
 
 
@@ -165,7 +165,7 @@ void main()
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 458
+; Bound: 454
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -195,18 +195,18 @@ OpName %39 "payload"
 OpName %195 "AddCarry"
 OpName %201 "PhysicalPointerFloat4NonWrite"
 OpMemberName %201 0 "value"
-OpName %295 "PhysicalPointerUintNonWrite"
-OpMemberName %295 0 "value"
-OpName %314 "PhysicalPointerUint2NonWrite"
-OpMemberName %314 0 "value"
-OpName %337 "PhysicalPointerUint3NonWrite"
-OpMemberName %337 0 "value"
-OpName %362 "PhysicalPointerUint4NonWrite"
-OpMemberName %362 0 "value"
-OpName %389 "PhysicalPointerFloat"
-OpMemberName %389 0 "value"
-OpName %411 "PhysicalPointerUint"
-OpMemberName %411 0 "value"
+OpName %293 "PhysicalPointerUintNonWrite"
+OpMemberName %293 0 "value"
+OpName %312 "PhysicalPointerUint2NonWrite"
+OpMemberName %312 0 "value"
+OpName %335 "PhysicalPointerUint3NonWrite"
+OpMemberName %335 0 "value"
+OpName %359 "PhysicalPointerUint4NonWrite"
+OpMemberName %359 0 "value"
+OpName %386 "PhysicalPointerFloat"
+OpMemberName %386 0 "value"
+OpName %407 "PhysicalPointerUint"
+OpMemberName %407 0 "value"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 4
@@ -249,24 +249,24 @@ OpDecorate %147 NonUniform
 OpMemberDecorate %201 0 Offset 0
 OpDecorate %201 Block
 OpMemberDecorate %201 0 NonWritable
+OpDecorate %227 NonUniform
 OpDecorate %229 NonUniform
-OpDecorate %231 NonUniform
-OpMemberDecorate %295 0 Offset 0
-OpDecorate %295 Block
-OpMemberDecorate %295 0 NonWritable
-OpMemberDecorate %314 0 Offset 0
-OpDecorate %314 Block
-OpMemberDecorate %314 0 NonWritable
-OpMemberDecorate %337 0 Offset 0
-OpDecorate %337 Block
-OpMemberDecorate %337 0 NonWritable
-OpMemberDecorate %362 0 Offset 0
-OpDecorate %362 Block
-OpMemberDecorate %362 0 NonWritable
-OpMemberDecorate %389 0 Offset 0
-OpDecorate %389 Block
-OpMemberDecorate %411 0 Offset 0
-OpDecorate %411 Block
+OpMemberDecorate %293 0 Offset 0
+OpDecorate %293 Block
+OpMemberDecorate %293 0 NonWritable
+OpMemberDecorate %312 0 Offset 0
+OpDecorate %312 Block
+OpMemberDecorate %312 0 NonWritable
+OpMemberDecorate %335 0 Offset 0
+OpDecorate %335 Block
+OpMemberDecorate %335 0 NonWritable
+OpMemberDecorate %359 0 Offset 0
+OpDecorate %359 Block
+OpMemberDecorate %359 0 NonWritable
+OpMemberDecorate %386 0 Offset 0
+OpDecorate %386 Block
+OpMemberDecorate %407 0 Offset 0
+OpDecorate %407 Block
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -332,37 +332,37 @@ OpDecorate %411 Block
 %201 = OpTypeStruct %26
 %202 = OpTypePointer PhysicalStorageBuffer %201
 %204 = OpTypePointer PhysicalStorageBuffer %26
-%222 = OpTypePointer UniformConstant %33
-%225 = OpConstant %5 10
-%230 = OpTypeSampledImage %18
-%232 = OpConstant %17 0.5
-%233 = OpConstant %17 0
-%235 = OpTypeVector %17 2
-%256 = OpConstant %5 14
-%295 = OpTypeStruct %5
-%296 = OpTypePointer PhysicalStorageBuffer %295
-%305 = OpTypePointer PhysicalStorageBuffer %5
-%314 = OpTypeStruct %13
-%315 = OpTypePointer PhysicalStorageBuffer %314
-%324 = OpTypePointer PhysicalStorageBuffer %13
-%336 = OpTypeVector %5 3
-%337 = OpTypeStruct %336
-%338 = OpTypePointer PhysicalStorageBuffer %337
-%347 = OpTypePointer PhysicalStorageBuffer %336
-%362 = OpTypeStruct %167
-%363 = OpTypePointer PhysicalStorageBuffer %362
-%372 = OpTypePointer PhysicalStorageBuffer %167
-%389 = OpTypeStruct %17
-%390 = OpTypePointer PhysicalStorageBuffer %389
-%401 = OpTypePointer PhysicalStorageBuffer %17
-%411 = OpTypeStruct %5
-%412 = OpTypePointer PhysicalStorageBuffer %411
+%220 = OpTypePointer UniformConstant %33
+%223 = OpConstant %5 10
+%228 = OpTypeSampledImage %18
+%230 = OpConstant %17 0.5
+%231 = OpConstant %17 0
+%233 = OpTypeVector %17 2
+%254 = OpConstant %5 14
+%293 = OpTypeStruct %5
+%294 = OpTypePointer PhysicalStorageBuffer %293
+%303 = OpTypePointer PhysicalStorageBuffer %5
+%312 = OpTypeStruct %13
+%313 = OpTypePointer PhysicalStorageBuffer %312
+%322 = OpTypePointer PhysicalStorageBuffer %13
+%334 = OpTypeVector %5 3
+%335 = OpTypeStruct %334
+%336 = OpTypePointer PhysicalStorageBuffer %335
+%345 = OpTypePointer PhysicalStorageBuffer %334
+%359 = OpTypeStruct %167
+%360 = OpTypePointer PhysicalStorageBuffer %359
+%369 = OpTypePointer PhysicalStorageBuffer %167
+%386 = OpTypeStruct %17
+%387 = OpTypePointer PhysicalStorageBuffer %386
+%398 = OpTypePointer PhysicalStorageBuffer %17
+%407 = OpTypeStruct %5
+%408 = OpTypePointer PhysicalStorageBuffer %407
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-%429 = OpUndef %26
-%444 = OpUndef %17
-OpBranch %456
-%456 = OpLabel
+%425 = OpUndef %26
+%440 = OpUndef %17
+OpBranch %452
+%452 = OpLabel
 %41 = OpAccessChain %40 %16 %11
 %42 = OpLoad %13 %41
 %44 = OpAccessChain %43 %16 %45
@@ -510,223 +510,219 @@ OpBranch %456
 %212 = OpFAdd %17 %188 %208
 %213 = OpFAdd %17 %189 %209
 %214 = OpFAdd %17 %190 %210
-%215 = OpLoad %5 %56
-%216 = OpBitwiseAnd %5 %215 %57
-%218 = OpAccessChain %62 %8 %45
-%219 = OpLoad %5 %218
-%220 = OpIAdd %5 %219 %216
-%217 = OpAccessChain %60 %21 %220
-%221 = OpLoad %18 %217
-%224 = OpAccessChain %48 %16 %225 %45
-%226 = OpLoad %5 %224
-%227 = OpShiftRightLogical %5 %226 %9
-%228 = OpIAdd %5 %227 %145
-%223 = OpAccessChain %222 %36 %228
-%229 = OpLoad %33 %223
-%231 = OpSampledImage %230 %221 %229
-%236 = OpCompositeConstruct %235 %232 %232
-%234 = OpImageSampleExplicitLod %26 %231 %236 Lod %233
-%237 = OpCompositeExtract %17 %234 0
-%238 = OpCompositeExtract %17 %234 1
-%239 = OpCompositeExtract %17 %234 2
-%240 = OpCompositeExtract %17 %234 3
-%241 = OpFAdd %17 %211 %237
-%242 = OpFAdd %17 %212 %238
-%243 = OpFAdd %17 %213 %239
-%244 = OpFAdd %17 %214 %240
-%245 = OpBitwiseXor %5 %215 %57
-%247 = OpAccessChain %62 %8 %45
-%248 = OpLoad %5 %247
-%249 = OpIAdd %5 %248 %215
-%246 = OpAccessChain %60 %21 %249
-%250 = OpLoad %18 %246
-%252 = OpAccessChain %48 %16 %225 %45
-%253 = OpLoad %5 %252
-%254 = OpShiftRightLogical %5 %253 %9
-%255 = OpIAdd %5 %254 %256
-%257 = OpIAdd %5 %255 %245
-%251 = OpAccessChain %222 %36 %257
-%258 = OpLoad %33 %251
-%259 = OpSampledImage %230 %250 %258
-%261 = OpCompositeConstruct %235 %232 %232
-%260 = OpImageSampleExplicitLod %26 %259 %261 Lod %233
-%262 = OpCompositeExtract %17 %260 0
-%263 = OpCompositeExtract %17 %260 1
-%264 = OpCompositeExtract %17 %260 2
-%265 = OpCompositeExtract %17 %260 3
+%216 = OpAccessChain %62 %8 %45
+%217 = OpLoad %5 %216
+%218 = OpIAdd %5 %217 %59
+%215 = OpAccessChain %60 %21 %218
+%219 = OpLoad %18 %215
+%222 = OpAccessChain %48 %16 %223 %45
+%224 = OpLoad %5 %222
+%225 = OpShiftRightLogical %5 %224 %9
+%226 = OpIAdd %5 %225 %145
+%221 = OpAccessChain %220 %36 %226
+%227 = OpLoad %33 %221
+%229 = OpSampledImage %228 %219 %227
+%234 = OpCompositeConstruct %233 %230 %230
+%232 = OpImageSampleExplicitLod %26 %229 %234 Lod %231
+%235 = OpCompositeExtract %17 %232 0
+%236 = OpCompositeExtract %17 %232 1
+%237 = OpCompositeExtract %17 %232 2
+%238 = OpCompositeExtract %17 %232 3
+%239 = OpFAdd %17 %211 %235
+%240 = OpFAdd %17 %212 %236
+%241 = OpFAdd %17 %213 %237
+%242 = OpFAdd %17 %214 %238
+%243 = OpBitwiseXor %5 %58 %57
+%245 = OpAccessChain %62 %8 %45
+%246 = OpLoad %5 %245
+%247 = OpIAdd %5 %246 %58
+%244 = OpAccessChain %60 %21 %247
+%248 = OpLoad %18 %244
+%250 = OpAccessChain %48 %16 %223 %45
+%251 = OpLoad %5 %250
+%252 = OpShiftRightLogical %5 %251 %9
+%253 = OpIAdd %5 %252 %254
+%255 = OpIAdd %5 %253 %243
+%249 = OpAccessChain %220 %36 %255
+%256 = OpLoad %33 %249
+%257 = OpSampledImage %228 %248 %256
+%259 = OpCompositeConstruct %233 %230 %230
+%258 = OpImageSampleExplicitLod %26 %257 %259 Lod %231
+%260 = OpCompositeExtract %17 %258 0
+%261 = OpCompositeExtract %17 %258 1
+%262 = OpCompositeExtract %17 %258 2
+%263 = OpCompositeExtract %17 %258 3
+%264 = OpFAdd %17 %239 %260
+%265 = OpFAdd %17 %240 %261
 %266 = OpFAdd %17 %241 %262
 %267 = OpFAdd %17 %242 %263
-%268 = OpFAdd %17 %243 %264
-%269 = OpFAdd %17 %244 %265
-%270 = OpAccessChain %40 %16 %162
-%271 = OpLoad %13 %270
-%272 = OpIMul %5 %215 %192
-%273 = OpIAdd %5 %272 %45
-%274 = OpCompositeExtract %5 %271 0
-%275 = OpCompositeExtract %5 %271 1
-%276 = OpIAddCarry %195 %274 %273
-%277 = OpCompositeExtract %5 %276 0
-%278 = OpCompositeExtract %5 %276 1
-%279 = OpIAdd %5 %275 %278
-%280 = OpCompositeConstruct %13 %277 %279
-%281 = OpBitcast %202 %280
-%282 = OpAccessChain %204 %281 %45
-%283 = OpLoad %26 %282 Aligned 4
-%284 = OpCompositeExtract %17 %283 0
-%285 = OpCompositeExtract %17 %283 1
-%286 = OpCompositeExtract %17 %283 2
-%287 = OpCompositeExtract %17 %283 3
+%268 = OpAccessChain %40 %16 %162
+%269 = OpLoad %13 %268
+%270 = OpIMul %5 %58 %192
+%271 = OpIAdd %5 %270 %45
+%272 = OpCompositeExtract %5 %269 0
+%273 = OpCompositeExtract %5 %269 1
+%274 = OpIAddCarry %195 %272 %271
+%275 = OpCompositeExtract %5 %274 0
+%276 = OpCompositeExtract %5 %274 1
+%277 = OpIAdd %5 %273 %276
+%278 = OpCompositeConstruct %13 %275 %277
+%279 = OpBitcast %202 %278
+%280 = OpAccessChain %204 %279 %45
+%281 = OpLoad %26 %280 Aligned 4
+%282 = OpCompositeExtract %17 %281 0
+%283 = OpCompositeExtract %17 %281 1
+%284 = OpCompositeExtract %17 %281 2
+%285 = OpCompositeExtract %17 %281 3
+%286 = OpFAdd %17 %264 %282
+%287 = OpFAdd %17 %265 %283
 %288 = OpFAdd %17 %266 %284
 %289 = OpFAdd %17 %267 %285
-%290 = OpFAdd %17 %268 %286
-%291 = OpFAdd %17 %269 %287
-%292 = OpShiftLeftLogical %5 %215 %162
-%293 = OpAccessChain %40 %16 %179
-%294 = OpLoad %13 %293
-%297 = OpCompositeExtract %5 %294 0
-%298 = OpCompositeExtract %5 %294 1
-%299 = OpIAddCarry %195 %297 %292
-%300 = OpCompositeExtract %5 %299 0
-%301 = OpCompositeExtract %5 %299 1
-%302 = OpIAdd %5 %298 %301
-%303 = OpCompositeConstruct %13 %300 %302
-%304 = OpBitcast %296 %303
-%306 = OpAccessChain %305 %304 %45
-%307 = OpLoad %5 %306 Aligned 4
-%308 = OpBitcast %17 %307
-%309 = OpFAdd %17 %288 %308
-%310 = OpFAdd %17 %289 %308
-%311 = OpFAdd %17 %290 %308
-%312 = OpFAdd %17 %291 %308
-%313 = OpShiftLeftLogical %5 %215 %165
-%316 = OpCompositeExtract %5 %294 0
-%317 = OpCompositeExtract %5 %294 1
-%318 = OpIAddCarry %195 %316 %313
-%319 = OpCompositeExtract %5 %318 0
-%320 = OpCompositeExtract %5 %318 1
-%321 = OpIAdd %5 %317 %320
-%322 = OpCompositeConstruct %13 %319 %321
-%323 = OpBitcast %315 %322
-%325 = OpAccessChain %324 %323 %45
-%326 = OpLoad %13 %325 Aligned 4
-%327 = OpCompositeExtract %5 %326 0
-%328 = OpCompositeExtract %5 %326 1
-%329 = OpBitcast %17 %327
-%330 = OpBitcast %17 %328
-%331 = OpFAdd %17 %309 %329
-%332 = OpFAdd %17 %310 %330
-%333 = OpFAdd %17 %311 %329
-%334 = OpFAdd %17 %312 %330
-%335 = OpIMul %5 %215 %54
-%339 = OpCompositeExtract %5 %294 0
-%340 = OpCompositeExtract %5 %294 1
-%341 = OpIAddCarry %195 %339 %335
-%342 = OpCompositeExtract %5 %341 0
-%343 = OpCompositeExtract %5 %341 1
-%344 = OpIAdd %5 %340 %343
-%345 = OpCompositeConstruct %13 %342 %344
-%346 = OpBitcast %338 %345
-%348 = OpAccessChain %347 %346 %45
-%349 = OpLoad %336 %348 Aligned 4
-%350 = OpCompositeExtract %5 %349 0
-%351 = OpCompositeExtract %5 %349 1
-%352 = OpCompositeExtract %5 %349 2
+%290 = OpShiftLeftLogical %5 %58 %162
+%291 = OpAccessChain %40 %16 %179
+%292 = OpLoad %13 %291
+%295 = OpCompositeExtract %5 %292 0
+%296 = OpCompositeExtract %5 %292 1
+%297 = OpIAddCarry %195 %295 %290
+%298 = OpCompositeExtract %5 %297 0
+%299 = OpCompositeExtract %5 %297 1
+%300 = OpIAdd %5 %296 %299
+%301 = OpCompositeConstruct %13 %298 %300
+%302 = OpBitcast %294 %301
+%304 = OpAccessChain %303 %302 %45
+%305 = OpLoad %5 %304 Aligned 4
+%306 = OpBitcast %17 %305
+%307 = OpFAdd %17 %286 %306
+%308 = OpFAdd %17 %287 %306
+%309 = OpFAdd %17 %288 %306
+%310 = OpFAdd %17 %289 %306
+%311 = OpShiftLeftLogical %5 %58 %165
+%314 = OpCompositeExtract %5 %292 0
+%315 = OpCompositeExtract %5 %292 1
+%316 = OpIAddCarry %195 %314 %311
+%317 = OpCompositeExtract %5 %316 0
+%318 = OpCompositeExtract %5 %316 1
+%319 = OpIAdd %5 %315 %318
+%320 = OpCompositeConstruct %13 %317 %319
+%321 = OpBitcast %313 %320
+%323 = OpAccessChain %322 %321 %45
+%324 = OpLoad %13 %323 Aligned 4
+%325 = OpCompositeExtract %5 %324 0
+%326 = OpCompositeExtract %5 %324 1
+%327 = OpBitcast %17 %325
+%328 = OpBitcast %17 %326
+%329 = OpFAdd %17 %307 %327
+%330 = OpFAdd %17 %308 %328
+%331 = OpFAdd %17 %309 %327
+%332 = OpFAdd %17 %310 %328
+%333 = OpIMul %5 %58 %54
+%337 = OpCompositeExtract %5 %292 0
+%338 = OpCompositeExtract %5 %292 1
+%339 = OpIAddCarry %195 %337 %333
+%340 = OpCompositeExtract %5 %339 0
+%341 = OpCompositeExtract %5 %339 1
+%342 = OpIAdd %5 %338 %341
+%343 = OpCompositeConstruct %13 %340 %342
+%344 = OpBitcast %336 %343
+%346 = OpAccessChain %345 %344 %45
+%347 = OpLoad %334 %346 Aligned 4
+%348 = OpCompositeExtract %5 %347 0
+%349 = OpCompositeExtract %5 %347 1
+%350 = OpCompositeExtract %5 %347 2
+%351 = OpBitcast %17 %348
+%352 = OpBitcast %17 %349
 %353 = OpBitcast %17 %350
-%354 = OpBitcast %17 %351
-%355 = OpBitcast %17 %352
+%354 = OpFAdd %17 %329 %351
+%355 = OpFAdd %17 %330 %352
 %356 = OpFAdd %17 %331 %353
-%357 = OpFAdd %17 %332 %354
-%358 = OpFAdd %17 %333 %355
-%359 = OpFAdd %17 %334 %355
-%360 = OpLoad %5 %56
-%361 = OpShiftLeftLogical %5 %360 %179
-%364 = OpCompositeExtract %5 %294 0
-%365 = OpCompositeExtract %5 %294 1
-%366 = OpIAddCarry %195 %364 %361
-%367 = OpCompositeExtract %5 %366 0
-%368 = OpCompositeExtract %5 %366 1
-%369 = OpIAdd %5 %365 %368
-%370 = OpCompositeConstruct %13 %367 %369
-%371 = OpBitcast %363 %370
-%373 = OpAccessChain %372 %371 %45
-%374 = OpLoad %167 %373 Aligned 4
-%375 = OpCompositeExtract %5 %374 0
-%376 = OpCompositeExtract %5 %374 1
-%377 = OpCompositeExtract %5 %374 2
-%378 = OpCompositeExtract %5 %374 3
+%357 = OpFAdd %17 %332 %353
+%358 = OpShiftLeftLogical %5 %58 %179
+%361 = OpCompositeExtract %5 %292 0
+%362 = OpCompositeExtract %5 %292 1
+%363 = OpIAddCarry %195 %361 %358
+%364 = OpCompositeExtract %5 %363 0
+%365 = OpCompositeExtract %5 %363 1
+%366 = OpIAdd %5 %362 %365
+%367 = OpCompositeConstruct %13 %364 %366
+%368 = OpBitcast %360 %367
+%370 = OpAccessChain %369 %368 %45
+%371 = OpLoad %167 %370 Aligned 4
+%372 = OpCompositeExtract %5 %371 0
+%373 = OpCompositeExtract %5 %371 1
+%374 = OpCompositeExtract %5 %371 2
+%375 = OpCompositeExtract %5 %371 3
+%376 = OpBitcast %17 %372
+%377 = OpBitcast %17 %373
+%378 = OpBitcast %17 %374
 %379 = OpBitcast %17 %375
-%380 = OpBitcast %17 %376
-%381 = OpBitcast %17 %377
-%382 = OpBitcast %17 %378
-%383 = OpFAdd %17 %356 %379
-%384 = OpFAdd %17 %357 %380
-%385 = OpFAdd %17 %358 %381
-%386 = OpFAdd %17 %359 %382
-%387 = OpAccessChain %40 %16 %165
-%388 = OpLoad %13 %387
-%391 = OpIMul %5 %360 %179
-%392 = OpIAdd %5 %391 %45
-%393 = OpCompositeExtract %5 %388 0
-%394 = OpCompositeExtract %5 %388 1
-%395 = OpIAddCarry %195 %393 %392
-%396 = OpCompositeExtract %5 %395 0
-%397 = OpCompositeExtract %5 %395 1
-%398 = OpIAdd %5 %394 %397
-%399 = OpCompositeConstruct %13 %396 %398
-%400 = OpBitcast %390 %399
-%402 = OpAccessChain %401 %400 %45
-%403 = OpLoad %17 %402 Aligned 4
-%404 = OpFAdd %17 %383 %403
-%405 = OpFAdd %17 %384 %403
-%406 = OpFAdd %17 %385 %403
-%407 = OpFAdd %17 %386 %403
-%408 = OpShiftLeftLogical %5 %360 %162
-%409 = OpAccessChain %40 %16 %9
-%410 = OpLoad %13 %409
-%413 = OpCompositeExtract %5 %410 0
-%414 = OpCompositeExtract %5 %410 1
-%415 = OpIAddCarry %195 %413 %408
-%416 = OpCompositeExtract %5 %415 0
-%417 = OpCompositeExtract %5 %415 1
-%418 = OpIAdd %5 %414 %417
-%419 = OpCompositeConstruct %13 %416 %418
-%420 = OpBitcast %412 %419
-%421 = OpAccessChain %305 %420 %45
-%422 = OpLoad %5 %421 Aligned 4
-%423 = OpBitcast %17 %422
-%424 = OpFAdd %17 %404 %423
-%425 = OpFAdd %17 %405 %423
-%426 = OpFAdd %17 %406 %423
-%427 = OpFAdd %17 %407 %423
-%428 = OpCompositeInsert %26 %424 %429 0
-%430 = OpCompositeInsert %26 %425 %428 1
-%431 = OpCompositeInsert %26 %426 %430 2
-%432 = OpCompositeInsert %26 %427 %431 3
-OpStore %74 %432
-%433 = OpIMul %5 %360 %179
-%434 = OpIAdd %5 %433 %45
-%435 = OpCompositeExtract %5 %388 0
-%436 = OpCompositeExtract %5 %388 1
-%437 = OpIAddCarry %195 %435 %434
-%438 = OpCompositeExtract %5 %437 0
-%439 = OpCompositeExtract %5 %437 1
-%440 = OpIAdd %5 %436 %439
-%441 = OpCompositeConstruct %13 %438 %440
-%442 = OpBitcast %390 %441
-%443 = OpAccessChain %401 %442 %45
-OpStore %443 %424 Aligned 4
-%445 = OpAccessChain %40 %16 %9
-%446 = OpLoad %13 %445
-%447 = OpCompositeExtract %5 %446 0
-%448 = OpCompositeExtract %5 %446 1
-%449 = OpIAddCarry %195 %447 %408
-%450 = OpCompositeExtract %5 %449 0
-%451 = OpCompositeExtract %5 %449 1
-%452 = OpIAdd %5 %448 %451
-%453 = OpCompositeConstruct %13 %450 %452
-%454 = OpBitcast %390 %453
-%455 = OpAccessChain %401 %454 %45
-OpStore %455 %425 Aligned 4
+%380 = OpFAdd %17 %354 %376
+%381 = OpFAdd %17 %355 %377
+%382 = OpFAdd %17 %356 %378
+%383 = OpFAdd %17 %357 %379
+%384 = OpAccessChain %40 %16 %165
+%385 = OpLoad %13 %384
+%388 = OpIMul %5 %58 %179
+%389 = OpIAdd %5 %388 %45
+%390 = OpCompositeExtract %5 %385 0
+%391 = OpCompositeExtract %5 %385 1
+%392 = OpIAddCarry %195 %390 %389
+%393 = OpCompositeExtract %5 %392 0
+%394 = OpCompositeExtract %5 %392 1
+%395 = OpIAdd %5 %391 %394
+%396 = OpCompositeConstruct %13 %393 %395
+%397 = OpBitcast %387 %396
+%399 = OpAccessChain %398 %397 %45
+%400 = OpLoad %17 %399 Aligned 4
+%401 = OpFAdd %17 %380 %400
+%402 = OpFAdd %17 %381 %400
+%403 = OpFAdd %17 %382 %400
+%404 = OpFAdd %17 %383 %400
+%405 = OpAccessChain %40 %16 %9
+%406 = OpLoad %13 %405
+%409 = OpCompositeExtract %5 %406 0
+%410 = OpCompositeExtract %5 %406 1
+%411 = OpIAddCarry %195 %409 %290
+%412 = OpCompositeExtract %5 %411 0
+%413 = OpCompositeExtract %5 %411 1
+%414 = OpIAdd %5 %410 %413
+%415 = OpCompositeConstruct %13 %412 %414
+%416 = OpBitcast %408 %415
+%417 = OpAccessChain %303 %416 %45
+%418 = OpLoad %5 %417 Aligned 4
+%419 = OpBitcast %17 %418
+%420 = OpFAdd %17 %401 %419
+%421 = OpFAdd %17 %402 %419
+%422 = OpFAdd %17 %403 %419
+%423 = OpFAdd %17 %404 %419
+%424 = OpCompositeInsert %26 %420 %425 0
+%426 = OpCompositeInsert %26 %421 %424 1
+%427 = OpCompositeInsert %26 %422 %426 2
+%428 = OpCompositeInsert %26 %423 %427 3
+OpStore %74 %428
+%429 = OpIMul %5 %58 %179
+%430 = OpIAdd %5 %429 %45
+%431 = OpCompositeExtract %5 %385 0
+%432 = OpCompositeExtract %5 %385 1
+%433 = OpIAddCarry %195 %431 %430
+%434 = OpCompositeExtract %5 %433 0
+%435 = OpCompositeExtract %5 %433 1
+%436 = OpIAdd %5 %432 %435
+%437 = OpCompositeConstruct %13 %434 %436
+%438 = OpBitcast %387 %437
+%439 = OpAccessChain %398 %438 %45
+OpStore %439 %420 Aligned 4
+%441 = OpAccessChain %40 %16 %9
+%442 = OpLoad %13 %441
+%443 = OpCompositeExtract %5 %442 0
+%444 = OpCompositeExtract %5 %442 1
+%445 = OpIAddCarry %195 %443 %290
+%446 = OpCompositeExtract %5 %445 0
+%447 = OpCompositeExtract %5 %445 1
+%448 = OpIAdd %5 %444 %447
+%449 = OpCompositeConstruct %13 %446 %448
+%450 = OpBitcast %387 %449
+%451 = OpAccessChain %398 %450 %45
+OpStore %451 %421 Aligned 4
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/semantics/inner-coverage.noglsl.frag
+++ b/reference/shaders/semantics/inner-coverage.noglsl.frag
@@ -1,62 +1,71 @@
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 33
+; Bound: 41
 ; Schema: 0
 OpCapability Shader
 OpCapability FragmentFullyCoveredEXT
 OpExtension "SPV_EXT_fragment_fully_covered"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %7 %10
+OpEntryPoint Fragment %3 "main" %7 %12 %21
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %7 "SV_Target"
-OpName %18 "discard_state"
-OpName %25 "discard_exit"
+OpName %26 "discard_state"
+OpName %33 "discard_exit"
 OpDecorate %7 Location 0
-OpDecorate %10 BuiltIn FullyCoveredEXT
+OpDecorate %12 BuiltIn SampleMask
+OpDecorate %21 BuiltIn FullyCoveredEXT
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeFloat 32
 %6 = OpTypePointer Output %5
 %7 = OpVariable %6 Output
-%8 = OpTypeBool
-%9 = OpTypePointer Input %8
-%10 = OpVariable %9 Input
-%12 = OpTypeInt 32 0
-%14 = OpConstant %12 1
-%15 = OpConstant %12 0
-%17 = OpTypePointer Private %8
-%18 = OpVariable %17 Private
-%19 = OpConstantFalse %8
-%20 = OpConstant %5 1
-%24 = OpConstantTrue %8
+%8 = OpTypeInt 32 0
+%9 = OpConstant %8 1
+%10 = OpTypeArray %8 %9
+%11 = OpTypePointer Input %10
+%12 = OpVariable %11 Input
+%13 = OpTypePointer Input %8
+%15 = OpConstant %8 0
+%17 = OpTypeBool
+%20 = OpTypePointer Input %17
+%21 = OpVariable %20 Input
+%25 = OpTypePointer Private %17
+%26 = OpVariable %25 Private
+%27 = OpConstantFalse %17
+%28 = OpConstant %5 1
+%32 = OpConstantTrue %17
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpStore %18 %19
-OpBranch %21
-%21 = OpLabel
-%11 = OpLoad %8 %10
-%13 = OpSelect %12 %11 %14 %15
-%16 = OpIEqual %8 %13 %15
-OpSelectionMerge %23 None
-OpBranchConditional %16 %22 %23
-%22 = OpLabel
-OpStore %18 %24
-OpBranch %23
-%23 = OpLabel
-OpStore %7 %20
-%31 = OpFunctionCall %1 %25
+OpStore %26 %27
+OpBranch %29
+%29 = OpLabel
+%14 = OpAccessChain %13 %12 %15
+%16 = OpLoad %8 %14
+%18 = OpIEqual %17 %15 %16
+%19 = OpSelect %8 %18 %9 %15
+%22 = OpLoad %17 %21
+%23 = OpSelect %8 %22 %9 %15
+%24 = OpIEqual %17 %23 %15
+OpSelectionMerge %31 None
+OpBranchConditional %24 %30 %31
+%30 = OpLabel
+OpStore %26 %32
+OpBranch %31
+%31 = OpLabel
+OpStore %7 %28
+%39 = OpFunctionCall %1 %33
 OpReturn
 OpFunctionEnd
-%25 = OpFunction %1 None %2
-%26 = OpLabel
-%29 = OpLoad %8 %18
-OpSelectionMerge %28 None
-OpBranchConditional %29 %27 %28
-%27 = OpLabel
+%33 = OpFunction %1 None %2
+%34 = OpLabel
+%37 = OpLoad %17 %26
+OpSelectionMerge %36 None
+OpBranchConditional %37 %35 %36
+%35 = OpLabel
 OpKill
-%28 = OpLabel
+%36 = OpLabel
 OpReturn
 OpFunctionEnd
 

--- a/reference/shaders/stages/callable-chain.rcall
+++ b/reference/shaders/stages/callable-chain.rcall
@@ -51,21 +51,21 @@ OpName %8 "payload"
 %8 = OpVariable %7 IncomingCallableDataNV
 %9 = OpTypePointer CallableDataNV %6
 %10 = OpVariable %9 CallableDataNV
-%11 = OpTypePointer IncomingCallableDataNV %5
+%11 = OpTypePointer CallableDataNV %5
 %13 = OpTypeInt 32 0
 %14 = OpConstant %13 0
-%16 = OpTypePointer CallableDataNV %5
+%15 = OpTypePointer IncomingCallableDataNV %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 OpBranch %19
 %19 = OpLabel
-%12 = OpInBoundsAccessChain %11 %8 %14
-%15 = OpLoad %5 %12
-%17 = OpInBoundsAccessChain %16 %10 %14
-OpStore %17 %15
+%12 = OpInBoundsAccessChain %11 %10 %14
+%16 = OpInBoundsAccessChain %15 %8 %14
+%17 = OpLoad %5 %16
+OpStore %12 %17
 OpExecuteCallableKHR %14 %10
-%18 = OpLoad %5 %17
-OpStore %12 %18
+%18 = OpLoad %5 %12
+OpStore %16 %18
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/stages/raygen-complex-storage-class.rgen
+++ b/reference/shaders/stages/raygen-complex-storage-class.rgen
@@ -7,7 +7,7 @@ struct _14
     vec4 _m0;
 };
 
-struct _18
+struct _15
 {
     _14 _m0;
     _14 _m1;
@@ -15,28 +15,33 @@ struct _18
 
 layout(set = 40, binding = 30) uniform accelerationStructureEXT AS;
 layout(set = 20, binding = 10) uniform writeonly image2D IMG;
-layout(location = 0) callableDataEXT _14 _16;
-layout(location = 1) callableDataEXT _14 _17;
-layout(location = 2) callableDataEXT _18 _20;
-layout(location = 3) rayPayloadEXT _14 _22;
-layout(location = 4) rayPayloadEXT _14 _23;
-layout(location = 5) rayPayloadEXT _18 _25;
+layout(location = 0) rayPayloadEXT _15 _30;
+layout(location = 1) rayPayloadEXT _14 _39;
+layout(location = 2) callableDataEXT _15 _50;
+layout(location = 3) callableDataEXT _14 _54;
 
 void main()
 {
-    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 5);
-    _23._m0 = _25._m0._m0;
-    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 4);
-    _22._m0 = _25._m1._m0;
-    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 3);
-    _20._m0._m0 = _23._m0;
-    _20._m1._m0 = _22._m0;
+    _15 _17;
+    _30 = _17;
+    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    _17 = _30;
+    _39 = _17._m0;
+    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
+    _17._m0 = _39;
+    _39 = _17._m1;
+    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
+    _17._m1 = _39;
+    _50 = _17;
     executeCallableEXT(0u, 2);
-    _17._m0 = _20._m0._m0;
-    executeCallableEXT(0u, 1);
-    _16._m0 = _20._m1._m0;
-    executeCallableEXT(0u, 0);
-    imageStore(IMG, ivec2(uvec2(0u)), vec4(_16._m0.x + _17._m0.x, _16._m0.y + _17._m0.y, _16._m0.z + _17._m0.z, _16._m0.w + _17._m0.w));
+    _17 = _50;
+    _54 = _17._m0;
+    executeCallableEXT(0u, 3);
+    _17._m0 = _54;
+    _54 = _17._m1;
+    executeCallableEXT(0u, 3);
+    _17._m1 = _54;
+    imageStore(IMG, ivec2(uvec2(0u)), vec4(_17._m1._m0.x + _17._m0._m0.x, _17._m1._m0.y + _17._m0._m0.y, _17._m1._m0.z + _17._m0._m0.z, _17._m1._m0.w + _17._m0._m0.w));
 }
 
 
@@ -45,7 +50,7 @@ void main()
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 80
+; Bound: 82
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
@@ -62,12 +67,12 @@ OpCapability StorageImageArrayNonUniformIndexing
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_ray_tracing"
 OpMemoryModel Logical GLSL450
-OpEntryPoint RayGenerationNV %3 "main" %8 %12 %16 %17 %20 %22 %23 %25
+OpEntryPoint RayGenerationNV %3 "main" %8 %12 %30 %39 %50 %54
 OpName %3 "main"
 OpName %8 "AS"
 OpName %12 "IMG"
 OpName %14 ""
-OpName %18 ""
+OpName %15 ""
 OpDecorate %8 DescriptorSet 40
 OpDecorate %8 Binding 30
 OpDecorate %12 DescriptorSet 20
@@ -85,86 +90,94 @@ OpDecorate %12 NonReadable
 %12 = OpVariable %11 UniformConstant
 %13 = OpTypeVector %9 4
 %14 = OpTypeStruct %13
-%15 = OpTypePointer CallableDataNV %14
-%16 = OpVariable %15 CallableDataNV
-%17 = OpVariable %15 CallableDataNV
-%18 = OpTypeStruct %14 %14
-%19 = OpTypePointer CallableDataNV %18
-%20 = OpVariable %19 CallableDataNV
-%21 = OpTypePointer RayPayloadNV %14
-%22 = OpVariable %21 RayPayloadNV
-%23 = OpVariable %21 RayPayloadNV
-%24 = OpTypePointer RayPayloadNV %18
-%25 = OpVariable %24 RayPayloadNV
-%27 = OpTypeInt 32 0
-%28 = OpConstant %27 0
-%29 = OpConstant %9 1
-%30 = OpConstant %9 0
-%31 = OpConstant %9 2
-%32 = OpConstant %9 3
-%33 = OpConstant %9 4
-%34 = OpTypeVector %9 3
-%37 = OpTypePointer RayPayloadNV %13
-%41 = OpConstant %27 1
-%53 = OpTypePointer CallableDataNV %13
-%75 = OpTypeVector %27 2
+%15 = OpTypeStruct %14 %14
+%16 = OpTypePointer Function %15
+%19 = OpTypeInt 32 0
+%20 = OpConstant %19 0
+%21 = OpConstant %9 1
+%22 = OpConstant %9 0
+%23 = OpConstant %9 2
+%24 = OpConstant %9 3
+%25 = OpConstant %9 4
+%26 = OpTypeVector %9 3
+%29 = OpTypePointer RayPayloadNV %15
+%30 = OpVariable %29 RayPayloadNV
+%33 = OpTypePointer Function %14
+%38 = OpTypePointer RayPayloadNV %14
+%39 = OpVariable %38 RayPayloadNV
+%43 = OpConstant %19 1
+%49 = OpTypePointer CallableDataNV %15
+%50 = OpVariable %49 CallableDataNV
+%53 = OpTypePointer CallableDataNV %14
+%54 = OpVariable %53 CallableDataNV
+%59 = OpTypePointer Function %13
+%77 = OpTypeVector %19 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %78
-%78 = OpLabel
-%26 = OpLoad %6 %8
-%35 = OpCompositeConstruct %34 %29 %31 %32
-%36 = OpCompositeConstruct %34 %30 %30 %29
-OpTraceRayKHR %26 %28 %28 %28 %28 %28 %35 %29 %36 %33 %25
-%38 = OpInBoundsAccessChain %37 %25 %28 %28
-%39 = OpLoad %13 %38
-%40 = OpInBoundsAccessChain %37 %25 %41 %28
-%42 = OpLoad %13 %40
-%43 = OpInBoundsAccessChain %37 %23 %28
-OpStore %43 %39
+%17 = OpVariable %16 Function
+OpBranch %80
+%80 = OpLabel
+%18 = OpLoad %6 %8
+%27 = OpCompositeConstruct %26 %21 %23 %24
+%28 = OpCompositeConstruct %26 %22 %22 %21
+%31 = OpLoad %15 %17
+OpStore %30 %31
+OpTraceRayKHR %18 %20 %20 %20 %20 %20 %27 %21 %28 %25 %30
+%32 = OpLoad %15 %30
+OpStore %17 %32
+%34 = OpInBoundsAccessChain %33 %17 %20
+%35 = OpLoad %6 %8
+%36 = OpCompositeConstruct %26 %21 %23 %24
+%37 = OpCompositeConstruct %26 %22 %22 %21
+%40 = OpLoad %14 %34
+OpStore %39 %40
+OpTraceRayKHR %35 %20 %20 %20 %20 %20 %36 %21 %37 %25 %39
+%41 = OpLoad %14 %39
+OpStore %34 %41
+%42 = OpInBoundsAccessChain %33 %17 %43
 %44 = OpLoad %6 %8
-%45 = OpCompositeConstruct %34 %29 %31 %32
-%46 = OpCompositeConstruct %34 %30 %30 %29
-OpTraceRayKHR %44 %28 %28 %28 %28 %28 %45 %29 %46 %33 %23
-%47 = OpLoad %13 %43
-%48 = OpInBoundsAccessChain %37 %22 %28
-OpStore %48 %42
-%49 = OpLoad %6 %8
-%50 = OpCompositeConstruct %34 %29 %31 %32
-%51 = OpCompositeConstruct %34 %30 %30 %29
-OpTraceRayKHR %49 %28 %28 %28 %28 %28 %50 %29 %51 %33 %22
-%52 = OpLoad %13 %48
-%54 = OpInBoundsAccessChain %53 %20 %28 %28
-OpStore %54 %47
-%55 = OpInBoundsAccessChain %53 %20 %41 %28
-OpStore %55 %52
-OpExecuteCallableKHR %28 %20
-%56 = OpLoad %13 %54
-%57 = OpLoad %13 %55
-%58 = OpInBoundsAccessChain %53 %17 %28
-OpStore %58 %56
-OpExecuteCallableKHR %28 %17
-%59 = OpLoad %13 %58
-%60 = OpCompositeExtract %9 %59 0
-%61 = OpCompositeExtract %9 %59 1
-%62 = OpCompositeExtract %9 %59 2
-%63 = OpCompositeExtract %9 %59 3
-%64 = OpInBoundsAccessChain %53 %16 %28
-OpStore %64 %57
-OpExecuteCallableKHR %28 %16
-%65 = OpLoad %13 %64
-%66 = OpCompositeExtract %9 %65 0
-%67 = OpFAdd %9 %66 %60
-%68 = OpCompositeExtract %9 %65 1
-%69 = OpFAdd %9 %68 %61
-%70 = OpCompositeExtract %9 %65 2
-%71 = OpFAdd %9 %70 %62
-%72 = OpCompositeExtract %9 %65 3
-%73 = OpFAdd %9 %72 %63
-%74 = OpLoad %10 %12
-%76 = OpCompositeConstruct %75 %28 %28
-%77 = OpCompositeConstruct %13 %67 %69 %71 %73
-OpImageWrite %74 %76 %77
+%45 = OpCompositeConstruct %26 %21 %23 %24
+%46 = OpCompositeConstruct %26 %22 %22 %21
+%47 = OpLoad %14 %42
+OpStore %39 %47
+OpTraceRayKHR %44 %20 %20 %20 %20 %20 %45 %21 %46 %25 %39
+%48 = OpLoad %14 %39
+OpStore %42 %48
+%51 = OpLoad %15 %17
+OpStore %50 %51
+OpExecuteCallableKHR %20 %50
+%52 = OpLoad %15 %50
+OpStore %17 %52
+%55 = OpLoad %14 %34
+OpStore %54 %55
+OpExecuteCallableKHR %20 %54
+%56 = OpLoad %14 %54
+OpStore %34 %56
+%57 = OpLoad %14 %42
+OpStore %54 %57
+OpExecuteCallableKHR %20 %54
+%58 = OpLoad %14 %54
+OpStore %42 %58
+%60 = OpInBoundsAccessChain %59 %17 %20 %20
+%61 = OpLoad %13 %60
+%62 = OpCompositeExtract %9 %61 0
+%63 = OpCompositeExtract %9 %61 1
+%64 = OpCompositeExtract %9 %61 2
+%65 = OpCompositeExtract %9 %61 3
+%66 = OpInBoundsAccessChain %59 %17 %43 %20
+%67 = OpLoad %13 %66
+%68 = OpCompositeExtract %9 %67 0
+%69 = OpFAdd %9 %68 %62
+%70 = OpCompositeExtract %9 %67 1
+%71 = OpFAdd %9 %70 %63
+%72 = OpCompositeExtract %9 %67 2
+%73 = OpFAdd %9 %72 %64
+%74 = OpCompositeExtract %9 %67 3
+%75 = OpFAdd %9 %74 %65
+%76 = OpLoad %10 %12
+%78 = OpCompositeConstruct %77 %20 %20
+%79 = OpCompositeConstruct %13 %69 %71 %73 %75
+OpImageWrite %76 %78 %79
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/stages/raygen.rgen
+++ b/reference/shaders/stages/raygen.rgen
@@ -2,26 +2,26 @@
 #extension GL_EXT_ray_tracing : require
 #extension GL_EXT_nonuniform_qualifier : require
 
-struct _13
-{
-    float _m0;
-};
-
-struct _17
+struct _14
 {
     vec4 _m0;
 };
 
+struct _17
+{
+    float _m0;
+};
+
 layout(set = 40, binding = 30) uniform accelerationStructureEXT AS;
 layout(set = 20, binding = 10) uniform writeonly image2D IMG;
-layout(location = 0) rayPayloadEXT _13 _15;
+layout(location = 0) rayPayloadEXT _14 _16;
 layout(location = 1) rayPayloadEXT _17 _19;
 
 void main()
 {
-    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
-    traceRayEXT(AS, 0u, 1u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
-    imageStore(IMG, ivec2(uvec2(0u)), vec4(_15._m0 + _19._m0.x, _15._m0 + _19._m0.y, _15._m0 + _19._m0.z, _15._m0 + _19._m0.w));
+    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(AS, 0u, 1u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
+    imageStore(IMG, ivec2(uvec2(0u)), vec4(_16._m0.x + _19._m0, _16._m0.y + _19._m0, _16._m0.z + _19._m0, _16._m0.w + _19._m0));
 }
 
 
@@ -47,11 +47,11 @@ OpCapability StorageImageArrayNonUniformIndexing
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_ray_tracing"
 OpMemoryModel Logical GLSL450
-OpEntryPoint RayGenerationNV %3 "main" %8 %12 %15 %19
+OpEntryPoint RayGenerationNV %3 "main" %8 %12 %16 %19
 OpName %3 "main"
 OpName %8 "AS"
 OpName %12 "IMG"
-OpName %13 ""
+OpName %14 ""
 OpName %17 ""
 OpDecorate %8 DescriptorSet 40
 OpDecorate %8 Binding 30
@@ -68,11 +68,11 @@ OpDecorate %12 NonReadable
 %10 = OpTypeImage %9 2D 0 0 0 2 Unknown
 %11 = OpTypePointer UniformConstant %10
 %12 = OpVariable %11 UniformConstant
-%13 = OpTypeStruct %9
-%14 = OpTypePointer RayPayloadNV %13
-%15 = OpVariable %14 RayPayloadNV
-%16 = OpTypeVector %9 4
-%17 = OpTypeStruct %16
+%13 = OpTypeVector %9 4
+%14 = OpTypeStruct %13
+%15 = OpTypePointer RayPayloadNV %14
+%16 = OpVariable %15 RayPayloadNV
+%17 = OpTypeStruct %9
 %18 = OpTypePointer RayPayloadNV %17
 %19 = OpVariable %18 RayPayloadNV
 %21 = OpTypeInt 32 0
@@ -83,8 +83,8 @@ OpDecorate %12 NonReadable
 %26 = OpConstant %9 3
 %27 = OpConstant %9 4
 %28 = OpTypeVector %9 3
-%31 = OpTypePointer RayPayloadNV %16
-%39 = OpConstant %21 1
+%32 = OpConstant %21 1
+%35 = OpTypePointer RayPayloadNV %13
 %42 = OpTypePointer RayPayloadNV %9
 %50 = OpTypeVector %21 2
 %3 = OpFunction %1 None %2
@@ -94,26 +94,26 @@ OpBranch %53
 %20 = OpLoad %6 %8
 %29 = OpCompositeConstruct %28 %23 %25 %26
 %30 = OpCompositeConstruct %28 %24 %24 %23
-OpTraceRayKHR %20 %22 %22 %22 %22 %22 %29 %23 %30 %27 %19
-%32 = OpInBoundsAccessChain %31 %19 %22
-%33 = OpLoad %16 %32
-%34 = OpCompositeExtract %9 %33 0
-%35 = OpCompositeExtract %9 %33 1
-%36 = OpCompositeExtract %9 %33 2
-%37 = OpCompositeExtract %9 %33 3
-%38 = OpLoad %6 %8
-%40 = OpCompositeConstruct %28 %23 %25 %26
-%41 = OpCompositeConstruct %28 %24 %24 %23
-OpTraceRayKHR %38 %22 %39 %22 %22 %22 %40 %23 %41 %27 %15
-%43 = OpInBoundsAccessChain %42 %15 %22
+OpTraceRayKHR %20 %22 %22 %22 %22 %22 %29 %23 %30 %27 %16
+%31 = OpLoad %6 %8
+%33 = OpCompositeConstruct %28 %23 %25 %26
+%34 = OpCompositeConstruct %28 %24 %24 %23
+OpTraceRayKHR %31 %22 %32 %22 %22 %22 %33 %23 %34 %27 %19
+%36 = OpInBoundsAccessChain %35 %16 %22
+%37 = OpLoad %13 %36
+%38 = OpCompositeExtract %9 %37 0
+%39 = OpCompositeExtract %9 %37 1
+%40 = OpCompositeExtract %9 %37 2
+%41 = OpCompositeExtract %9 %37 3
+%43 = OpInBoundsAccessChain %42 %19 %22
 %44 = OpLoad %9 %43
-%45 = OpFAdd %9 %44 %34
-%46 = OpFAdd %9 %44 %35
-%47 = OpFAdd %9 %44 %36
-%48 = OpFAdd %9 %44 %37
+%45 = OpFAdd %9 %38 %44
+%46 = OpFAdd %9 %39 %44
+%47 = OpFAdd %9 %40 %44
+%48 = OpFAdd %9 %41 %44
 %49 = OpLoad %10 %12
 %51 = OpCompositeConstruct %50 %22 %22
-%52 = OpCompositeConstruct %16 %45 %46 %47 %48
+%52 = OpCompositeConstruct %13 %45 %46 %47 %48
 OpImageWrite %49 %51 %52
 OpReturn
 OpFunctionEnd

--- a/reference/shaders/stages/raymiss-chain.rmiss
+++ b/reference/shaders/stages/raymiss-chain.rmiss
@@ -60,10 +60,10 @@ OpDecorate %8 Binding 0
 %13 = OpVariable %12 IncomingRayPayloadNV
 %14 = OpTypePointer RayPayloadNV %11
 %15 = OpVariable %14 RayPayloadNV
-%16 = OpTypePointer IncomingRayPayloadNV %10
+%16 = OpTypePointer RayPayloadNV %10
 %18 = OpTypeInt 32 0
 %19 = OpConstant %18 0
-%21 = OpTypePointer RayPayloadNV %10
+%20 = OpTypePointer IncomingRayPayloadNV %10
 %24 = OpConstant %9 1
 %25 = OpConstant %9 0
 %26 = OpConstant %9 2
@@ -74,16 +74,16 @@ OpDecorate %8 Binding 0
 %4 = OpLabel
 OpBranch %33
 %33 = OpLabel
-%17 = OpInBoundsAccessChain %16 %13 %19
-%20 = OpLoad %10 %17
-%22 = OpInBoundsAccessChain %21 %15 %19
-OpStore %22 %20
+%17 = OpInBoundsAccessChain %16 %15 %19
+%21 = OpInBoundsAccessChain %20 %13 %19
+%22 = OpLoad %10 %21
+OpStore %17 %22
 %23 = OpLoad %6 %8
 %30 = OpCompositeConstruct %29 %24 %26 %27
 %31 = OpCompositeConstruct %29 %25 %25 %24
 OpTraceRayKHR %23 %19 %19 %19 %19 %19 %30 %24 %31 %28 %15
-%32 = OpLoad %10 %22
-OpStore %17 %32
+%32 = OpLoad %10 %17
+OpStore %21 %32
 OpReturn
 OpFunctionEnd
 #endif

--- a/shaders/dxil-builtin/wave-reduce.comp
+++ b/shaders/dxil-builtin/wave-reduce.comp
@@ -34,11 +34,11 @@ void main(uint index : SV_DispatchThreadID)
 		BufI.Store(index * STRIDE, value);
 		value = WaveActiveProduct(iindex);
 		BufI.Store(index * STRIDE + 4, value);
-		value = WaveActiveBitAnd(iindex);
+		value = WaveActiveBitAnd(uint(iindex));
 		BufI.Store(index * STRIDE + 8, value);
-		value = WaveActiveBitOr(iindex);
+		value = WaveActiveBitOr(uint(iindex));
 		BufI.Store(index * STRIDE + 12, value);
-		value = WaveActiveBitXor(iindex);
+		value = WaveActiveBitXor(uint(iindex));
 		BufI.Store(index * STRIDE + 16, value);
 		value = WaveActiveMin(iindex);
 		BufI.Store(index * STRIDE + 20, value);

--- a/shaders/semantics/position-short.frag
+++ b/shaders/semantics/position-short.frag
@@ -1,4 +1,0 @@
-float3 main(float3 pos : SV_Position) : SV_Target
-{
-	return pos;
-}

--- a/shaders/semantics/position-short.vert
+++ b/shaders/semantics/position-short.vert
@@ -1,4 +1,0 @@
-float3 main() : SV_Position
-{
-	return 1.0.xxx;
-}


### PR DESCRIPTION
Need this for constexpr cast shaders.

Marked as draft as `raygen-complex-storage-class.rgen` currently fails with `A memory declaration object must be used in TraceRayKHR.` when being reflected back.