### PR TITLE
Only emit RT resources which are active in entry point.

### DIFF
--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -174,9 +174,18 @@ struct Converter::Impl
 		DXIL::ResourceType type;
 		unsigned meta_index;
 		llvm::Value *offset;
+		const llvm::GlobalVariable *variable;
 		bool non_uniform;
 	};
 	UnorderedMap<const llvm::Value *, ResourceMetaReference> llvm_global_variable_to_resource_mapping;
+	UnorderedSet<const llvm::GlobalVariable *> llvm_active_global_resource_variables;
+
+	struct ResourceVariableMeta
+	{
+		bool is_lib_variable;
+		bool is_active;
+	};
+	ResourceVariableMeta get_resource_variable_meta(const llvm::MDNode *resource) const;
 
 	struct ExecutionModeMeta
 	{

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -441,6 +441,8 @@ bool analyze_dxil_instruction(Converter::Impl &impl, const llvm::CallInst *instr
 		else if (itr->second.type == DXIL::ResourceType::SRV)
 			impl.llvm_value_to_srv_resource_index_map[instruction] = itr->second.meta_index;
 
+		impl.llvm_active_global_resource_variables.insert(itr->second.variable);
+
 		if (impl.options.descriptor_qa_enabled && impl.options.descriptor_qa_sink_handles)
 			impl.resource_handle_to_block[instruction] = bb;
 		break;

--- a/reference/shaders/stages/raygen-skip-inactive-resources.rgen
+++ b/reference/shaders/stages/raygen-skip-inactive-resources.rgen
@@ -1,0 +1,120 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+struct _14
+{
+    vec4 _m0;
+};
+
+struct _17
+{
+    float _m0;
+};
+
+layout(set = 40, binding = 30) uniform accelerationStructureEXT AS;
+layout(set = 20, binding = 10) uniform writeonly image2D IMG;
+layout(location = 0) rayPayloadEXT _14 _16;
+layout(location = 1) rayPayloadEXT _17 _19;
+
+void main()
+{
+    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    traceRayEXT(AS, 0u, 1u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
+    imageStore(IMG, ivec2(uvec2(0u)), vec4(_16._m0.x + _19._m0, _16._m0.y + _19._m0, _16._m0.z + _19._m0, _16._m0.w + _19._m0));
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.4
+; Generator: Unknown(30017); 21022
+; Bound: 55
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationNV %3 "main" %8 %12 %16 %19
+OpName %3 "main"
+OpName %8 "AS"
+OpName %12 "IMG"
+OpName %14 ""
+OpName %17 ""
+OpDecorate %8 DescriptorSet 40
+OpDecorate %8 Binding 30
+OpDecorate %12 DescriptorSet 20
+OpDecorate %12 Binding 10
+OpDecorate %12 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 1
+%6 = OpTypeAccelerationStructureKHR
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeVector %9 4
+%14 = OpTypeStruct %13
+%15 = OpTypePointer RayPayloadNV %14
+%16 = OpVariable %15 RayPayloadNV
+%17 = OpTypeStruct %9
+%18 = OpTypePointer RayPayloadNV %17
+%19 = OpVariable %18 RayPayloadNV
+%21 = OpTypeInt 32 0
+%22 = OpConstant %21 0
+%23 = OpConstant %9 1
+%24 = OpConstant %9 0
+%25 = OpConstant %9 2
+%26 = OpConstant %9 3
+%27 = OpConstant %9 4
+%28 = OpTypeVector %9 3
+%32 = OpConstant %21 1
+%35 = OpTypePointer RayPayloadNV %13
+%42 = OpTypePointer RayPayloadNV %9
+%50 = OpTypeVector %21 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %53
+%53 = OpLabel
+%20 = OpLoad %6 %8
+%29 = OpCompositeConstruct %28 %23 %25 %26
+%30 = OpCompositeConstruct %28 %24 %24 %23
+OpTraceRayKHR %20 %22 %22 %22 %22 %22 %29 %23 %30 %27 %16
+%31 = OpLoad %6 %8
+%33 = OpCompositeConstruct %28 %23 %25 %26
+%34 = OpCompositeConstruct %28 %24 %24 %23
+OpTraceRayKHR %31 %22 %32 %22 %22 %22 %33 %23 %34 %27 %19
+%36 = OpInBoundsAccessChain %35 %16 %22
+%37 = OpLoad %13 %36
+%38 = OpCompositeExtract %9 %37 0
+%39 = OpCompositeExtract %9 %37 1
+%40 = OpCompositeExtract %9 %37 2
+%41 = OpCompositeExtract %9 %37 3
+%43 = OpInBoundsAccessChain %42 %19 %22
+%44 = OpLoad %9 %43
+%45 = OpFAdd %9 %38 %44
+%46 = OpFAdd %9 %39 %44
+%47 = OpFAdd %9 %40 %44
+%48 = OpFAdd %9 %41 %44
+%49 = OpLoad %10 %12
+%51 = OpCompositeConstruct %50 %22 %22
+%52 = OpCompositeConstruct %13 %45 %46 %47 %48
+OpImageWrite %49 %51 %52
+OpReturn
+OpFunctionEnd
+#endif

--- a/shaders/stages/raygen-skip-inactive-resources.rgen
+++ b/shaders/stages/raygen-skip-inactive-resources.rgen
@@ -1,0 +1,38 @@
+struct Payload
+{
+	float4 color;
+};
+
+struct Payload1
+{
+	float color;
+};
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+SamplerState S : register(s0);
+Texture2D<float4> T : register(t0);
+
+[shader("miss")]
+void RayMiss(inout Payload payload)
+{
+	payload.color = T.SampleLevel(S, 0.5.xx, 0.0);
+}
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload payload0;
+	Payload1 payload1;
+	TraceRay(AS, RAY_FLAG_NONE, 0, 0, 0, 0, ray, payload0);
+	TraceRay(AS, RAY_FLAG_NONE, 1, 0, 0, 0, ray, payload1);
+
+	IMG[int2(0, 0)] = payload0.color + payload1.color;
+}


### PR DESCRIPTION
It does not appear to be required to declare unused resources in root
signature if the resource is not considered active.