### PR TITLE
Implement workaround for WaveReadFirstLane in control flow.

### DIFF
--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -669,6 +669,8 @@ struct Converter::Impl
 	UnorderedSet<const llvm::CallInst *> resource_handles_needing_sink;
 	UnorderedSet<const llvm::CallInst *> resource_handle_is_conservative;
 	UnorderedMap<const llvm::BasicBlock *, Vector<const llvm::Instruction *>> bb_to_sinks;
+	UnorderedSet<const llvm::CallInst *> wave_op_forced_helper_lanes;
+	UnorderedSet<const llvm::Value *> control_sensitive_bools;
 
 	bool type_can_relax_precision(const llvm::Type *type, bool known_integer_sign) const;
 	void decorate_relaxed_precision(const llvm::Type *type, spv::Id id, bool known_integer_sign);

--- a/opcodes/dxil/dxil_waveops.cpp
+++ b/opcodes/dxil/dxil_waveops.cpp
@@ -82,7 +82,8 @@ bool emit_wave_builtin_instruction(spv::BuiltIn builtin, Converter::Impl &impl, 
 
 bool emit_wave_boolean_instruction(spv::Op opcode, Converter::Impl &impl, const llvm::CallInst *instruction)
 {
-	if (opcode == spv::OpGroupNonUniformAllEqual && wave_op_needs_helper_lane_masking(impl))
+	if (opcode == spv::OpGroupNonUniformAllEqual && wave_op_needs_helper_lane_masking(impl) &&
+	    impl.control_sensitive_bools.count(instruction) == 0)
 	{
 		auto *is_helper_lane = impl.allocate(spv::OpIsHelperInvocationEXT, impl.builder().makeBoolType());
 		impl.add(is_helper_lane);
@@ -181,7 +182,7 @@ bool emit_wave_ballot_instruction(Converter::Impl &impl, const llvm::CallInst *i
 
 bool emit_wave_read_lane_first_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
 {
-	if (wave_op_needs_helper_lane_masking(impl))
+	if (wave_op_needs_helper_lane_masking(impl) && impl.wave_op_forced_helper_lanes.count(instruction) == 0)
 	{
 		auto *is_helper_lane = impl.allocate(spv::OpIsHelperInvocationEXT, impl.builder().makeBoolType());
 		impl.add(is_helper_lane);

--- a/opcodes/opcodes_llvm_builtins.hpp
+++ b/opcodes/opcodes_llvm_builtins.hpp
@@ -49,6 +49,8 @@ bool analyze_store_instruction(Converter::Impl &impl, const llvm::StoreInst *ins
 bool analyze_phi_instruction(Converter::Impl &impl, const llvm::PHINode *instruction);
 bool analyze_getelementptr_instruction(Converter::Impl &impl, const llvm::GetElementPtrInst *instruction);
 bool analyze_extractvalue_instruction(Converter::Impl &impl, const llvm::ExtractValueInst *instruction);
+bool analyze_compare_instruction(Converter::Impl &impl, const llvm::CmpInst *instruction);
+bool analyze_branch_instruction(Converter::Impl &impl, const llvm::BranchInst *instruction);
 
 bool emit_llvm_instruction(Converter::Impl &impl, const llvm::Instruction &instruction);
 

--- a/reference/shaders/dxil-builtin/wave-all-equal.frag
+++ b/reference/shaders/dxil-builtin/wave-all-equal.frag
@@ -6,22 +6,6 @@ layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _8;
 layout(location = 0) flat in uint INDEX;
 bool discard_state;
 
-bool _28;
-
-bool WaveActiveAllEqual(uint _21, bool _22)
-{
-    bool _31;
-    if (_22)
-    {
-        _31 = _28;
-    }
-    else
-    {
-        _31 = subgroupAllEqual(_21);
-    }
-    return _31;
-}
-
 void discard_exit()
 {
     if (discard_state)
@@ -37,7 +21,7 @@ void main()
     {
         discard_state = true;
     }
-    if (WaveActiveAllEqual(INDEX, gl_HelperInvocation || discard_state))
+    if (subgroupAllEqual(INDEX))
     {
         imageStore(_8, int(INDEX), uvec4(1u));
     }
@@ -50,25 +34,24 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 57
+; Bound: 45
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
 OpCapability GroupNonUniformVote
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %3 "main" %10 %46
+OpEntryPoint Fragment %3 "main" %10 %34
 OpExecutionMode %3 OriginUpperLeft
 OpName %3 "main"
 OpName %10 "INDEX"
 OpName %17 "discard_state"
-OpName %23 "WaveActiveAllEqual"
-OpName %49 "discard_exit"
+OpName %37 "discard_exit"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %8 NonReadable
 OpDecorate %10 Flat
 OpDecorate %10 Location 0
-OpDecorate %46 BuiltIn HelperInvocation
+OpDecorate %34 BuiltIn HelperInvocation
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -82,67 +65,50 @@ OpDecorate %46 BuiltIn HelperInvocation
 %16 = OpTypePointer Private %13
 %17 = OpVariable %16 Private
 %18 = OpConstantFalse %13
-%20 = OpTypeFunction %13 %5 %13
-%30 = OpConstant %5 3
-%35 = OpConstant %5 2
-%36 = OpConstant %5 1
-%37 = OpTypeVector %5 4
-%44 = OpConstantTrue %13
-%45 = OpTypePointer Input %13
-%46 = OpVariable %45 Input
+%20 = OpConstant %5 3
+%23 = OpConstant %5 2
+%24 = OpConstant %5 1
+%25 = OpTypeVector %5 4
+%32 = OpConstantTrue %13
+%33 = OpTypePointer Input %13
+%34 = OpVariable %33 Input
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 OpStore %17 %18
-OpBranch %39
-%39 = OpLabel
+OpBranch %27
+%27 = OpLabel
 %11 = OpLoad %6 %8
 %12 = OpLoad %5 %10
 %14 = OpIEqual %13 %12 %15
-OpSelectionMerge %41 None
-OpBranchConditional %14 %40 %41
-%40 = OpLabel
-OpStore %17 %44
-OpBranch %41
-%41 = OpLabel
-%47 = OpLoad %13 %46
-%48 = OpLoad %13 %17
-%19 = OpLogicalOr %13 %47 %48
-%33 = OpFunctionCall %13 %23 %12 %19
-OpSelectionMerge %43 None
-OpBranchConditional %33 %42 %43
-%42 = OpLabel
-%34 = OpShiftLeftLogical %5 %12 %35
-%38 = OpCompositeConstruct %37 %36 %36 %36 %36
-OpImageWrite %11 %12 %38
-OpBranch %43
-%43 = OpLabel
-%55 = OpFunctionCall %1 %49
+OpSelectionMerge %29 None
+OpBranchConditional %14 %28 %29
+%28 = OpLabel
+OpStore %17 %32
+OpBranch %29
+%29 = OpLabel
+%35 = OpLoad %13 %34
+%36 = OpLoad %13 %17
+%21 = OpLogicalOr %13 %35 %36
+%19 = OpGroupNonUniformAllEqual %13 %20 %12
+OpSelectionMerge %31 None
+OpBranchConditional %19 %30 %31
+%30 = OpLabel
+%22 = OpShiftLeftLogical %5 %12 %23
+%26 = OpCompositeConstruct %25 %24 %24 %24 %24
+OpImageWrite %11 %12 %26
+OpBranch %31
+%31 = OpLabel
+%43 = OpFunctionCall %1 %37
 OpReturn
 OpFunctionEnd
-%23 = OpFunction %13 None %20
-%21 = OpFunctionParameter %5
-%22 = OpFunctionParameter %13
-%24 = OpLabel
-OpSelectionMerge %27 None
-OpBranchConditional %22 %25 %26
-%25 = OpLabel
-%28 = OpUndef %13
-OpBranch %27
-%26 = OpLabel
-%29 = OpGroupNonUniformAllEqual %13 %30 %21
-OpBranch %27
-%27 = OpLabel
-%31 = OpPhi %13 %29 %26 %28 %25
-OpReturnValue %31
-OpFunctionEnd
-%49 = OpFunction %1 None %2
-%50 = OpLabel
-%53 = OpLoad %13 %17
-OpSelectionMerge %52 None
-OpBranchConditional %53 %51 %52
-%51 = OpLabel
+%37 = OpFunction %1 None %2
+%38 = OpLabel
+%41 = OpLoad %13 %17
+OpSelectionMerge %40 None
+OpBranchConditional %41 %39 %40
+%39 = OpLabel
 OpKill
-%52 = OpLabel
+%40 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif


### PR DESCRIPTION
In waterfall loops, some games rely on helper lanes to participate.

Detect WaveReadFirstLane(x) == x patterns and act accordingly if that boolean is used as part of a branch instruction.