### PR TITLE
Implement AGS U64 atomics + readlane

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(dxil-converter STATIC
         opcodes/dxil/dxil_buffer.hpp opcodes/dxil/dxil_buffer.cpp
         opcodes/dxil/dxil_ray_tracing.hpp opcodes/dxil/dxil_ray_tracing.cpp
         opcodes/dxil/dxil_mesh.hpp opcodes/dxil/dxil_mesh.cpp
+        opcodes/dxil/dxil_ags.hpp
         opcodes/opcodes_llvm_builtins.hpp opcodes/opcodes_llvm_builtins.cpp
         opcodes/opcodes_dxil_builtins.hpp opcodes/opcodes_dxil_builtins.cpp)
 set_target_properties(dxil-converter PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -242,6 +242,22 @@ struct Converter::Impl
 	UnorderedMap<const llvm::Value *, spv::Id> llvm_value_actual_type;
 	UnorderedSet<uint32_t> llvm_attribute_at_vertex_indices;
 
+	struct
+	{
+		// For magic resource types, assume there is one globally declared dummy resource.
+		// Don't conflict with sentinel index for SM 6.6 heap.
+		uint32_t uav_magic_resource_type_index = UINT32_MAX - 1;
+		spv::Id magic_ptr_id = 0;
+		uint32_t active_uav_index = 0;
+		spv::Id active_uav_ptr = 0;
+		DXIL::Op active_uav_op;
+		AgsInstruction instructions[AgsInstruction::MaxPhases];
+		const llvm::CallInst *backdoor_instructions[AgsInstruction::MaxPhases];
+		unsigned phases = 0;
+	} ags;
+
+	void push_ags_instruction(const llvm::CallInst *instruction);
+
 	// DXIL has no storage class concept for hit/callable/payload types.
 	const llvm::Type *llvm_hit_attribute_output_type = nullptr;
 	spv::Id llvm_hit_attribute_output_value = 0;

--- a/opcodes/dxil/dxil_ags.hpp
+++ b/opcodes/dxil/dxil_ags.hpp
@@ -1,0 +1,279 @@
+/* Copyright (c) 2019-2022 Hans-Kristian Arntzen for Valve Corporation
+*
+* SPDX-License-Identifier: MIT
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <stdint.h>
+#include "opcodes/opcodes.hpp"
+
+namespace dxil_spv
+{
+// From https://github.com/GPUOpen-LibrariesAndSDKs/AGS_SDK/blob/master/ags_lib/hlsl/ags_shader_intrinsics_dx12.hlsl
+
+//
+// Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+static constexpr uint32_t AgsUAVMagicRegisterSpace = 2147420894;
+
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_MagicCodeShift   = 28;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_MagicCodeMask    = 0xf;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_OpcodePhaseShift = 24;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_OpcodePhaseMask  = 0x3;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_DataShift        = 8;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_DataMask         = 0xffff;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_OpcodeShift      = 0;
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_OpcodeMask       = 0xff;
+
+static constexpr uint32_t AmdExtD3DShaderIntrinsics_MagicCode        = 0x5;
+
+
+/**
+***********************************************************************************************************************
+*   Intrinsic opcodes.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Readfirstlane          = 0x01;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Readlane               = 0x02;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_LaneId                 = 0x03;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Swizzle                = 0x04;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Ballot                 = 0x05;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_MBCnt                  = 0x06;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Min3U                  = 0x07;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Min3F                  = 0x08;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Med3U                  = 0x09;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Med3F                  = 0x0a;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Max3U                  = 0x0b;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Max3F                  = 0x0c;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_BaryCoord              = 0x0d;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_VtxParam               = 0x0e;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Reserved1              = 0x0f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Reserved2              = 0x10;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_Reserved3              = 0x11;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_WaveReduce             = 0x12;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_WaveScan               = 0x13;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_LoadDwAtAddr           = 0x14;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_DrawIndex              = 0x17;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_AtomicU64              = 0x18;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_GetWaveSize            = 0x19;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_BaseInstance           = 0x1a;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_BaseVertex             = 0x1b;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_FloatConversion        = 0x1c;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_ReadlaneAt             = 0x1d;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_ShaderClock            = 0x1f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcode_ShaderRealtimeClock    = 0x20;
+
+/**
+***********************************************************************************************************************
+*   Intrinsic opcode phases.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcodePhase_0   = 0x0;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcodePhase_1   = 0x1;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcodePhase_2   = 0x2;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsOpcodePhase_3   = 0x3;
+
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsWaveOp defines for supported operations. Can be used as the parameter for the
+*   AmdExtD3DShaderIntrinsicsOpcode_WaveOp intrinsic.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_AddF = 0x01;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_AddI = 0x02;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_AddU = 0x03;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MulF = 0x04;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MulI = 0x05;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MulU = 0x06;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MinF = 0x07;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MinI = 0x08;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MinU = 0x09;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MaxF = 0x0a;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MaxI = 0x0b;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_MaxU = 0x0c;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_And  = 0x0d;    // Reduction only
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_Or   = 0x0e;    // Reduction only
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_Xor  = 0x0f;    // Reduction only
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsWaveOp masks and shifts for opcode and flags
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_OpcodeShift = 0;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_OpcodeMask  = 0xff;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_FlagShift   = 8;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_FlagMask    = 0xff;
+
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsWaveOp flags for use with AmdExtD3DShaderIntrinsicsOpcode_WaveScan.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_Inclusive  = 0x01;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsWaveOp_Exclusive  = 0x02;
+
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsSwizzle defines for common swizzles.  Can be used as the operation parameter for the
+*   AmdExtD3DShaderIntrinsics_Swizzle intrinsic.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_SwapX1     = 0x041f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_SwapX2     = 0x081f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_SwapX4     = 0x101f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_SwapX8     = 0x201f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_SwapX16    = 0x401f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_ReverseX2  = 0x041f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_ReverseX4  = 0x0c1f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_ReverseX8  = 0x1c1f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_ReverseX16 = 0x3c1f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_ReverseX32 = 0x7c1f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_BCastX2    = 0x003e;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_BCastX4    = 0x003c;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_BCastX8    = 0x0038;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_BCastX16   = 0x0030;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsSwizzle_BCastX32   = 0x0020;
+
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsBarycentric defines for barycentric interpolation mode.  To be used with
+*   AmdExtD3DShaderIntrinsicsOpcode_IjBarycentricCoords to specify the interpolation mode.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_LinearCenter   = 0x1;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_LinearCentroid = 0x2;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_LinearSample   = 0x3;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_PerspCenter    = 0x4;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_PerspCentroid  = 0x5;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_PerspSample    = 0x6;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_PerspPullModel = 0x7;
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsBarycentric defines for specifying vertex and parameter indices.  To be used as inputs to
+*   the AmdExtD3DShaderIntrinsicsOpcode_VertexParameter function
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Vertex0       = 0x0;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Vertex1       = 0x1;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Vertex2       = 0x2;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param0        = 0x00;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param1        = 0x01;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param2        = 0x02;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param3        = 0x03;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param4        = 0x04;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param5        = 0x05;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param6        = 0x06;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param7        = 0x07;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param8        = 0x08;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param9        = 0x09;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param10       = 0x0a;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param11       = 0x0b;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param12       = 0x0c;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param13       = 0x0d;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param14       = 0x0e;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param15       = 0x0f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param16       = 0x10;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param17       = 0x11;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param18       = 0x12;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param19       = 0x13;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param20       = 0x14;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param21       = 0x15;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param22       = 0x16;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param23       = 0x17;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param24       = 0x18;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param25       = 0x19;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param26       = 0x1a;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param27       = 0x1b;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param28       = 0x1c;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param29       = 0x1d;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param30       = 0x1e;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_Param31       = 0x1f;
+
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ComponentX     = 0x0;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ComponentY     = 0x1;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ComponentZ     = 0x2;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ComponentW     = 0x3;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ParamShift     = 0;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ParamMask      = 0x1f;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_VtxShift       = 0x5;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_VtxMask        = 0x3;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ComponentShift = 0x7;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsBarycentric_ComponentMask  = 0x3;
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsAtomic defines for supported operations. Can be used as the parameter for the
+*   AmdExtD3DShaderIntrinsicsOpcode_AtomicU64 intrinsic.
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_MinU64     = 0x01;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_MaxU64     = 0x02;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_AndU64     = 0x03;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_OrU64      = 0x04;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_XorU64     = 0x05;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_AddU64     = 0x06;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_XchgU64    = 0x07;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsAtomicOp_CmpXchgU64 = 0x08;
+
+/**
+***********************************************************************************************************************
+*   AmdExtD3DShaderIntrinsicsFloatConversion defines for supported rounding modes from float to float16 conversions.
+*   To be used as an input AmdExtD3DShaderIntrinsicsOpcode_FloatConversion instruction
+***********************************************************************************************************************
+*/
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsFloatConversionOp_FToF16Near    = 0x01;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsFloatConversionOp_FToF16NegInf  = 0x02;
+static constexpr uint32_t AmdExtD3DShaderIntrinsicsFloatConversionOp_FToF16PlusInf = 0x03;
+
+static inline bool is_ags_magic(uint32_t v)
+{
+	return (v >> AmdExtD3DShaderIntrinsics_MagicCodeShift) == AmdExtD3DShaderIntrinsics_MagicCode;
+}
+
+static inline AgsInstruction decode_ags_instruction(uint32_t v)
+{
+	AgsInstruction inst = {};
+
+	inst.opcode = (v >> AmdExtD3DShaderIntrinsics_OpcodeShift) & AmdExtD3DShaderIntrinsics_OpcodeMask;
+	inst.phase = (v >> AmdExtD3DShaderIntrinsics_OpcodePhaseShift) & AmdExtD3DShaderIntrinsics_OpcodePhaseMask;
+	inst.immediate = (v >> AmdExtD3DShaderIntrinsics_DataShift) & AmdExtD3DShaderIntrinsics_DataMask;
+
+	return inst;
+}
+}

