### PR TITLE
Don't create duplicate edges when rewriting branches.

### DIFF
--- a/node_pool.cpp
+++ b/node_pool.cpp
@@ -32,7 +32,7 @@ CFGNodePool::~CFGNodePool()
 
 CFGNode *CFGNodePool::create_node()
 {
-	auto node = std::unique_ptr<CFGNode>(new CFGNode);
+	auto node = std::unique_ptr<CFGNode>(new CFGNode(*this));
 	auto *ret = node.get();
 	nodes.push_back(std::move(node));
 	return ret;


### PR DESCRIPTION
Detect this scenario and create intermediate blocks instead.

Fix #78.