### PR TITLE
Handle scenario where struct is used as PHI instead of vector.

### DIFF
--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -5783,6 +5783,11 @@ bool Converter::Impl::analyze_instructions(const llvm::Function *function)
 				if (!analyze_load_instruction(*this, load_inst))
 					return false;
 			}
+			else if (auto *phi_inst = llvm::dyn_cast<llvm::PHINode>(&inst))
+			{
+				if (!analyze_phi_instruction(*this, phi_inst))
+					return false;
+			}
 			else if (auto *getelementptr_inst = llvm::dyn_cast<llvm::GetElementPtrInst>(&inst))
 			{
 				if (!analyze_getelementptr_instruction(*this, getelementptr_inst))

--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -227,6 +227,8 @@ struct Converter::Impl
 		unsigned components = 0;
 		// If true, the composite was loaded as a vector, i.e. typed buffer or texture read.
 		bool forced_composite = true;
+		// Forces a composite to be treated as a struct instead of vector or scalar.
+		bool forced_struct = false;
 	};
 	UnorderedMap<const llvm::Value *, CompositeMeta> llvm_composite_meta;
 

--- a/opcodes/dxil/dxil_buffer.cpp
+++ b/opcodes/dxil/dxil_buffer.cpp
@@ -504,6 +504,8 @@ static bool emit_physical_buffer_load_instruction(Converter::Impl &impl, const l
 	if (vecsize == 1)
 		impl.llvm_composite_meta[instruction].forced_composite = false;
 
+	build_exploded_composite_from_vector(impl, instruction, vecsize);
+
 	return true;
 }
 
@@ -784,6 +786,8 @@ bool emit_buffer_load_instruction(Converter::Impl &impl, const llvm::CallInst *i
 			}
 			else
 				impl.rewrite_value(instruction, constructed_id);
+
+			build_exploded_composite_from_vector(impl, instruction, conservative_num_elements);
 		}
 
 		access_meta.forced_composite = false;
@@ -818,7 +822,10 @@ bool emit_buffer_load_instruction(Converter::Impl &impl, const llvm::CallInst *i
 		if (sparse)
 			impl.repack_sparse_feedback(meta.component_type, 4, instruction, target_type);
 		else
+		{
 			impl.fixup_load_type_typed(meta.component_type, 4, instruction, target_type);
+			build_exploded_composite_from_vector(impl, instruction, 4);
+		}
 	}
 
 	return true;

--- a/opcodes/dxil/dxil_common.hpp
+++ b/opcodes/dxil/dxil_common.hpp
@@ -65,4 +65,6 @@ Converter::Impl::ClipCullMeta *output_clip_cull_distance_meta(
 bool emit_store_clip_cull_distance(
 	Converter::Impl &impl, const llvm::CallInst *instruction,
 	const Converter::Impl::ClipCullMeta &meta);
+
+void build_exploded_composite_from_vector(Converter::Impl &impl, const llvm::Instruction *inst, unsigned active_lanes);
 }

--- a/opcodes/dxil/dxil_resources.cpp
+++ b/opcodes/dxil/dxil_resources.cpp
@@ -1642,6 +1642,8 @@ static bool emit_cbuffer_load_physical_pointer(Converter::Impl &impl, const llvm
 		impl.rewrite_value(instruction, cast_op->id);
 	}
 
+	build_exploded_composite_from_vector(impl, instruction, 4);
+
 	return true;
 }
 
@@ -1771,6 +1773,8 @@ static bool emit_cbuffer_load_from_uints(Converter::Impl &impl, const llvm::Call
 		impl.rewrite_value(instruction, cast_op->id);
 	}
 
+	build_exploded_composite_from_vector(impl, instruction, 4);
+
 	return true;
 }
 
@@ -1887,6 +1891,8 @@ bool emit_cbuffer_load_instruction(Converter::Impl &impl, const llvm::CallInst *
 			impl.rewrite_value(instruction, cast_op->id);
 		}
 
+		build_exploded_composite_from_vector(impl, instruction, 4);
+
 		return true;
 	}
 }
@@ -1996,6 +2002,8 @@ bool emit_cbuffer_load_legacy_instruction(Converter::Impl &impl, const llvm::Cal
 			impl.add(cast_op);
 			impl.rewrite_value(instruction, cast_op->id);
 		}
+
+		build_exploded_composite_from_vector(impl, instruction, 4);
 	}
 
 	return true;