--- a/opcodes/dxil/dxil_buffer.cpp
+++ b/opcodes/dxil/dxil_buffer.cpp
@@ -25,6 +25,7 @@
 #include "dxil_buffer.hpp"
 #include "dxil_common.hpp"
 #include "dxil_sampling.hpp"
+#include "dxil_ags.hpp"
 #include "logging.hpp"
 #include "opcodes/converter_impl.hpp"
 #include "spirv_module.hpp"
@@ -962,6 +963,15 @@ bool emit_buffer_store_instruction(Converter::Impl &impl, const llvm::CallInst *
 {
 	auto &builder = impl.builder();
 	spv::Id image_id = impl.get_id_for_value(instruction->getOperand(1));
+
+	// Deferred 64-bit atomic. Resolve in a later AGS atomic.
+	if (impl.ags.phases == 2 && impl.ags.backdoor_instructions[0] == instruction->getOperand(2))
+	{
+		impl.ags.active_uav_ptr = image_id;
+		impl.ags.active_uav_op = DXIL::Op::BufferStore;
+		return true;
+	}
+
 	const auto &meta = impl.handle_to_resource_meta[image_id];
 
 	if (meta.storage == spv::StorageClassPhysicalStorageBuffer)
@@ -1137,6 +1147,15 @@ bool emit_buffer_store_instruction(Converter::Impl &impl, const llvm::CallInst *
 bool emit_raw_buffer_store_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
 {
 	spv::Id ptr_id = impl.get_id_for_value(instruction->getOperand(1));
+
+	// Deferred 64-bit atomic. Resolve in a later AGS atomic.
+	if (impl.ags.phases == 2 && impl.ags.backdoor_instructions[0] == instruction->getOperand(2))
+	{
+		impl.ags.active_uav_ptr = ptr_id;
+		impl.ags.active_uav_op = DXIL::Op::BufferStore;
+		return true;
+	}
+
 	const auto &meta = impl.handle_to_resource_meta[ptr_id];
 
 	if (meta.storage != spv::StorageClassPhysicalStorageBuffer)
@@ -1301,11 +1320,173 @@ bool emit_atomic_binop_instruction(Converter::Impl &impl, const llvm::CallInst *
 	return true;
 }
 
+static bool emit_magic_ags_atomic_u64(Converter::Impl &impl, spv::Id image_id,
+                                      spv::Op atomic_opcode, const llvm::CallInst *instruction)
+{
+	auto &builder = impl.builder();
+	builder.addCapability(spv::CapabilityInt64Atomics);
+
+	const auto &meta = impl.handle_to_resource_meta[image_id];
+
+	spv::Id coords[3] = {};
+	uint32_t num_coords_full = 0, num_coords = 0;
+
+	if (meta.kind == DXIL::ResourceKind::StructuredBuffer)
+		LOGE("RWStructuredBuffer not supported for AGS u64 atomics.\n");
+	else if (meta.kind == DXIL::ResourceKind::TypedBuffer)
+		LOGE("RWBuffer not supported for AGS u64 atomics.\n");
+
+	if (meta.kind == DXIL::ResourceKind::RawBuffer)
+	{
+		// AGS header only supports BAB.
+		coords[0] = build_index_divider(impl, impl.ags.backdoor_instructions[0]->getOperand(5), 3, 1);
+		num_coords = 1;
+		num_coords_full = 1;
+	}
+	else
+	{
+		if (!get_image_dimensions(impl, image_id, &num_coords_full, &num_coords))
+			return false;
+
+		if (num_coords_full > 3)
+			return false;
+
+		// The actual coordinates are stored in the backdoor instructions.
+		for (uint32_t i = 0; i < num_coords_full; i++)
+		{
+			auto *coord_value = impl.ags.backdoor_instructions[i / 2]->getOperand(5 + (i & 1));
+			coords[i] = impl.get_id_for_value(coord_value);
+		}
+	}
+
+	spv::Id coord = impl.build_vector(builder.makeUintType(32), coords, num_coords_full);
+
+	DXIL::ComponentType component_type;
+	spv::Id counter_ptr_id = emit_atomic_access_chain(impl, meta, RawWidth::B64, image_id, coord, component_type);
+
+	spv::Id u32s[2];
+	u32s[0] = impl.get_id_for_value(impl.ags.backdoor_instructions[1]->getOperand(6));
+	u32s[1] = impl.get_id_for_value(impl.ags.backdoor_instructions[2]->getOperand(5));
+	spv::Id u32_vec = impl.build_vector(builder.makeUintType(32), u32s, 2);
+
+	auto *bitcast_op = impl.allocate(spv::OpBitcast, impl.get_type_id(DXIL::ComponentType::U64, 1, 1));
+	bitcast_op->add_id(u32_vec);
+	impl.add(bitcast_op);
+
+	auto *atomic_op = impl.allocate(atomic_opcode, impl.get_type_id(DXIL::ComponentType::U64, 1, 1));
+
+	atomic_op->add_id(counter_ptr_id);
+	atomic_op->add_id(builder.makeUintConstant(spv::ScopeDevice));
+	atomic_op->add_id(builder.makeUintConstant(0));
+	atomic_op->add_id(bitcast_op->id);
+	impl.add(atomic_op);
+
+	bitcast_op = impl.allocate(spv::OpBitcast, impl.get_type_id(DXIL::ComponentType::U32, 1, 2));
+	bitcast_op->add_id(atomic_op->id);
+	impl.add(bitcast_op);
+
+	for (unsigned i = 0; i < 2; i++)
+	{
+		auto *extract_op = impl.allocate(spv::OpCompositeExtract, impl.get_type_id(DXIL::ComponentType::U32, 1, 1));
+		extract_op->add_id(bitcast_op->id);
+		extract_op->add_literal(i);
+		impl.add(extract_op);
+		u32s[i] = extract_op->id;
+	}
+
+	// The backdoor instructions end up with the final result.
+	impl.rewrite_value(impl.ags.backdoor_instructions[0], u32s[0]);
+	impl.rewrite_value(impl.ags.backdoor_instructions[2], u32s[1]);
+	impl.rewrite_value(instruction, u32s[1]);
+	return true;
+}
+
+static bool emit_magic_ags_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
+{
+	impl.push_ags_instruction(instruction);
+
+	// We might be able to retire an instruction now.
+	// Only support exactly what we need to support. Anything else will fail compilation.
+	if (impl.ags.phases == 0)
+		return true;
+
+	switch (impl.ags.instructions[0].opcode)
+	{
+	case AmdExtD3DShaderIntrinsicsOpcode_AtomicU64:
+	{
+		if (impl.ags.active_uav_op != DXIL::Op::TextureStore || impl.ags.active_uav_ptr == 0)
+		{
+			LOGE("Attempting to use U64 atomics on non-textures. This is unsupported.\n");
+			return false;
+		}
+
+		spv::Op atomic_op = spv::OpNop;
+		if (impl.ags.phases == 3)
+		{
+			switch (impl.ags.instructions[0].immediate)
+			{
+			case AmdExtD3DShaderIntrinsicsAtomicOp_MaxU64:
+				atomic_op = spv::OpAtomicUMax;
+				break;
+			case AmdExtD3DShaderIntrinsicsAtomicOp_MinU64:
+				atomic_op = spv::OpAtomicUMin;
+				break;
+			case AmdExtD3DShaderIntrinsicsAtomicOp_AddU64:
+				atomic_op = spv::OpAtomicIAdd;
+				break;
+			case AmdExtD3DShaderIntrinsicsAtomicOp_XorU64:
+				atomic_op = spv::OpAtomicXor;
+				break;
+			case AmdExtD3DShaderIntrinsicsAtomicOp_OrU64:
+				atomic_op = spv::OpAtomicOr;
+				break;
+			case AmdExtD3DShaderIntrinsicsAtomicOp_AndU64:
+				atomic_op = spv::OpAtomicAnd;
+				break;
+			case AmdExtD3DShaderIntrinsicsAtomicOp_XchgU64:
+				atomic_op = spv::OpAtomicExchange;
+				break;
+			default:
+				// CmpXchg isn't hard to support, just need to modify the impl a bit, but only care if we have to.
+				LOGE("Unsupported AGS AtomicU64 variant: immediate %u.\n", impl.ags.instructions[0].immediate);
+				return false;
+			}
+
+			// Magic 64-bit image atomics.
+			if ((impl.ags.active_uav_op == DXIL::Op::TextureStore ||
+			     impl.ags.active_uav_op == DXIL::Op::BufferStore) && impl.ags.active_uav_ptr)
+			{
+				return emit_magic_ags_atomic_u64(impl, impl.ags.active_uav_ptr, atomic_op, instruction);
+			}
+			else
+			{
+				LOGE("Attempting to use AGS U64 atomic on unknown resource type.\n");
+				return false;
+			}
+		}
+		break;
+	}
+
+	default:
+		LOGE("Unsupported AGS magic instruction 0x%x (immediate %u).\n",
+		     impl.ags.instructions[0].opcode,
+		     impl.ags.instructions[0].immediate);
+		return false;
+	}
+
+	return true;
+}
+
 bool emit_atomic_cmpxchg_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
 {
 	auto &builder = impl.builder();
 	spv::Id image_id = impl.get_id_for_value(instruction->getOperand(1));
+
+	if (image_id == impl.ags.magic_ptr_id)
+		return emit_magic_ags_instruction(impl, instruction);
+
 	const auto &meta = impl.handle_to_resource_meta[image_id];
+
 	spv::Id coords[3] = {};
 	uint32_t num_coords_full = 0, num_coords = 0;
 

--- a/opcodes/dxil/dxil_resources.cpp
+++ b/opcodes/dxil/dxil_resources.cpp
@@ -1094,6 +1094,19 @@ static bool emit_create_handle(Converter::Impl &impl, const llvm::CallInst *inst
 
 	case DXIL::ResourceType::UAV:
 	{
+		if (resource_range == impl.ags.uav_magic_resource_type_index)
+		{
+			// Resources tied to constant uints are considered "magic".
+			if (impl.ags.magic_ptr_id == 0)
+			{
+				spv::Id dummy_value = impl.spirv_module.allocate_id();
+				impl.ags.magic_ptr_id = dummy_value;
+			}
+
+			impl.rewrite_value(instruction, impl.ags.magic_ptr_id);
+			break;
+		}
+
 		auto &reference = get_resource_reference(impl, resource_type, instruction, resource_range);
 
 		if (resource_is_physical_pointer(impl, reference))

--- a/opcodes/dxil/dxil_sampling.cpp
+++ b/opcodes/dxil/dxil_sampling.cpp
@@ -716,6 +716,15 @@ bool emit_texture_store_instruction_dispatch(Converter::Impl &impl, const llvm::
 	auto &builder = impl.builder();
 
 	spv::Id image_id = impl.get_id_for_value(instruction->getOperand(1));
+
+	// Deferred 64-bit atomic. Resolve in a later AGS atomic.
+	if (impl.ags.phases == 2 && impl.ags.backdoor_instructions[0] == instruction->getOperand(2) && !multi_sampled)
+	{
+		impl.ags.active_uav_ptr = image_id;
+		impl.ags.active_uav_op = DXIL::Op::TextureStore;
+		return true;
+	}
+
 	const auto &meta = impl.handle_to_resource_meta[image_id];
 	spv::Id coord[3] = {};
 

--- a/opcodes/opcodes.hpp
+++ b/opcodes/opcodes.hpp
@@ -44,4 +44,18 @@ namespace dxil_spv
 enum class RawType { Integer, Float, Count };
 enum class RawWidth { B16 = 0, B32, B64, Count };
 enum class RawVecSize { V1 = 0, V2, V3, V4, Count };
+
+enum class MagicResource : uint8_t
+{
+	None,
+	AGS
+};
+
+struct AgsInstruction
+{
+	enum { MaxPhases = 4 };
+	uint32_t opcode;
+	uint32_t phase;
+	uint32_t immediate;
+};
 }

--- a/reference/shaders/control-flow/dual-inner-loop-early-return.comp
+++ b/reference/shaders/control-flow/dual-inner-loop-early-return.comp
@@ -1,9 +1,9 @@
 #version 460
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _8;
-
 uint _50;
+
+layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _8;
 
 void main()
 {

--- a/reference/shaders/control-flow/inner-loop-early-return.comp
+++ b/reference/shaders/control-flow/inner-loop-early-return.comp
@@ -1,9 +1,9 @@
 #version 460
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _8;
-
 uint _41;
+
+layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _8;
 
 void main()
 {

--- a/reference/shaders/control-flow/interleaved-unrolled-loop-breaks.comp
+++ b/reference/shaders/control-flow/interleaved-unrolled-loop-breaks.comp
@@ -1,8 +1,6 @@
 #version 460
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0, r32ui) uniform uimageBuffer _8;
-
 uint _75;
 uint _77;
 uint _78;
@@ -28,6 +26,8 @@ uint _99;
 uint _100;
 uint _101;
 uint _102;
+
+layout(set = 0, binding = 0, r32ui) uniform uimageBuffer _8;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/buffer-load-feedback.frag
+++ b/reference/shaders/dxil-builtin/buffer-load-feedback.frag
@@ -25,14 +25,6 @@ struct _82
     uint _m4;
 };
 
-layout(set = 0, binding = 1) uniform usamplerBuffer _8;
-layout(set = 0, binding = 2) uniform usamplerBuffer _9;
-layout(set = 0, binding = 1, r32ui) uniform readonly uimageBuffer _12;
-layout(set = 0, binding = 2, r32ui) uniform readonly uimageBuffer _13;
-
-layout(location = 0) flat in uint TEXCOORD;
-layout(location = 0) out vec2 SV_Target;
-
 uint _40;
 uint _41;
 uint _62;
@@ -41,6 +33,14 @@ float _86;
 float _87;
 float _107;
 float _108;
+
+layout(set = 0, binding = 1) uniform usamplerBuffer _8;
+layout(set = 0, binding = 2) uniform usamplerBuffer _9;
+layout(set = 0, binding = 1, r32ui) uniform readonly uimageBuffer _12;
+layout(set = 0, binding = 2, r32ui) uniform readonly uimageBuffer _13;
+
+layout(location = 0) flat in uint TEXCOORD;
+layout(location = 0) out vec2 SV_Target;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/buffer-load.frag
+++ b/reference/shaders/dxil-builtin/buffer-load.frag
@@ -1,5 +1,8 @@
 #version 460
 
+uint _104;
+uint _121;
+
 layout(set = 0, binding = 0) uniform samplerBuffer _8;
 layout(set = 0, binding = 1) uniform usamplerBuffer _12;
 layout(set = 0, binding = 2) uniform usamplerBuffer _13;
@@ -11,9 +14,6 @@ layout(set = 0, binding = 3, r32ui) uniform readonly uimageBuffer _22;
 
 layout(location = 0) flat in uint TEXCOORD;
 layout(location = 0) out vec2 SV_Target;
-
-uint _104;
-uint _121;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/get-dimensions.bindless.root-constant.frag
+++ b/reference/shaders/dxil-builtin/get-dimensions.bindless.root-constant.frag
@@ -3,6 +3,8 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_samplerless_texture_functions : require
 
+uint _61;
+
 layout(push_constant, std430) uniform RootConstants
 {
     uint _m0;
@@ -35,8 +37,6 @@ layout(set = 4, binding = 0, r32ui) uniform readonly writeonly uimageBuffer _39[
 layout(location = 0) flat in uint LEVEL;
 layout(location = 0, component = 1) flat in uint INDEX;
 layout(location = 0) out uint SV_Target;
-
-uint _61;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/get-dimensions.bindless.root-constant.ssbo.frag
+++ b/reference/shaders/dxil-builtin/get-dimensions.bindless.root-constant.ssbo.frag
@@ -3,6 +3,8 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_samplerless_texture_functions : require
 
+uint _67;
+
 layout(set = 1, binding = 0, std430) restrict readonly buffer SSBO
 {
     uint _m0[];
@@ -51,8 +53,6 @@ layout(set = 4, binding = 0) uniform readonly writeonly imageBuffer _35[];
 layout(location = 0) flat in uint LEVEL;
 layout(location = 0, component = 1) flat in uint INDEX;
 layout(location = 0) out uint SV_Target;
-
-uint _67;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/get-dimensions.frag
+++ b/reference/shaders/dxil-builtin/get-dimensions.frag
@@ -1,6 +1,13 @@
 #version 460
 #extension GL_EXT_samplerless_texture_functions : require
 
+uint _92;
+uint _93;
+uint _100;
+uint _107;
+uint _122;
+uint _143;
+
 layout(set = 0, binding = 0) uniform texture1D _8;
 layout(set = 0, binding = 1) uniform texture1DArray _11;
 layout(set = 0, binding = 2) uniform texture2D _14;
@@ -24,13 +31,6 @@ layout(set = 0, binding = 11, r32ui) uniform readonly writeonly uimageBuffer _62
 
 layout(location = 0) flat in uint LEVEL;
 layout(location = 0) out uint SV_Target;
-
-uint _92;
-uint _93;
-uint _100;
-uint _107;
-uint _122;
-uint _143;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/object-ray-direction.rany
+++ b/reference/shaders/dxil-builtin/object-ray-direction.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _22;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _22;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/object-ray-origin.rany
+++ b/reference/shaders/dxil-builtin/object-ray-origin.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _22;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _22;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/object-to-world-3x4.rany
+++ b/reference/shaders/dxil-builtin/object-to-world-3x4.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _59;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _59;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/object-to-world-4x3.rany
+++ b/reference/shaders/dxil-builtin/object-to-world-4x3.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _59;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _59;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/ray-t-current.rany
+++ b/reference/shaders/dxil-builtin/ray-t-current.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _18;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _18;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/ray-t-min.rany
+++ b/reference/shaders/dxil-builtin/ray-t-min.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _18;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _18;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/wave-match.frag
+++ b/reference/shaders/dxil-builtin/wave-match.frag
@@ -1,13 +1,13 @@
 #version 460
 #extension GL_KHR_shader_subgroup_ballot : require
 
+uvec4 _36;
+
 layout(set = 0, binding = 0) uniform usamplerBuffer _8;
 layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _11;
 
 layout(location = 0) flat in uint THR;
 bool discard_state;
-
-uvec4 _36;
 
 uvec4 WaveMatch(uint _27, bool _28)
 {

--- a/reference/shaders/dxil-builtin/wave-multi-prefix-count-bits.frag
+++ b/reference/shaders/dxil-builtin/wave-multi-prefix-count-bits.frag
@@ -1,14 +1,14 @@
 #version 460
 #extension GL_KHR_shader_subgroup_ballot : require
 
+uint _63;
+
 layout(set = 0, binding = 0) uniform usamplerBuffer _8;
 layout(set = 0, binding = 1) uniform usamplerBuffer _9;
 layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _12;
 
 layout(location = 0) flat in uint THR;
 bool discard_state;
-
-uint _63;
 
 uint WaveMultiPrefixCountBits(bool _53, uvec4 _54, bool _55)
 {

--- a/reference/shaders/dxil-builtin/wave-multi-prefix-op.comp
+++ b/reference/shaders/dxil-builtin/wave-multi-prefix-op.comp
@@ -3,10 +3,6 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) uniform usamplerBuffer _8;
-layout(set = 0, binding = 1) uniform usamplerBuffer _9;
-layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _12;
-
 uint _54;
 float _101;
 uint _145;
@@ -14,6 +10,10 @@ float _189;
 uint _233;
 uint _278;
 uint _324;
+
+layout(set = 0, binding = 0) uniform usamplerBuffer _8;
+layout(set = 0, binding = 1) uniform usamplerBuffer _9;
+layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _12;
 
 uint WaveMultiPrefixSum(uint _50, uvec4 _51)
 {

--- a/reference/shaders/dxil-builtin/wave-multi-prefix-op.frag
+++ b/reference/shaders/dxil-builtin/wave-multi-prefix-op.frag
@@ -2,12 +2,6 @@
 #extension GL_KHR_shader_subgroup_ballot : require
 #extension GL_KHR_shader_subgroup_arithmetic : require
 
-layout(set = 0, binding = 0) uniform usamplerBuffer _8;
-layout(set = 0, binding = 1) uniform usamplerBuffer _9;
-layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _12;
-
-layout(location = 0) flat in uint THR;
-
 uint _50;
 float _97;
 uint _141;
@@ -15,6 +9,12 @@ float _185;
 uint _229;
 uint _274;
 uint _320;
+
+layout(set = 0, binding = 0) uniform usamplerBuffer _8;
+layout(set = 0, binding = 1) uniform usamplerBuffer _9;
+layout(set = 0, binding = 0, r32ui) uniform writeonly uimageBuffer _12;
+
+layout(location = 0) flat in uint THR;
 
 uint WaveMultiPrefixSum(uint _46, uvec4 _47)
 {

--- a/reference/shaders/dxil-builtin/world-ray-direction.rany
+++ b/reference/shaders/dxil-builtin/world-ray-direction.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _22;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _22;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/world-ray-origin.rany
+++ b/reference/shaders/dxil-builtin/world-ray-origin.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _22;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _22;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/world-to-object-3x4.rany
+++ b/reference/shaders/dxil-builtin/world-to-object-3x4.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _59;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _59;
 
 void main()
 {

--- a/reference/shaders/dxil-builtin/world-to-object-4x3.rany
+++ b/reference/shaders/dxil-builtin/world-to-object-4x3.rany
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec3 _59;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec3 _59;
 
 void main()
 {

--- a/reference/shaders/opts/wave-read-lane-first.bindless.local-root-signature.rmiss
+++ b/reference/shaders/opts/wave-read-lane-first.bindless.local-root-signature.rmiss
@@ -10,6 +10,8 @@ struct _25
     uint _m1;
 };
 
+vec4 _89;
+
 layout(shaderRecordEXT, std430) buffer SBTBlock
 {
     uint _m0[5];
@@ -43,8 +45,6 @@ layout(push_constant, std430) uniform RootConstants
 } registers;
 
 layout(location = 0) rayPayloadInEXT _25 payload;
-
-vec4 _89;
 
 void main()
 {

--- a/reference/shaders/resources/cbv.no-legacy-cbuf-layout.local-root-signature.rmiss
+++ b/reference/shaders/resources/cbv.no-legacy-cbuf-layout.local-root-signature.rmiss
@@ -8,6 +8,9 @@ struct _17
     uvec4 _m1;
 };
 
+vec4 _38;
+uvec4 _54;
+
 layout(shaderRecordEXT, std430) buffer SBTBlock
 {
     uint _m0[5];
@@ -24,9 +27,6 @@ layout(shaderRecordEXT, std430) buffer SBTBlock
 } SBT;
 
 layout(location = 0) rayPayloadInEXT _17 payload;
-
-vec4 _38;
-uvec4 _54;
 
 void main()
 {

--- a/reference/shaders/resources/root-bda.root-descriptor.comp
+++ b/reference/shaders/resources/root-bda.root-descriptor.comp
@@ -12,6 +12,9 @@
 #extension GL_EXT_buffer_reference_uvec2 : require
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+float16_t _72;
+uint _112;
+
 layout(buffer_reference) buffer PhysicalPointerFloat4NonWriteArray;
 layout(buffer_reference) buffer PhysicalPointerFloat4NonWriteCBVArray;
 layout(buffer_reference) buffer PhysicalPointerFloat4CoherentArray;
@@ -67,9 +70,6 @@ layout(push_constant, std430) uniform RootConstants
     uvec2 _m2;
     uvec2 _m3;
 } registers;
-
-float16_t _72;
-uint _112;
 
 void main()
 {

--- a/reference/shaders/resources/rt-resources.bindless.local-root-signature.rmiss
+++ b/reference/shaders/resources/rt-resources.bindless.local-root-signature.rmiss
@@ -12,6 +12,9 @@ struct _37
     uint _m1;
 };
 
+vec4 _372;
+float _378;
+
 layout(buffer_reference) buffer PhysicalPointerFloat4NonWriteCBVArray;
 layout(buffer_reference) buffer PhysicalPointerFloat4NonWriteArray;
 layout(buffer_reference) buffer PhysicalPointerUintNonWriteArray;
@@ -96,9 +99,6 @@ layout(set = 0, binding = 0) uniform texture2D _21[];
 layout(set = 3, binding = 0, r32f) uniform readonly image2D _25[];
 layout(set = 2, binding = 0) uniform sampler _36[];
 layout(location = 0) rayPayloadInEXT _37 payload;
-
-vec4 _372;
-float _378;
 
 void main()
 {

--- a/reference/shaders/resources/rt-resources.bindless.rmiss
+++ b/reference/shaders/resources/rt-resources.bindless.rmiss
@@ -10,6 +10,8 @@ struct _15
     uint _m1;
 };
 
+vec4 _73;
+
 layout(push_constant, std430) uniform RootConstants
 {
     uint _m0;
@@ -24,8 +26,6 @@ layout(push_constant, std430) uniform RootConstants
 
 layout(set = 0, binding = 0) uniform texture2D _13[];
 layout(location = 0) rayPayloadInEXT _15 payload;
-
-vec4 _73;
 
 void main()
 {

--- a/reference/shaders/resources/rt-resources.rmiss
+++ b/reference/shaders/resources/rt-resources.rmiss
@@ -9,11 +9,11 @@ struct _16
     uint _m1;
 };
 
+vec4 _50;
+
 layout(set = 0, binding = 0) uniform texture2D Tex[2];
 layout(set = 1, binding = 0) uniform texture2D TexUnsized[];
 layout(location = 0) rayPayloadInEXT _16 payload;
-
-vec4 _50;
 
 void main()
 {

--- a/reference/shaders/resources/sm66/atomics-component-alias.sm66.comp
+++ b/reference/shaders/resources/sm66/atomics-component-alias.sm66.comp
@@ -4,13 +4,14 @@
 #else
 #error No extension available for 64-bit integers.
 #endif
+#extension GL_EXT_shader_image_int64 : require
 #extension GL_EXT_samplerless_texture_functions : require
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
 layout(set = 0, binding = 0) uniform usamplerBuffer _8;
 layout(set = 0, binding = 1) uniform utexture2D _11;
-layout(set = 0, binding = 0) uniform imageBuffer _15;
-layout(set = 0, binding = 1) uniform image2D _18;
+layout(set = 0, binding = 0, r64ui) uniform u64imageBuffer _15;
+layout(set = 0, binding = 1, r64ui) uniform u64image2D _18;
 
 void main()
 {

--- a/reference/shaders/resources/sm66/atomics-typed-64bit-heap.sm66.comp
+++ b/reference/shaders/resources/sm66/atomics-typed-64bit-heap.sm66.comp
@@ -5,10 +5,11 @@
 #error No extension available for 64-bit integers.
 #endif
 #extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_shader_image_int64 : require
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) uniform imageBuffer _9[];
-layout(set = 0, binding = 0) uniform image2D _13[];
+layout(set = 0, binding = 0, r64ui) uniform u64imageBuffer _9[];
+layout(set = 0, binding = 0, r64ui) uniform u64image2D _13[];
 
 void main()
 {

--- a/reference/shaders/resources/sm66/atomics-typed-64bit.bindless.sm66.comp
+++ b/reference/shaders/resources/sm66/atomics-typed-64bit.bindless.sm66.comp
@@ -6,6 +6,7 @@
 #endif
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_shader_image_int64 : require
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
 layout(push_constant, std430) uniform RootConstants
@@ -20,8 +21,8 @@ layout(push_constant, std430) uniform RootConstants
     uint _m7;
 } registers;
 
-layout(set = 4, binding = 0) uniform imageBuffer _13[];
-layout(set = 3, binding = 0) uniform image2D _17[];
+layout(set = 4, binding = 0, r64ui) uniform u64imageBuffer _13[];
+layout(set = 3, binding = 0, r64ui) uniform u64image2D _17[];
 
 void main()
 {

--- a/reference/shaders/resources/sm66/atomics-typed-64bit.sm66.comp
+++ b/reference/shaders/resources/sm66/atomics-typed-64bit.sm66.comp
@@ -4,12 +4,13 @@
 #else
 #error No extension available for 64-bit integers.
 #endif
+#extension GL_EXT_shader_image_int64 : require
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) uniform imageBuffer _8;
-layout(set = 0, binding = 1) uniform imageBuffer _9;
-layout(set = 0, binding = 2) uniform image2D _12;
-layout(set = 0, binding = 3) uniform image2D _13;
+layout(set = 0, binding = 0, r64ui) uniform u64imageBuffer _8;
+layout(set = 0, binding = 1, r64ui) uniform u64imageBuffer _9;
+layout(set = 0, binding = 2, r64ui) uniform u64image2D _12;
+layout(set = 0, binding = 3, r64ui) uniform u64image2D _13;
 
 void main()
 {

--- a/reference/shaders/resources/ssbo-minprecision.sm60.ssbo.native-fp16.root-descriptor.frag
+++ b/reference/shaders/resources/ssbo-minprecision.sm60.ssbo.native-fp16.root-descriptor.frag
@@ -11,6 +11,9 @@
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference_uvec2 : require
 
+float16_t _57;
+uint16_t _73;
+
 layout(buffer_reference) buffer PhysicalPointerFloatNonWriteArray;
 layout(buffer_reference) buffer PhysicalPointerFloatArray;
 layout(buffer_reference) buffer PhysicalPointerUintArray;
@@ -44,9 +47,6 @@ layout(push_constant, std430) uniform RootConstants
 
 layout(location = 0) flat in mediump int A;
 layout(location = 0) out int SV_Target;
-
-float16_t _57;
-uint16_t _73;
 
 void main()
 {

--- a/reference/shaders/resources/ssbo-minprecision.sm60.ssbo.root-descriptor.frag
+++ b/reference/shaders/resources/ssbo-minprecision.sm60.ssbo.root-descriptor.frag
@@ -2,6 +2,8 @@
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference_uvec2 : require
 
+float _43;
+
 layout(buffer_reference) buffer PhysicalPointerFloatNonWriteArray;
 layout(buffer_reference) buffer PhysicalPointerFloatArray;
 layout(buffer_reference, buffer_reference_align = 4, std430) readonly buffer PhysicalPointerFloatNonWriteArray
@@ -24,8 +26,6 @@ layout(push_constant, std430) uniform RootConstants
 
 layout(location = 0) flat in mediump int A;
 layout(location = 0) out int SV_Target;
-
-float _43;
 
 void main()
 {

--- a/reference/shaders/stages/closesthit.rclosest
+++ b/reference/shaders/stages/closesthit.rclosest
@@ -12,10 +12,10 @@ struct _11
     vec2 _m0;
 };
 
+vec2 _20;
+
 layout(location = 0) rayPayloadInEXT _7 payload;
 hitAttributeEXT _11 hit;
-
-vec2 _20;
 
 void main()
 {

--- a/reference/shaders/stages/mesh-clip-cull.mesh
+++ b/reference/shaders/stages/mesh-clip-cull.mesh
@@ -6,9 +6,9 @@ layout(max_vertices = 24, max_primitives = 8, triangles) out;
 out gl_MeshPerVertexEXT
 {
     vec4 gl_Position;
-    float gl_ClipDistance[24];
-    float gl_CullDistance[24];
-};
+    float gl_ClipDistance[4];
+    float gl_CullDistance[4];
+} gl_MeshVerticesEXT[];
 
 struct _26
 {
@@ -26,14 +26,14 @@ void main()
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.y = _28._m0[gl_LocalInvocationIndex][1u];
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.z = _28._m0[gl_LocalInvocationIndex][2u];
     gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_Position.w = _28._m0[gl_LocalInvocationIndex][3u];
-    gl_ClipDistance[gl_LocalInvocationIndex][0u] = _28._m1[gl_LocalInvocationIndex][0u];
-    gl_ClipDistance[gl_LocalInvocationIndex][1u] = _28._m1[gl_LocalInvocationIndex][1u];
-    gl_ClipDistance[gl_LocalInvocationIndex][2u] = _28._m1[gl_LocalInvocationIndex][2u];
-    gl_ClipDistance[gl_LocalInvocationIndex][3u] = _28._m1[gl_LocalInvocationIndex][3u];
-    gl_CullDistance[gl_LocalInvocationIndex][0u] = _28._m2[gl_LocalInvocationIndex][0u];
-    gl_CullDistance[gl_LocalInvocationIndex][1u] = _28._m2[gl_LocalInvocationIndex][1u];
-    gl_CullDistance[gl_LocalInvocationIndex][2u] = _28._m2[gl_LocalInvocationIndex][2u];
-    gl_CullDistance[gl_LocalInvocationIndex][3u] = _28._m2[gl_LocalInvocationIndex][3u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[0u] = _28._m1[gl_LocalInvocationIndex][0u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[1u] = _28._m1[gl_LocalInvocationIndex][1u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[2u] = _28._m1[gl_LocalInvocationIndex][2u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_ClipDistance[3u] = _28._m1[gl_LocalInvocationIndex][3u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[0u] = _28._m2[gl_LocalInvocationIndex][0u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[1u] = _28._m2[gl_LocalInvocationIndex][1u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[2u] = _28._m2[gl_LocalInvocationIndex][2u];
+    gl_MeshVerticesEXT[gl_LocalInvocationIndex].gl_CullDistance[3u] = _28._m2[gl_LocalInvocationIndex][3u];
     if (gl_LocalInvocationIndex < 8u)
     {
         uint _73 = gl_LocalInvocationIndex * 3u;


### PR DESCRIPTION
- Required by Mortal Kombat 1 for some silly reason even when AGS init fails ...
- Also hit by F1 2021 it seems which uses readlane ...