### PR TITLE
More CFG fixes

### DIFF
--- a/cfg_structurizer.cpp
+++ b/cfg_structurizer.cpp
@@ -1802,6 +1802,9 @@ void CFGStructurizer::split_merge_scopes()
 
 bool CFGStructurizer::query_reachability(const CFGNode &from, const CFGNode &to) const
 {
+	if (&from == &to)
+		return true;
+
 	const uint32_t *src_reachability = &reachability_bitset[from.forward_post_visit_order * reachability_stride];
 	return (src_reachability[to.forward_post_visit_order / 32] & (1u << (to.forward_post_visit_order & 31u))) != 0;
 }

--- a/cfg_structurizer.hpp
+++ b/cfg_structurizer.hpp
@@ -89,7 +89,7 @@ private:
 	static void isolate_structured(UnorderedSet<CFGNode *> &nodes, const CFGNode *header, const CFGNode *merge);
 
 	static Vector<IncomingValue>::const_iterator find_incoming_value(const CFGNode *frontier_pred,
-	                                                                      const Vector<IncomingValue> &incoming);
+	                                                                 const Vector<IncomingValue> &incoming);
 
 	void rewrite_selection_breaks(CFGNode *header, CFGNode *ladder_to);
 
@@ -117,10 +117,12 @@ private:
 	void retarget_pred_from(CFGNode *new_node, CFGNode *old_succ);
 	void retarget_succ_from(CFGNode *new_node, CFGNode *old_pred);
 
-	CFGNode *get_post_dominance_frontier_with_cfg_subset_that_reaches(CFGNode *node,
-	                                                                  CFGNode *must_reach,
-	                                                                  CFGNode *must_reach_frontier) const;
-	bool exists_path_in_cfg_without_intermediate_node(CFGNode *start_block, CFGNode *end_block, CFGNode *stop_block) const;
+	CFGNode *get_post_dominance_frontier_with_cfg_subset_that_reaches(const CFGNode *node,
+	                                                                  const CFGNode *must_reach,
+	                                                                  const CFGNode *must_reach_frontier) const;
+	bool exists_path_in_cfg_without_intermediate_node(const CFGNode *start_block,
+	                                                  const CFGNode *end_block,
+	                                                  const CFGNode *stop_block) const;
 
 	struct PHINode
 	{
@@ -144,5 +146,8 @@ private:
 
 	static bool can_complete_phi_insertion(const PHI &phi, const CFGNode *end_node);
 	bool query_reachability_through_back_edges(const CFGNode &from, const CFGNode &to) const;
+	bool query_reachability_split_loop_header(const CFGNode &from, const CFGNode &to, const CFGNode &end_node) const;
+	bool phi_frontier_makes_forward_progress(const PHI &phi, const CFGNode *frontier,
+	                                         const CFGNode *end_node) const;
 };
 } // namespace dxil_spv

--- a/cfg_structurizer.hpp
+++ b/cfg_structurizer.hpp
@@ -117,7 +117,9 @@ private:
 	void retarget_pred_from(CFGNode *new_node, CFGNode *old_succ);
 	void retarget_succ_from(CFGNode *new_node, CFGNode *old_pred);
 
-	CFGNode *get_post_dominance_frontier_with_cfg_subset_that_reaches(CFGNode *node, CFGNode *must_reach) const;
+	CFGNode *get_post_dominance_frontier_with_cfg_subset_that_reaches(CFGNode *node,
+	                                                                  CFGNode *must_reach,
+	                                                                  CFGNode *must_reach_frontier) const;
 	bool exists_path_in_cfg_without_intermediate_node(CFGNode *start_block, CFGNode *end_block, CFGNode *stop_block) const;
 
 	struct PHINode
@@ -139,5 +141,8 @@ private:
 
 	void log_cfg(const char *tag) const;
 	void log_cfg_graphviz(const char *path) const;
+
+	static bool can_complete_phi_insertion(const PHI &phi, const CFGNode *end_node);
+	bool query_reachability_through_back_edges(const CFGNode &from, const CFGNode &to) const;
 };
 } // namespace dxil_spv

