### PR TITLE
Honor dx.precise on unpack/pack FP instructions.

### DIFF
--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -583,6 +583,7 @@ struct Converter::Impl
 		bool discards = false;
 		bool can_require_primitive_culling = false;
 		bool require_compute_shader_derivatives = false;
+		bool precise_f16_to_f32_observed = false;
 	} shader_analysis;
 
 	// For descriptor QA, we need to rewrite how resource handles are emitted.

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -875,6 +875,12 @@ bool analyze_dxil_resource_instruction(Converter::Impl &impl, const llvm::CallIn
 		}
 		break;
 
+	case DXIL::Op::LegacyF16ToF32:
+		// Very specific check for HZD invariance. See f32_to_f16 code for details.
+		if (instruction->getMetadata("dx.precise") != nullptr)
+			impl.shader_analysis.precise_f16_to_f32_observed = true;
+		break;
+
 	default:
 		break;
 	}


### PR DESCRIPTION
HZD shows invariance issues if we don't consider this case since we have
observed pack -> imageStore -> unpack patterns in the wild, and at least
NV compiler appears to optimize away pack/unpack, leaving full FP32
precision in one shaders and FP16 precision in another, leading to
invariance issues, despite shader being declared as invariant.

OpQuantizeF16 seems to be the only workaround.