### PR TITLE
Handle precision qualifiers better.

### DIFF
--- a/bc/instruction.cpp
+++ b/bc/instruction.cpp
@@ -109,6 +109,16 @@ BinaryOperator::BinaryOps BinaryOperator::getOpcode() const
 	return op;
 }
 
+bool BinaryOperator::isFast() const
+{
+	return fast_math;
+}
+
+void BinaryOperator::set_fast_math(bool enabled)
+{
+	fast_math = enabled;
+}
+
 UnaryOperator::UnaryOperator(UnaryOps uop, Value *value)
     : Instruction(value->getType(), ValueKind::UnaryOperator)
 {

--- a/bc/instruction.hpp
+++ b/bc/instruction.hpp
@@ -206,10 +206,14 @@ public:
 	BinaryOperator(Value *LHS, Value *RHS, BinaryOps op);
 	BinaryOps getOpcode() const;
 
+	void set_fast_math(bool enabled);
+	bool isFast() const;
+
 	LLVMBC_DEFAULT_VALUE_KIND_IMPL
 
 private:
 	BinaryOps op;
+	bool fast_math = false;
 };
 
 class CastInst : public Instruction

--- a/opcodes/opcodes_llvm_builtins.cpp
+++ b/opcodes/opcodes_llvm_builtins.cpp
@@ -78,24 +78,29 @@ bool emit_binary_instruction(Converter::Impl &impl, const llvm::BinaryOperator *
 {
 	bool signed_input = false;
 	bool is_width_sensitive = false;
+	bool is_precision_sensitive = false;
 	spv::Op opcode;
 
 	switch (instruction->getOpcode())
 	{
 	case llvm::BinaryOperator::BinaryOps::FAdd:
 		opcode = spv::OpFAdd;
+		is_precision_sensitive = true;
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::FSub:
 		opcode = spv::OpFSub;
+		is_precision_sensitive = true;
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::FMul:
 		opcode = spv::OpFMul;
+		is_precision_sensitive = true;
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::FDiv:
 		opcode = spv::OpFDiv;
+		is_precision_sensitive = true;
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::Add:
@@ -144,6 +149,7 @@ bool emit_binary_instruction(Converter::Impl &impl, const llvm::BinaryOperator *
 
 	case llvm::BinaryOperator::BinaryOps::FRem:
 		opcode = spv::OpFRem;
+		is_precision_sensitive = true;
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::URem:
@@ -218,6 +224,8 @@ bool emit_binary_instruction(Converter::Impl &impl, const llvm::BinaryOperator *
 	op->add_ids({ id0, id1 });
 
 	impl.add(op);
+	if (!instruction->isFast() && is_precision_sensitive)
+		impl.builder().addDecoration(op->id, spv::DecorationNoContraction);
 	return true;
 }
 

--- a/reference/shaders/dxil-builtin/fmad-precise.frag
+++ b/reference/shaders/dxil-builtin/fmad-precise.frag
@@ -5,7 +5,9 @@ layout(location = 0) out float SV_Target;
 
 void main()
 {
-    SV_Target = fma(A.x, A.y, A.z);
+    precise float _22 = A.x * A.y;
+    precise float _23 = _22 + A.z;
+    SV_Target = _23;
 }
 
 
@@ -17,7 +19,6 @@ void main()
 ; Bound: 26
 ; Schema: 0
 OpCapability Shader
-%22 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %3 "main" %8 %10
 OpExecutionMode %3 OriginUpperLeft
@@ -26,6 +27,7 @@ OpName %8 "A"
 OpName %10 "SV_Target"
 OpDecorate %8 Location 0
 OpDecorate %10 Location 0
+OpDecorate %22 NoContraction
 OpDecorate %23 NoContraction
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -50,7 +52,8 @@ OpBranch %24
 %18 = OpLoad %5 %16
 %19 = OpAccessChain %11 %8 %20
 %21 = OpLoad %5 %19
-%23 = OpExtInst %5 %22 Fma %15 %18 %21
+%22 = OpFMul %5 %15 %18
+%23 = OpFAdd %5 %22 %21
 OpStore %10 %23
 OpReturn
 OpFunctionEnd

--- a/reference/shaders/llvm-builtin/precise_math.frag
+++ b/reference/shaders/llvm-builtin/precise_math.frag
@@ -1,0 +1,70 @@
+#version 460
+
+layout(location = 0) in float A;
+layout(location = 0, component = 1) in float B;
+layout(location = 0, component = 2) in float C;
+layout(location = 0) out float SV_Target;
+
+void main()
+{
+    precise float _15 = B * A;
+    precise float _16 = C + _15;
+    precise float _17 = A + _16;
+    precise float _18 = _17 - B;
+    precise float _19 = C * _18;
+    SV_Target = _19;
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.3
+; Generator: Unknown(30017); 21022
+; Bound: 22
+; Schema: 0
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %3 "main" %7 %8 %9 %11
+OpExecutionMode %3 OriginUpperLeft
+OpName %3 "main"
+OpName %7 "A"
+OpName %8 "B"
+OpName %9 "C"
+OpName %11 "SV_Target"
+OpDecorate %7 Location 0
+OpDecorate %8 Location 0
+OpDecorate %8 Component 1
+OpDecorate %9 Location 0
+OpDecorate %9 Component 2
+OpDecorate %11 Location 0
+OpDecorate %15 NoContraction
+OpDecorate %16 NoContraction
+OpDecorate %17 NoContraction
+OpDecorate %18 NoContraction
+OpDecorate %19 NoContraction
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeFloat 32
+%6 = OpTypePointer Input %5
+%7 = OpVariable %6 Input
+%8 = OpVariable %6 Input
+%9 = OpVariable %6 Input
+%10 = OpTypePointer Output %5
+%11 = OpVariable %10 Output
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %20
+%20 = OpLabel
+%12 = OpLoad %5 %9
+%13 = OpLoad %5 %8
+%14 = OpLoad %5 %7
+%15 = OpFMul %5 %13 %14
+%16 = OpFAdd %5 %12 %15
+%17 = OpFAdd %5 %14 %16
+%18 = OpFSub %5 %17 %13
+%19 = OpFMul %5 %12 %18
+OpStore %11 %19
+OpReturn
+OpFunctionEnd
+#endif

--- a/shaders/llvm-builtin/precise_math.frag
+++ b/shaders/llvm-builtin/precise_math.frag
@@ -1,0 +1,9 @@
+precise float main(float a : A, float b : B, float c : C) : SV_Target
+{
+	precise float tmp;
+	tmp = a * b + c;
+	tmp += a;
+	tmp -= b;
+	tmp *= c;
+	return tmp;
+}


### PR DESCRIPTION
- Correctly split expressions for precise mad.
- NoContraction on fma() is meaningless as SPIR-V fma is invariant.
- Check precision sensitivity of builtin arithmetic instructions.
- Parse fast math flags.