--- a/reference/shaders/control-flow/loop-return.comp
+++ b/reference/shaders/control-flow/loop-return.comp
@@ -25,11 +25,9 @@ void main()
             {
                 _38 = gl_GlobalInvocationID.y == 0u;
                 uint frontier_phi_8_pred;
-                uint frontier_phi_8_pred_1;
                 if (_38)
                 {
                     frontier_phi_8_pred = _37;
-                    frontier_phi_8_pred_1 = 0u;
                 }
                 else
                 {
@@ -73,7 +71,6 @@ void main()
                         break;
                     }
                     frontier_phi_8_pred = frontier_phi_20_pred;
-                    frontier_phi_8_pred_1 = frontier_phi_20_pred_1;
                 }
                 _31 = frontier_phi_8_pred;
                 uint _36 = _35 + 1u;
@@ -112,11 +109,9 @@ void main()
             {
                 _42 = gl_GlobalInvocationID.y == 0u;
                 uint frontier_phi_10_pred;
-                uint frontier_phi_10_pred_1;
                 if (_42)
                 {
                     frontier_phi_10_pred = _41;
-                    frontier_phi_10_pred_1 = 0u;
                 }
                 else
                 {
@@ -160,7 +155,6 @@ void main()
                         break;
                     }
                     frontier_phi_10_pred = frontier_phi_21_pred;
-                    frontier_phi_10_pred_1 = frontier_phi_21_pred_1;
                 }
                 _32 = frontier_phi_10_pred;
                 uint _40 = _39 + 1u;
@@ -189,7 +183,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 129
+; Bound: 127
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -204,13 +198,11 @@ OpName %85 "frontier_phi_10.pred"
 OpName %86 "frontier_phi_20.pred"
 OpName %87 "frontier_phi_8.pred"
 OpName %88 "frontier_phi_21.pred"
-OpName %89 "frontier_phi_10.pred"
-OpName %90 "frontier_phi_14"
-OpName %91 "frontier_phi_3.2.ladder"
-OpName %92 "frontier_phi_20.pred"
-OpName %93 "frontier_phi_8.pred"
-OpName %94 "frontier_phi_12"
-OpName %95 "frontier_phi_3.1.ladder"
+OpName %89 "frontier_phi_14"
+OpName %90 "frontier_phi_3.2.ladder"
+OpName %91 "frontier_phi_20.pred"
+OpName %92 "frontier_phi_12"
+OpName %93 "frontier_phi_3.1.ladder"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %12 BuiltIn GlobalInvocationId
@@ -235,8 +227,8 @@ OpDecorate %12 BuiltIn GlobalInvocationId
 %82 = OpConstantTrue %23
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %96
-%96 = OpLabel
+OpBranch %94
+%94 = OpLabel
 %9 = OpLoad %6 %8
 %14 = OpAccessChain %13 %12 %15
 %16 = OpLoad %5 %14
@@ -245,43 +237,43 @@ OpBranch %96
 %20 = OpAccessChain %13 %12 %21
 %22 = OpLoad %5 %20
 %24 = OpULessThan %23 %16 %25
-OpSelectionMerge %127 None
-OpBranchConditional %24 %112 %97
-%112 = OpLabel
+OpSelectionMerge %125 None
+OpBranchConditional %24 %110 %95
+%110 = OpLabel
 %26 = OpIEqual %23 %16 %15
-OpSelectionMerge %126 None
-OpBranchConditional %26 %126 %113
-%113 = OpLabel
-OpBranch %114
-%114 = OpLabel
-%35 = OpPhi %5 %15 %113 %36 %124
-%37 = OpPhi %5 %15 %113 %31 %124
+OpSelectionMerge %124 None
+OpBranchConditional %26 %124 %111
+%111 = OpLabel
+OpBranch %112
+%112 = OpLabel
+%35 = OpPhi %5 %15 %111 %36 %122
+%37 = OpPhi %5 %15 %111 %31 %122
 %38 = OpIEqual %23 %19 %15
-OpLoopMerge %125 %124 None
+OpLoopMerge %123 %122 None
+OpBranch %113
+%113 = OpLabel
+OpSelectionMerge %121 None
+OpBranchConditional %38 %121 %114
+%114 = OpLabel
 OpBranch %115
 %115 = OpLabel
