### PR TITLE
Use https instead of git protocol for the submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "third_party/spirv-headers"]
 	path = third_party/spirv-headers
-	url = git://github.com/KhronosGroup/SPIRV-Headers
+	url = https://github.com/KhronosGroup/SPIRV-Headers
 [submodule "third_party/SPIRV-Tools"]
 	path = third_party/SPIRV-Tools
-	url = git://github.com/KhronosGroup/SPIRV-Tools
+	url = https://github.com/KhronosGroup/SPIRV-Tools
 [submodule "third_party/SPIRV-Cross"]
 	path = third_party/SPIRV-Cross
-	url = git://github.com/KhronosGroup/SPIRV-Cross
+	url = https://github.com/KhronosGroup/SPIRV-Cross


### PR DESCRIPTION
GitHub is obsoleting unencrypted git:// access. The first brownout
happened on November 2, 2021.

Context: https://github.blog/2021-09-01-improving-git-protocol-security-github/