### PR TITLE
Never rewrite IDs in value_map directly.

### DIFF
--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -336,6 +336,7 @@ struct Converter::Impl
 	Operation *allocate(spv::Op op, spv::Id type_id);
 	Operation *allocate(spv::Op op, const llvm::Value *value, spv::Id type_id);
 	Operation *allocate(spv::Op op, spv::Id id, spv::Id type_id);
+	void rewrite_value(const llvm::Value *value, spv::Id id);
 	spv::Builder &builder();
 	spv::Id create_variable(spv::StorageClass storage, spv::Id type_id, const char *name = nullptr);
 	spv::Id create_variable_with_initializer(spv::StorageClass storage, spv::Id type_id,

--- a/opcodes/dxil/dxil_arithmetic.cpp
+++ b/opcodes/dxil/dxil_arithmetic.cpp
@@ -409,7 +409,7 @@ bool emit_i8_dot_instruction(Converter::Impl &impl, const llvm::CallInst *instru
 		impl.add(add_op);
 	}
 
-	impl.value_map[instruction] = acc;
+	impl.rewrite_value(instruction, acc);
 	return true;
 }
 

--- a/opcodes/dxil/dxil_buffer.cpp
+++ b/opcodes/dxil/dxil_buffer.cpp
@@ -404,7 +404,8 @@ static bool emit_physical_buffer_load_instruction(Converter::Impl &impl, const l
 		impl.add(cast_op);
 		loaded_id = cast_op->id;
 	}
-	impl.value_map[instruction] = loaded_id;
+
+	impl.rewrite_value(instruction, loaded_id);
 
 	if (vecsize == 1)
 		impl.llvm_composite_meta[instruction].forced_composite = false;
@@ -655,10 +656,10 @@ bool emit_buffer_load_instruction(Converter::Impl &impl, const llvm::CallInst *i
 					casted_id = op->id;
 				}
 
-				impl.value_map[instruction] = casted_id;
+				impl.rewrite_value(instruction, casted_id);
 			}
 			else
-				impl.value_map[instruction] = constructed_id;
+				impl.rewrite_value(instruction, constructed_id);
 		}
 
 		access_meta.forced_composite = false;
@@ -1246,7 +1247,7 @@ bool emit_buffer_update_counter_instruction(Converter::Impl &impl, const llvm::C
 		op = impl.allocate(spv::OpISub, builder.makeUintType(32));
 		op->add_ids({ result_id, builder.makeUintConstant(1) });
 		impl.add(op);
-		impl.value_map[instruction] = op->id;
+		impl.rewrite_value(instruction, op->id);
 	}
 
 	return true;

--- a/opcodes/dxil/dxil_compute.cpp
+++ b/opcodes/dxil/dxil_compute.cpp
@@ -104,7 +104,7 @@ bool emit_thread_id_load_instruction(spv::BuiltIn builtin, Converter::Impl &impl
 			if (dim < 3 && impl.execution_mode_meta.workgroup_threads[dim] == 1)
 			{
 				spv::Id const_zero = impl.builder().makeUintConstant(0);
-				impl.value_map[instruction] = const_zero;
+				impl.rewrite_value(instruction, const_zero);
 				return true;
 			}
 		}

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -329,7 +329,7 @@ bool emit_allocate_ray_query(Converter::Impl &impl, const llvm::CallInst *inst)
 	// The return type of allocateRayQuery appears to be i32, so this might be how it's intended to be done ...
 	auto &builder = impl.builder();
 	spv::Id var_id = impl.spirv_module.create_variable(spv::StorageClassPrivate, builder.makeRayQueryType());
-	impl.value_map[inst] = var_id;
+	impl.rewrite_value(inst, var_id);
 	impl.handle_to_storage_class[inst] = spv::StorageClassPrivate;
 	emit_ray_query_capabilities(impl);
 	return true;

--- a/opcodes/dxil/dxil_sampling.cpp
+++ b/opcodes/dxil/dxil_sampling.cpp
@@ -291,7 +291,7 @@ bool emit_sample_instruction(DXIL::Op opcode, Converter::Impl &impl, const llvm:
 			impl.allocate(spv::OpCompositeConstruct, builder.makeVectorType(impl.get_type_id(target_type), 4));
 		splat_op->add_ids({ loaded_id, loaded_id, loaded_id, loaded_id });
 		impl.add(splat_op);
-		impl.value_map[instruction] = splat_op->id;
+		impl.rewrite_value(instruction, splat_op->id);
 	}
 	else
 	{
@@ -599,7 +599,7 @@ bool emit_get_dimensions_instruction(Converter::Impl &impl, const llvm::CallInst
 	{
 		if (num_coords == 1)
 			access_meta.forced_composite = false;
-		impl.value_map[instruction] = dimensions_op->id;
+		impl.rewrite_value(instruction, dimensions_op->id);
 	}
 	else if (dimensions_op)
 	{
@@ -622,7 +622,7 @@ bool emit_get_dimensions_instruction(Converter::Impl &impl, const llvm::CallInst
 		access_meta.forced_composite = false;
 		access_meta.access_mask = 1;
 		access_meta.components = 1;
-		impl.value_map[instruction] = aux_op->id;
+		impl.rewrite_value(instruction, aux_op->id);
 	}
 
 	builder.addCapability(spv::CapabilityImageQuery);
@@ -865,7 +865,7 @@ static spv::Id build_rasterizer_sample_count(Converter::Impl &impl)
 
 bool emit_get_render_target_sample_count(Converter::Impl &impl, const llvm::CallInst *instruction)
 {
-	impl.value_map[instruction] = build_rasterizer_sample_count(impl);
+	impl.rewrite_value(instruction, build_rasterizer_sample_count(impl));
 	return true;
 }
 


### PR DESCRIPTION
If PHI inputs consumed the values first, they will be stale. Go through
a common code path so we handle all scenarios where IDs are rewritten.