-OpSelectionMerge %123 None
-OpBranchConditional %38 %123 %116
-%116 = OpLabel
-OpBranch %117
-%117 = OpLabel
-%47 = OpPhi %5 %37 %116 %43 %119
-%48 = OpPhi %5 %15 %116 %49 %119
+%47 = OpPhi %5 %37 %114 %43 %117
+%48 = OpPhi %5 %15 %114 %49 %117
 %50 = OpBitwiseXor %5 %48 %35
 %51 = OpShiftLeftLogical %5 %50 %21
 %52 = OpImageRead %33 %9 %50
 %53 = OpCompositeExtract %5 %52 0
 %54 = OpIEqual %23 %53 %25
-OpLoopMerge %121 %119 None
-OpBranchConditional %54 %120 %118
-%120 = OpLabel
+OpLoopMerge %119 %117 None
+OpBranchConditional %54 %118 %116
+%118 = OpLabel
 %64 = OpImageRead %33 %9 %63
 %65 = OpCompositeExtract %5 %64 0
 %29 = OpIAdd %5 %65 %47
-OpBranch %121
-%118 = OpLabel
 OpBranch %119
-%119 = OpLabel
+%116 = OpLabel
+OpBranch %117
+%117 = OpLabel
 %66 = OpShiftLeftLogical %5 %35 %21
 %67 = OpIMul %5 %66 %48
 %68 = OpShiftRightLogical %5 %67 %21
@@ -290,65 +282,64 @@ OpBranch %119
 %43 = OpIAdd %5 %70 %47
 %49 = OpIAdd %5 %48 %18
 %71 = OpULessThan %23 %49 %19
-OpBranchConditional %71 %117 %121
+OpBranchConditional %71 %115 %119
+%119 = OpLabel
+%80 = OpPhi %23 %81 %117 %82 %118
+%86 = OpPhi %5 %43 %117 %37 %118
+%91 = OpPhi %5 %15 %117 %29 %118
+OpSelectionMerge %120 None
+OpBranchConditional %80 %123 %120
+%120 = OpLabel
+OpBranch %121
 %121 = OpLabel
-%80 = OpPhi %23 %81 %119 %82 %120
-%86 = OpPhi %5 %43 %119 %37 %120
-%92 = OpPhi %5 %15 %119 %29 %120
-OpSelectionMerge %122 None
-OpBranchConditional %80 %125 %122
-%122 = OpLabel
-OpBranch %123
-%123 = OpLabel
-%87 = OpPhi %5 %37 %115 %86 %122
-%93 = OpPhi %5 %15 %115 %92 %122
+%87 = OpPhi %5 %37 %113 %86 %120
 %31 = OpCopyObject %5 %87
-OpBranch %124
-%124 = OpLabel
+OpBranch %122
+%122 = OpLabel
 %36 = OpIAdd %5 %35 %18
 %44 = OpULessThan %23 %36 %16
-OpBranchConditional %44 %114 %125
-%125 = OpLabel
-%94 = OpPhi %5 %31 %124 %92 %121
-OpBranch %126
-%126 = OpLabel
-%95 = OpPhi %5 %15 %112 %94 %125
-OpBranch %127
-%97 = OpLabel
+OpBranchConditional %44 %112 %123
+%123 = OpLabel
+%92 = OpPhi %5 %31 %122 %91 %119
+OpBranch %124
+%124 = OpLabel
+%93 = OpPhi %5 %15 %110 %92 %123
+OpBranch %125
+%95 = OpLabel
 %27 = OpIEqual %23 %22 %15
-OpSelectionMerge %111 None
-OpBranchConditional %27 %111 %98
-%98 = OpLabel
-OpBranch %99
-%99 = OpLabel
-%39 = OpPhi %5 %15 %98 %40 %109
-%41 = OpPhi %5 %15 %98 %32 %109
+OpSelectionMerge %109 None
+OpBranchConditional %27 %109 %96
+%96 = OpLabel
+OpBranch %97
+%97 = OpLabel
+%39 = OpPhi %5 %15 %96 %40 %107
+%41 = OpPhi %5 %15 %96 %32 %107
 %42 = OpIEqual %23 %19 %15
