### PR TITLE
Accept '-' as an identifier character.

### DIFF
--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -3202,7 +3202,7 @@ static bool is_identifier(char c)
 	const auto is_lower = [](char c) -> bool { return c >= 'a' && c <= 'z'; };
 	const auto is_upper = [](char c) -> bool { return c >= 'A' && c <= 'Z'; };
 	const auto is_digit = [](char c) -> bool { return c >= '0' && c <= '9'; };
-	return is_lower(c) || is_upper(c) || c == '_' || is_digit(c);
+	return is_lower(c) || is_upper(c) || c == '_' || c == '-' || is_digit(c);
 }
 
 static bool is_mangled_entry_point(const char *user)


### PR DESCRIPTION
This fixes a crash when enabling DXR support in Dead Space.

I added some logging to `Converter::entry_point_matches`. `entry` is the one read from DXIL and `user` is passed to the API.

> user: 14CB8A03-0000-0000-0900-000000000000,
> entry: ?14CB8A03-0000-0000-0900-000000000000@@YAXXZ,
> user mangled? 1,
> entry mangled: 1,
> demangled entry: 14CB8A03
