### PR TITLE
Do not emit MinLod when zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@
 /cmake-build-release
 *.iml
 /.idea
+/.vs
+/.vscode
 /external/dxc*
 /external/DirectXShaderCompiler
 /external/llvm
 /shaders-dxil
 /reference/shaders-dxil
+/build
+/out/build

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Standard CMake build.
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make
-make install
+cmake --build . --config Release
 ```
 
 ## Linking against dxil-spirv


### PR DESCRIPTION
# Context

The DirectX compiler seems to use zero as a default value when emitting sample instructions. Before now, `dxil-spirv` would pass along this zero value to the resulting SPIR-V. Then, `SPIRV-Cross` reported an error that MinLod is not supported for HLSL.

# Approach

When deciding whether or not to emit the MinLod argument, I check if the value is a floating point constant and if that constant is zero.

I used `convertToFloat`. Should I have used `convertToDouble` instead()?

# Notes

I also updated the build instructions and added some lines to the git ignore file.