--- a/opcodes/dxil/dxil_sampling.cpp
+++ b/opcodes/dxil/dxil_sampling.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "dxil_sampling.hpp"
+#include "dxil_common.hpp"
 #include "logging.hpp"
 #include "opcodes/converter_impl.hpp"
 
@@ -307,6 +308,8 @@ bool emit_sample_instruction(DXIL::Op opcode, Converter::Impl &impl, const llvm:
 		impl.fixup_load_type_typed(meta.component_type, 4, instruction, target_type);
 	}
 
+	build_exploded_composite_from_vector(impl, instruction, 4);
+
 	return true;
 }
 
@@ -397,7 +400,10 @@ bool emit_sample_grad_instruction(Converter::Impl &impl, const llvm::CallInst *i
 	if (sparse)
 		impl.repack_sparse_feedback(meta.component_type, 4, instruction, target_type);
 	else
+	{
 		impl.fixup_load_type_typed(meta.component_type, 4, instruction, target_type);
+		build_exploded_composite_from_vector(impl, instruction, 4);
+	}
 	return true;
 }
 
@@ -488,7 +494,10 @@ bool emit_texture_load_instruction(Converter::Impl &impl, const llvm::CallInst *
 	if (sparse)
 		impl.repack_sparse_feedback(meta.component_type, 4, instruction, target_type);
 	else
+	{
 		impl.fixup_load_type_typed(meta.component_type, 4, instruction, target_type);
+		build_exploded_composite_from_vector(impl, instruction, 4);
+	}
 	return true;
 }
 
@@ -762,7 +771,10 @@ bool emit_texture_gather_instruction(bool compare, Converter::Impl &impl, const 
 	if (sparse)
 		impl.repack_sparse_feedback(meta.component_type, 4, instruction, target_type);
 	else
+	{
 		impl.fixup_load_type_typed(meta.component_type, 4, instruction, target_type);
+		build_exploded_composite_from_vector(impl, instruction, 4);
+	}
 	return true;
 }
 

--- a/opcodes/opcodes_llvm_builtins.cpp
+++ b/opcodes/opcodes_llvm_builtins.cpp
@@ -1525,6 +1525,29 @@ bool analyze_load_instruction(Converter::Impl &impl, const llvm::LoadInst *inst)
 	return true;
 }
 
+bool analyze_phi_instruction(Converter::Impl &impl, const llvm::PHINode *inst)
+{
+	auto *type = inst->getType();
+	if (type->getTypeID() != llvm::Type::TypeID::StructTyID || type->getStructNumElements() != 4)
+		return true;
+
+	// If a PHI is the exploded struct type we expect from resource load operations,
+	// we need to drop the neat vector types that are actually readable
+	// and fall back to struct types instead like DXIL wants.
+	// At this point we cannot track SSA uses through all possible PHIs,
+	// and we must assume that all components can be used.
+
+	for (unsigned i = 0; i < inst->getNumIncomingValues(); i++)
+	{
+		auto &m = impl.llvm_composite_meta[inst->getIncomingValue(i)];
+		m.forced_struct = true;
+		m.access_mask = 0xf;
+		m.components = 4;
+	}
+
+	return true;
+}
+
 bool analyze_extractvalue_instruction(Converter::Impl &impl, const llvm::ExtractValueInst *inst)
 {
 	if (inst->getNumIndices() == 1 &&

--- a/opcodes/opcodes_llvm_builtins.hpp
+++ b/opcodes/opcodes_llvm_builtins.hpp
@@ -45,6 +45,7 @@ bool emit_extractelement_instruction(Converter::Impl &impl, const llvm::ExtractE
 bool emit_insertelement_instruction(Converter::Impl &impl, const llvm::InsertElementInst *instruction);
 
 bool analyze_load_instruction(Converter::Impl &impl, const llvm::LoadInst *instruction);
+bool analyze_phi_instruction(Converter::Impl &impl, const llvm::PHINode *instruction);
 bool analyze_getelementptr_instruction(Converter::Impl &impl, const llvm::GetElementPtrInst *instruction);
 bool analyze_extractvalue_instruction(Converter::Impl &impl, const llvm::ExtractValueInst *instruction);
 


### PR DESCRIPTION
If our pretend-vectors are used in contexts that aren't directly compatible we have to explode the vectors into structs instead to accurately observe the type system in DXIL.