-OpLoopMerge %110 %109 None
+OpLoopMerge %108 %107 None
+OpBranch %98
+%98 = OpLabel
+OpSelectionMerge %106 None
+OpBranchConditional %42 %106 %99
+%99 = OpLabel
 OpBranch %100
 %100 = OpLabel
-OpSelectionMerge %108 None
-OpBranchConditional %42 %108 %101
-%101 = OpLabel
-OpBranch %102
-%102 = OpLabel
-%55 = OpPhi %5 %15 %101 %56 %104
-%57 = OpPhi %5 %41 %101 %45 %104
+%55 = OpPhi %5 %15 %99 %56 %102
+%57 = OpPhi %5 %41 %99 %45 %102
 %58 = OpBitwiseXor %5 %55 %39
 %59 = OpShiftLeftLogical %5 %58 %21
 %60 = OpImageRead %33 %9 %58
 %61 = OpCompositeExtract %5 %60 0
 %62 = OpIEqual %23 %61 %25
-OpLoopMerge %106 %104 None
-OpBranchConditional %62 %105 %103
-%105 = OpLabel
+OpLoopMerge %104 %102 None
+OpBranchConditional %62 %103 %101
+%103 = OpLabel
 %72 = OpImageRead %33 %9 %63
 %73 = OpCompositeExtract %5 %72 0
 %30 = OpIAdd %5 %73 %57
-OpBranch %106
-%103 = OpLabel
 OpBranch %104
-%104 = OpLabel
+%101 = OpLabel
+OpBranch %102
+%102 = OpLabel
 %74 = OpShiftLeftLogical %5 %39 %21
 %75 = OpIMul %5 %74 %55
 %76 = OpShiftRightLogical %5 %75 %21
@@ -357,32 +348,31 @@ OpBranch %104
 %45 = OpIAdd %5 %78 %57
 %56 = OpIAdd %5 %55 %18
 %79 = OpULessThan %23 %56 %19
-OpBranchConditional %79 %102 %106
+OpBranchConditional %79 %100 %104
+%104 = OpLabel
+%83 = OpPhi %23 %81 %102 %82 %103
+%84 = OpPhi %5 %45 %102 %41 %103
+%88 = OpPhi %5 %15 %102 %30 %103
+OpSelectionMerge %105 None
+OpBranchConditional %83 %108 %105
+%105 = OpLabel
+OpBranch %106
 %106 = OpLabel
-%83 = OpPhi %23 %81 %104 %82 %105
-%84 = OpPhi %5 %45 %104 %41 %105
-%88 = OpPhi %5 %15 %104 %30 %105
-OpSelectionMerge %107 None
-OpBranchConditional %83 %110 %107
-%107 = OpLabel
-OpBranch %108
-%108 = OpLabel
-%85 = OpPhi %5 %41 %100 %84 %107
-%89 = OpPhi %5 %15 %100 %88 %107
+%85 = OpPhi %5 %41 %98 %84 %105
 %32 = OpCopyObject %5 %85
-OpBranch %109
-%109 = OpLabel
+OpBranch %107
+%107 = OpLabel
 %40 = OpIAdd %5 %39 %18
 %46 = OpULessThan %23 %40 %22
-OpBranchConditional %46 %99 %110
-%110 = OpLabel
-%90 = OpPhi %5 %32 %109 %88 %106
-OpBranch %111
-%111 = OpLabel
-%91 = OpPhi %5 %15 %97 %90 %110
-OpBranch %127
-%127 = OpLabel
-%28 = OpPhi %5 %95 %126 %91 %111
+OpBranchConditional %46 %97 %108
+%108 = OpLabel
+%89 = OpPhi %5 %32 %107 %88 %104
+OpBranch %109
+%109 = OpLabel
+%90 = OpPhi %5 %15 %95 %89 %108
+OpBranch %125
+%125 = OpLabel
+%28 = OpPhi %5 %93 %124 %90 %109
 %34 = OpCompositeConstruct %33 %28 %28 %28 %28
 OpImageWrite %9 %15 %34
 OpReturn


### PR DESCRIPTION
Fixes undef being used as Phi inputs. Fixes weird sun particles punching through walls in RE8.
Also optimizes PHI placement a fair bit and avoids generating useless PHI frontiers.