### PR TITLE
Ensure that integer patch i/o variables are unsigned.

### DIFF
--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -3519,7 +3519,7 @@ bool Converter::Impl::emit_patch_variables()
 		auto *patch = llvm::cast<llvm::MDNode>(patch_node->getOperand(i));
 		auto element_id = get_constant_metadata(patch, 0);
 		auto semantic_name = get_string_metadata(patch, 1);
-		auto actual_element_type = normalize_component_type(static_cast<DXIL::ComponentType>(get_constant_metadata(patch, 2)));
+		auto actual_element_type = convert_component_to_unsigned(normalize_component_type(static_cast<DXIL::ComponentType>(get_constant_metadata(patch, 2))));
 		auto effective_element_type = get_effective_input_output_type(actual_element_type);
 		auto system_value = static_cast<DXIL::Semantic>(get_constant_metadata(patch, 3));
 


### PR DESCRIPTION
Witcher 3 has a tess eval shader that declares the following variable:
```glsl
layout(location = 3) patch in uint CMLEVEL;
```

but the rest of the code base seems to assume that I/O integer variables are unsigned, so we end up generatig invalid SPIR-V. This fixes the variable type and allows the game to run.