### PR TITLE
Parse enough of SM 6.4 library subobject metadata to report failures.

### DIFF
--- a/dxil.hpp
+++ b/dxil.hpp
@@ -88,6 +88,17 @@ enum class FourCC : uint32_t
 	ShaderHash = fourcc('H', 'A', 'S', 'H')
 };
 
+enum class RuntimeDataPartType : uint32_t
+{
+	Invalid = 0,
+	StringBuffer = 1,
+	IndexArrays = 2,
+	ResourceTable = 3,
+	FunctionTable = 4,
+	RawBytes = 5,
+	SubobjectTable = 6
+};
+
 enum class ComponentType : uint8_t
 {
 	Invalid = 0,

--- a/dxil_parser.hpp
+++ b/dxil_parser.hpp
@@ -40,5 +40,6 @@ private:
 
 	bool parse_dxil(MemoryStream &stream);
 	bool parse_iosg1(MemoryStream &stream, Vector<DXIL::IOElement> &elements);
+	bool parse_rdat(MemoryStream &stream);
 };
 } // namespace dxil_spv


### PR DESCRIPTION
Esoteric feature. Defer implementation of this until we need to.