### PR TITLE
vectorize emulated fp16 -> fp8 conversion

### DIFF
--- a/reference/shaders/ags/cs_wmma_copy_transpose_fp16.sm66.ssbo.comp
+++ b/reference/shaders/ags/cs_wmma_copy_transpose_fp16.sm66.ssbo.comp
@@ -63,12 +63,12 @@ coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> CoopMatFP16toFP8(coo
     {
         uint _96 = _95 + 1u;
         int16_t _99 = float16BitsToInt16(_87[_95]);
-        int16_t _108 = (_99 << int16_t(1us)) - 16384s;
-        int16_t _112 = (_108 >> 11s) - 1s;
-        int16_t _124 = (_108 & ((_112 & (-2048s)) ^ (-1s))) | (_112 & 2048s);
-        i8vec2 _131 = unpack8(_124 >> max((-_112), 0s));
-        int8_t _134 = _131.y;
-        coop_output[_95] = ((uint8_t(_134) + ((uint8_t((_134 & int8_t(1)) | (_131.x | int8_t(_124 & 127s))) > uint8_t(128)) ? uint8_t(1) : uint8_t(0))) & uint8_t(127)) | (unpack8(_99).y & uint8_t(128));
+        int16_t _107 = (_99 << int16_t(1us)) - 16384s;
+        int16_t _111 = (_107 >> 11s) - 1s;
+        int16_t _123 = (_107 & ((_111 & (-2048s)) ^ (-1s))) | (_111 & 2048s);
+        int16_t _126 = _123 >> max((-_111), 0s);
+        int16_t _128 = int16_t(uint16_t(_126) >> uint16_t(8s));
+        coop_output[_95] = uint8_t(((_128 + int16_t(uint16_t(((_128 & 1s) | (_126 | (_123 & 127s))) << 8s) > 32768us)) & 127s) | (int16_t(uint16_t(_99) >> 15us) << 7s));
         if (_96 < uint(coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB>(0).length()))
         {
             _95 = _96;
@@ -113,17 +113,17 @@ void main()
     subgroupBarrier();
     coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _80;
     coopMatLoad(_80, LDSTransposeScratch, _78, 16u, gl_CooperativeMatrixLayoutColumnMajor);
-    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _151 = _80;
-    coopMatStore(CoopMatFP16toFP8(_151), _25._m0, 1024u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
-    uint _154 = gl_SubgroupID * 256u;
+    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _145 = _80;
+    coopMatStore(CoopMatFP16toFP8(_145), _25._m0, 1024u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    uint _148 = gl_SubgroupID * 256u;
     subgroupMemoryBarrierShared();
     subgroupBarrier();
-    coopMatStore(_80, LDSTransposeScratch, _154, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopMatStore(_80, LDSTransposeScratch, _148, 16u, gl_CooperativeMatrixLayoutColumnMajor);
     subgroupMemoryBarrierShared();
     subgroupBarrier();
-    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _156;
-    coopMatLoad(_156, LDSTransposeScratch, _154, 16u, gl_CooperativeMatrixLayoutColumnMajor);
-    coopMatStore(coopmat<float, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(_156), _25._m0, 2048u, 64u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _150;
+    coopMatLoad(_150, LDSTransposeScratch, _148, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopMatStore(coopmat<float, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(_150), _25._m0, 2048u, 64u, gl_CooperativeMatrixLayoutColumnMajor);
 }
 
 
@@ -133,7 +133,7 @@ void main()
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 162
+; Bound: 156
 ; Schema: 0
 OpCapability Shader
 OpCapability Float16
@@ -220,32 +220,28 @@ OpDecorate %36 BuiltIn SubgroupId
 %85 = OpTypePointer Function %10
 %86 = OpTypeFunction %83 %85
 %90 = OpTypePointer Function %83
-%100 = OpTypeVector %17 2
-%104 = OpConstant %17 128
-%106 = OpTypeInt 16 0
-%107 = OpConstant %106 1
-%109 = OpConstant %84 16384
-%111 = OpConstant %84 11
-%113 = OpConstant %84 1
-%116 = OpConstant %84 0
-%118 = OpConstant %84 2048
-%120 = OpConstant %84 -2048
-%122 = OpConstant %84 -1
-%126 = OpConstant %84 127
-%127 = OpTypeInt 8 1
-%130 = OpTypeVector %127 2
-%136 = OpConstant %127 1
-%140 = OpConstant %17 1
-%141 = OpConstant %17 0
-%144 = OpConstant %17 127
-%146 = OpTypePointer Function %17
-%159 = OpConstant %2 2048
+%101 = OpTypeInt 16 0
+%102 = OpConstant %101 15
+%104 = OpConstant %84 7
+%106 = OpConstant %101 1
+%108 = OpConstant %84 16384
+%110 = OpConstant %84 11
+%112 = OpConstant %84 1
+%115 = OpConstant %84 0
+%117 = OpConstant %84 2048
+%119 = OpConstant %84 -2048
+%121 = OpConstant %84 -1
+%125 = OpConstant %84 127
+%129 = OpConstant %84 8
+%134 = OpConstant %101 32768
+%140 = OpTypePointer Function %17
+%153 = OpConstant %2 2048
 %15 = OpFunction %13 None %14
 %16 = OpLabel
 %75 = OpVariable %53 Function
-%151 = OpVariable %85 Function
-OpBranch %160
-%160 = OpLabel
+%145 = OpVariable %85 Function
+OpBranch %154
+%154 = OpLabel
 %28 = OpAccessChain %27 %21 %7 %7
 %30 = OpCooperativeMatrixLoadKHR %5 %28 %9 %29 NonPrivatePointer
 %37 = OpLoad %2 %36
@@ -277,19 +273,19 @@ OpCooperativeMatrixStoreKHR %79 %76 %9 %4 NonPrivatePointer
 OpControlBarrier %6 %6 %41
 %80 = OpCooperativeMatrixLoadKHR %10 %79 %9 %4 NonPrivatePointer
 %81 = OpAccessChain %27 %25 %7 %82
-OpStore %151 %80
-%152 = OpFunctionCall %83 %88 %151
-OpCooperativeMatrixStoreKHR %81 %152 %9 %4 NonPrivatePointer
-%153 = OpLoad %2 %36
-%154 = OpIMul %2 %153 %31
-%155 = OpInBoundsAccessChain %39 %34 %154
+OpStore %145 %80
+%146 = OpFunctionCall %83 %88 %145
+OpCooperativeMatrixStoreKHR %81 %146 %9 %4 NonPrivatePointer
+%147 = OpLoad %2 %36
+%148 = OpIMul %2 %147 %31
+%149 = OpInBoundsAccessChain %39 %34 %148
 OpControlBarrier %6 %6 %41
-OpCooperativeMatrixStoreKHR %155 %80 %9 %4 NonPrivatePointer
+OpCooperativeMatrixStoreKHR %149 %80 %9 %4 NonPrivatePointer
 OpControlBarrier %6 %6 %41
-%156 = OpCooperativeMatrixLoadKHR %5 %155 %9 %4 NonPrivatePointer
-%157 = OpFConvert %12 %156
-%158 = OpAccessChain %27 %25 %7 %159
-OpCooperativeMatrixStoreKHR %158 %157 %9 %50 NonPrivatePointer
+%150 = OpCooperativeMatrixLoadKHR %5 %149 %9 %4 NonPrivatePointer
+%151 = OpFConvert %12 %150
+%152 = OpAccessChain %27 %25 %7 %153
+OpCooperativeMatrixStoreKHR %152 %151 %9 %50 NonPrivatePointer
 OpReturn
 OpFunctionEnd
 %56 = OpFunction %5 None %54
@@ -325,41 +321,39 @@ OpBranch %93
 %97 = OpInBoundsAccessChain %64 %87 %95
 %98 = OpLoad %1 %97
 %99 = OpBitcast %84 %98
-%101 = OpBitcast %100 %99
-%102 = OpCompositeExtract %17 %101 1
-%103 = OpBitwiseAnd %17 %102 %104
-%105 = OpShiftLeftLogical %84 %99 %107
-%108 = OpISub %84 %105 %109
-%110 = OpShiftRightArithmetic %84 %108 %111
-%112 = OpISub %84 %110 %113
-%114 = OpSNegate %84 %112
-%115 = OpExtInst %84 %67 SMax %114 %116
-%117 = OpBitwiseAnd %84 %112 %118
-%119 = OpBitwiseAnd %84 %112 %120
-%121 = OpBitwiseXor %84 %119 %122
-%123 = OpBitwiseAnd %84 %108 %121
-%124 = OpBitwiseOr %84 %123 %117
-%125 = OpBitwiseAnd %84 %124 %126
-%128 = OpSConvert %127 %125
-%129 = OpShiftRightArithmetic %84 %124 %115
-%131 = OpBitcast %130 %129
-%132 = OpCompositeExtract %127 %131 0
-%133 = OpBitwiseOr %127 %132 %128
-%134 = OpCompositeExtract %127 %131 1
-%135 = OpBitwiseAnd %127 %134 %136
-%137 = OpBitwiseOr %127 %135 %133
-%138 = OpUGreaterThan %52 %137 %104
-%139 = OpSelect %17 %138 %140 %141
-%142 = OpIAdd %17 %134 %139
-%143 = OpBitwiseAnd %17 %142 %144
-%145 = OpBitwiseOr %17 %143 %103
-%147 = OpInBoundsAccessChain %146 %91 %95
-OpStore %147 %145
-%148 = OpULessThan %52 %96 %92
+%100 = OpShiftRightLogical %84 %99 %102
+%103 = OpShiftLeftLogical %84 %100 %104
+%105 = OpShiftLeftLogical %84 %99 %106
+%107 = OpISub %84 %105 %108
+%109 = OpShiftRightArithmetic %84 %107 %110
+%111 = OpISub %84 %109 %112
+%113 = OpSNegate %84 %111
+%114 = OpExtInst %84 %67 SMax %113 %115
+%116 = OpBitwiseAnd %84 %111 %117
+%118 = OpBitwiseAnd %84 %111 %119
+%120 = OpBitwiseXor %84 %118 %121
+%122 = OpBitwiseAnd %84 %107 %120
+%123 = OpBitwiseOr %84 %122 %116
+%124 = OpBitwiseAnd %84 %123 %125
+%126 = OpShiftRightArithmetic %84 %123 %114
+%127 = OpBitwiseOr %84 %126 %124
+%128 = OpShiftRightLogical %84 %126 %129
+%130 = OpBitwiseAnd %84 %128 %112
+%131 = OpBitwiseOr %84 %130 %127
+%132 = OpShiftLeftLogical %84 %131 %129
+%133 = OpUGreaterThan %52 %132 %134
+%135 = OpSelect %84 %133 %112 %115
+%136 = OpIAdd %84 %128 %135
+%137 = OpBitwiseAnd %84 %136 %125
+%138 = OpBitwiseOr %84 %137 %103
+%139 = OpUConvert %17 %138
+%141 = OpInBoundsAccessChain %140 %91 %95
+OpStore %141 %139
+%142 = OpULessThan %52 %96 %92
 OpLoopMerge %94 %93 None
-OpBranchConditional %148 %93 %94
+OpBranchConditional %142 %93 %94
 %94 = OpLabel
-%149 = OpLoad %83 %91
-OpReturnValue %149
+%143 = OpLoad %83 %91
+OpReturnValue %143
 OpFunctionEnd
 #endif

--- a/reference/shaders/ags/cs_wmma_copy_transpose_fp16.sm66.ssbo.comp
+++ b/reference/shaders/ags/cs_wmma_copy_transpose_fp16.sm66.ssbo.comp
@@ -54,24 +54,27 @@ coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> CoopMatS
     return coop_output;
 }
 
-coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> CoopMatFP16toFP8(coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _87)
+coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> CoopMatFP16toFP8(coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _91)
 {
-    uint _95;
-    _95 = 0u;
+    uint _99;
+    _99 = 0u;
     coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> coop_output;
     for (;;)
     {
-        uint _96 = _95 + 1u;
-        int16_t _99 = float16BitsToInt16(_87[_95]);
-        int16_t _107 = (_99 << int16_t(1us)) - 16384s;
-        int16_t _111 = (_107 >> 11s) - 1s;
-        int16_t _123 = (_107 & ((_111 & (-2048s)) ^ (-1s))) | (_111 & 2048s);
-        int16_t _126 = _123 >> max((-_111), 0s);
-        int16_t _128 = int16_t(uint16_t(_126) >> uint16_t(8s));
-        coop_output[_95] = uint8_t(((_128 + int16_t(uint16_t(((_128 & 1s) | (_126 | (_123 & 127s))) << 8s) > 32768us)) & 127s) | (int16_t(uint16_t(_99) >> 15us) << 7s));
-        if (_96 < uint(coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB>(0).length()))
+        uint _100 = _99 + 2u;
+        uint _101 = _99 + 1u;
+        i16vec2 _107 = float16BitsToInt16(f16vec2(_91[_99], _91[_101]));
+        i16vec2 _117 = (_107 << i16vec2(1)) - i16vec2(16384);
+        i16vec2 _123 = (_117 >> i16vec2(11)) - i16vec2(1);
+        i16vec2 _138 = (_117 & ((_123 & i16vec2(-2048)) ^ i16vec2(-1))) | (_123 & i16vec2(2048));
+        i16vec2 _142 = _138 >> max((-_123), i16vec2(0));
+        i16vec2 _144 = i16vec2(u16vec2(_142) >> u16vec2(i16vec2(8)));
+        u8vec2 _159 = u8vec2(((_144 + i16vec2(greaterThan(u16vec2(((_144 & i16vec2(1)) | (_142 | (_138 & i16vec2(127)))) << i16vec2(8)), u16vec2(32768)))) & i16vec2(127)) | (i16vec2(u16vec2(_107) >> u16vec2(i16vec2(15))) << i16vec2(7)));
+        coop_output[_99] = _159.x;
+        coop_output[_101] = _159.y;
+        if (_100 < uint(coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB>(0).length()))
         {
-            _95 = _96;
+            _99 = _100;
         }
         else
         {
@@ -113,17 +116,17 @@ void main()
     subgroupBarrier();
     coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _80;
     coopMatLoad(_80, LDSTransposeScratch, _78, 16u, gl_CooperativeMatrixLayoutColumnMajor);
-    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _145 = _80;
-    coopMatStore(CoopMatFP16toFP8(_145), _25._m0, 1024u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
-    uint _148 = gl_SubgroupID * 256u;
+    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseB> _168 = _80;
+    coopMatStore(CoopMatFP16toFP8(_168), _25._m0, 1024u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    uint _171 = gl_SubgroupID * 256u;
     subgroupMemoryBarrierShared();
     subgroupBarrier();
-    coopMatStore(_80, LDSTransposeScratch, _148, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopMatStore(_80, LDSTransposeScratch, _171, 16u, gl_CooperativeMatrixLayoutColumnMajor);
     subgroupMemoryBarrierShared();
     subgroupBarrier();
-    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _150;
-    coopMatLoad(_150, LDSTransposeScratch, _148, 16u, gl_CooperativeMatrixLayoutColumnMajor);
-    coopMatStore(coopmat<float, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(_150), _25._m0, 2048u, 64u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _173;
+    coopMatLoad(_173, LDSTransposeScratch, _171, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopMatStore(coopmat<float, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(_173), _25._m0, 2048u, 64u, gl_CooperativeMatrixLayoutColumnMajor);
 }
 
 
@@ -133,7 +136,7 @@ void main()
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 156
+; Bound: 179
 ; Schema: 0
 OpCapability Shader
 OpCapability Float16
@@ -158,8 +161,8 @@ OpName %23 "SSBO"
 OpName %34 "LDSTransposeScratch"
 OpName %56 "CoopMatSaturateFP8"
 OpName %58 "coop_output"
-OpName %88 "CoopMatFP16toFP8"
-OpName %91 "coop_output"
+OpName %92 "CoopMatFP16toFP8"
+OpName %95 "coop_output"
 OpDecorate %18 ArrayStride 1
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %19 Block
@@ -217,31 +220,47 @@ OpDecorate %36 BuiltIn SubgroupId
 %82 = OpConstant %2 1024
 %83 = OpTypeCooperativeMatrixKHR %17 %6 %4 %4 %9
 %84 = OpTypeInt 16 1
-%85 = OpTypePointer Function %10
-%86 = OpTypeFunction %83 %85
-%90 = OpTypePointer Function %83
-%101 = OpTypeInt 16 0
-%102 = OpConstant %101 15
-%104 = OpConstant %84 7
-%106 = OpConstant %101 1
-%108 = OpConstant %84 16384
-%110 = OpConstant %84 11
-%112 = OpConstant %84 1
-%115 = OpConstant %84 0
-%117 = OpConstant %84 2048
-%119 = OpConstant %84 -2048
-%121 = OpConstant %84 -1
-%125 = OpConstant %84 127
-%129 = OpConstant %84 8
-%134 = OpConstant %101 32768
-%140 = OpTypePointer Function %17
-%153 = OpConstant %2 2048
+%85 = OpTypeVector %52 2
+%86 = OpTypeVector %1 2
+%87 = OpTypeVector %84 2
+%88 = OpTypeVector %17 2
+%89 = OpTypePointer Function %10
+%90 = OpTypeFunction %83 %89
+%94 = OpTypePointer Function %83
+%109 = OpConstant %84 15
+%110 = OpConstantComposite %87 %109 %109
+%112 = OpConstant %84 7
+%113 = OpConstantComposite %87 %112 %112
+%115 = OpConstant %84 1
+%116 = OpConstantComposite %87 %115 %115
+%118 = OpConstant %84 16384
+%119 = OpConstantComposite %87 %118 %118
+%121 = OpConstant %84 11
+%122 = OpConstantComposite %87 %121 %121
+%126 = OpConstant %84 0
+%127 = OpConstantComposite %87 %126 %126
+%129 = OpConstant %84 2048
+%130 = OpConstantComposite %87 %129 %129
+%132 = OpConstant %84 -2048
+%133 = OpConstantComposite %87 %132 %132
+%135 = OpConstant %84 -1
+%136 = OpConstantComposite %87 %135 %135
+%140 = OpConstant %84 127
+%141 = OpConstantComposite %87 %140 %140
+%145 = OpConstant %84 8
+%146 = OpConstantComposite %87 %145 %145
+%151 = OpTypeInt 16 0
+%152 = OpConstant %151 32768
+%153 = OpTypeVector %151 2
+%154 = OpConstantComposite %153 %152 %152
+%160 = OpTypePointer Function %17
+%176 = OpConstant %2 2048
 %15 = OpFunction %13 None %14
 %16 = OpLabel
 %75 = OpVariable %53 Function
-%145 = OpVariable %85 Function
-OpBranch %154
-%154 = OpLabel
+%168 = OpVariable %89 Function
+OpBranch %177
+%177 = OpLabel
 %28 = OpAccessChain %27 %21 %7 %7
 %30 = OpCooperativeMatrixLoadKHR %5 %28 %9 %29 NonPrivatePointer
 %37 = OpLoad %2 %36
@@ -273,19 +292,19 @@ OpCooperativeMatrixStoreKHR %79 %76 %9 %4 NonPrivatePointer
 OpControlBarrier %6 %6 %41
 %80 = OpCooperativeMatrixLoadKHR %10 %79 %9 %4 NonPrivatePointer
 %81 = OpAccessChain %27 %25 %7 %82
-OpStore %145 %80
-%146 = OpFunctionCall %83 %88 %145
-OpCooperativeMatrixStoreKHR %81 %146 %9 %4 NonPrivatePointer
-%147 = OpLoad %2 %36
-%148 = OpIMul %2 %147 %31
-%149 = OpInBoundsAccessChain %39 %34 %148
+OpStore %168 %80
+%169 = OpFunctionCall %83 %92 %168
+OpCooperativeMatrixStoreKHR %81 %169 %9 %4 NonPrivatePointer
+%170 = OpLoad %2 %36
+%171 = OpIMul %2 %170 %31
+%172 = OpInBoundsAccessChain %39 %34 %171
 OpControlBarrier %6 %6 %41
-OpCooperativeMatrixStoreKHR %149 %80 %9 %4 NonPrivatePointer
+OpCooperativeMatrixStoreKHR %172 %80 %9 %4 NonPrivatePointer
 OpControlBarrier %6 %6 %41
-%150 = OpCooperativeMatrixLoadKHR %5 %149 %9 %4 NonPrivatePointer
-%151 = OpFConvert %12 %150
-%152 = OpAccessChain %27 %25 %7 %153
-OpCooperativeMatrixStoreKHR %152 %151 %9 %50 NonPrivatePointer
+%173 = OpCooperativeMatrixLoadKHR %5 %172 %9 %4 NonPrivatePointer
+%174 = OpFConvert %12 %173
+%175 = OpAccessChain %27 %25 %7 %176
+OpCooperativeMatrixStoreKHR %175 %174 %9 %50 NonPrivatePointer
 OpReturn
 OpFunctionEnd
 %56 = OpFunction %5 None %54
@@ -309,51 +328,59 @@ OpBranchConditional %72 %60 %61
 %73 = OpLoad %5 %58
 OpReturnValue %73
 OpFunctionEnd
-%88 = OpFunction %83 None %86
-%87 = OpFunctionParameter %85
-%89 = OpLabel
-%91 = OpVariable %90 Function
-%92 = OpCooperativeMatrixLengthKHR %2 %83
-OpBranch %93
+%92 = OpFunction %83 None %90
+%91 = OpFunctionParameter %89
 %93 = OpLabel
-%95 = OpPhi %2 %7 %89 %96 %93
-%96 = OpIAdd %2 %95 %9
-%97 = OpInBoundsAccessChain %64 %87 %95
-%98 = OpLoad %1 %97
-%99 = OpBitcast %84 %98
-%100 = OpShiftRightLogical %84 %99 %102
-%103 = OpShiftLeftLogical %84 %100 %104
-%105 = OpShiftLeftLogical %84 %99 %106
-%107 = OpISub %84 %105 %108
-%109 = OpShiftRightArithmetic %84 %107 %110
-%111 = OpISub %84 %109 %112
-%113 = OpSNegate %84 %111
-%114 = OpExtInst %84 %67 SMax %113 %115
-%116 = OpBitwiseAnd %84 %111 %117
-%118 = OpBitwiseAnd %84 %111 %119
-%120 = OpBitwiseXor %84 %118 %121
-%122 = OpBitwiseAnd %84 %107 %120
-%123 = OpBitwiseOr %84 %122 %116
-%124 = OpBitwiseAnd %84 %123 %125
-%126 = OpShiftRightArithmetic %84 %123 %114
-%127 = OpBitwiseOr %84 %126 %124
-%128 = OpShiftRightLogical %84 %126 %129
-%130 = OpBitwiseAnd %84 %128 %112
-%131 = OpBitwiseOr %84 %130 %127
-%132 = OpShiftLeftLogical %84 %131 %129
-%133 = OpUGreaterThan %52 %132 %134
-%135 = OpSelect %84 %133 %112 %115
-%136 = OpIAdd %84 %128 %135
-%137 = OpBitwiseAnd %84 %136 %125
-%138 = OpBitwiseOr %84 %137 %103
-%139 = OpUConvert %17 %138
-%141 = OpInBoundsAccessChain %140 %91 %95
-OpStore %141 %139
-%142 = OpULessThan %52 %96 %92
-OpLoopMerge %94 %93 None
-OpBranchConditional %142 %93 %94
-%94 = OpLabel
-%143 = OpLoad %83 %91
-OpReturnValue %143
+%95 = OpVariable %94 Function
+%96 = OpCooperativeMatrixLengthKHR %2 %83
+OpBranch %97
+%97 = OpLabel
+%99 = OpPhi %2 %7 %93 %100 %97
+%100 = OpIAdd %2 %99 %3
+%101 = OpIAdd %2 %99 %9
+%102 = OpInBoundsAccessChain %64 %91 %99
+%103 = OpLoad %1 %102
+%104 = OpInBoundsAccessChain %64 %91 %101
+%105 = OpLoad %1 %104
+%106 = OpCompositeConstruct %86 %103 %105
+%107 = OpBitcast %87 %106
+%108 = OpShiftRightLogical %87 %107 %110
+%111 = OpShiftLeftLogical %87 %108 %113
+%114 = OpShiftLeftLogical %87 %107 %116
+%117 = OpISub %87 %114 %119
+%120 = OpShiftRightArithmetic %87 %117 %122
+%123 = OpISub %87 %120 %116
+%124 = OpSNegate %87 %123
+%125 = OpExtInst %87 %67 SMax %124 %127
+%128 = OpBitwiseAnd %87 %123 %130
+%131 = OpBitwiseAnd %87 %123 %133
+%134 = OpBitwiseXor %87 %131 %136
+%137 = OpBitwiseAnd %87 %117 %134
+%138 = OpBitwiseOr %87 %137 %128
+%139 = OpBitwiseAnd %87 %138 %141
+%142 = OpShiftRightArithmetic %87 %138 %125
+%143 = OpBitwiseOr %87 %142 %139
+%144 = OpShiftRightLogical %87 %142 %146
+%147 = OpBitwiseAnd %87 %144 %116
+%148 = OpBitwiseOr %87 %147 %143
+%149 = OpShiftLeftLogical %87 %148 %146
+%150 = OpUGreaterThan %85 %149 %154
+%155 = OpSelect %87 %150 %116 %127
+%156 = OpIAdd %87 %144 %155
+%157 = OpBitwiseAnd %87 %156 %141
+%158 = OpBitwiseOr %87 %157 %111
+%159 = OpUConvert %88 %158
+%161 = OpInBoundsAccessChain %160 %95 %99
+%162 = OpCompositeExtract %17 %159 0
+OpStore %161 %162
+%163 = OpInBoundsAccessChain %160 %95 %101
+%164 = OpCompositeExtract %17 %159 1
+OpStore %163 %164
+%165 = OpULessThan %52 %100 %96
+OpLoopMerge %98 %97 None
+OpBranchConditional %165 %97 %98
+%98 = OpLabel
+%166 = OpLoad %83 %95
+OpReturnValue %166
 OpFunctionEnd
 #endif

--- a/reference/shaders/ags/cs_wmma_f32_16x16x16_f16_quant_fp8.sm66.ssbo.comp
+++ b/reference/shaders/ags/cs_wmma_f32_16x16x16_f16_quant_fp8.sm66.ssbo.comp
@@ -51,24 +51,27 @@ coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> CoopMatS
     return coop_output;
 }
 
-coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> CoopMatFP16toFP8(coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _69)
+coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> CoopMatFP16toFP8(coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _73)
 {
-    uint _77;
-    _77 = 0u;
+    uint _81;
+    _81 = 0u;
     coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> coop_output;
     for (;;)
     {
-        uint _78 = _77 + 1u;
-        int16_t _81 = float16BitsToInt16(_69[_77]);
-        int16_t _89 = (_81 << int16_t(1us)) - 16384s;
-        int16_t _93 = (_89 >> 11s) - 1s;
-        int16_t _105 = (_89 & ((_93 & (-2048s)) ^ (-1s))) | (_93 & 2048s);
-        int16_t _108 = _105 >> max((-_93), 0s);
-        int16_t _110 = int16_t(uint16_t(_108) >> uint16_t(8s));
-        coop_output[_77] = uint8_t(((_110 + int16_t(uint16_t(((_110 & 1s) | (_108 | (_105 & 127s))) << 8s) > 32768us)) & 127s) | (int16_t(uint16_t(_81) >> 15us) << 7s));
-        if (_78 < uint(coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(0).length()))
+        uint _82 = _81 + 2u;
+        uint _83 = _81 + 1u;
+        i16vec2 _89 = float16BitsToInt16(f16vec2(_73[_81], _73[_83]));
+        i16vec2 _99 = (_89 << i16vec2(1)) - i16vec2(16384);
+        i16vec2 _105 = (_99 >> i16vec2(11)) - i16vec2(1);
+        i16vec2 _120 = (_99 & ((_105 & i16vec2(-2048)) ^ i16vec2(-1))) | (_105 & i16vec2(2048));
+        i16vec2 _124 = _120 >> max((-_105), i16vec2(0));
+        i16vec2 _126 = i16vec2(u16vec2(_124) >> u16vec2(i16vec2(8)));
+        u8vec2 _141 = u8vec2(((_126 + i16vec2(greaterThan(u16vec2(((_126 & i16vec2(1)) | (_124 | (_120 & i16vec2(127)))) << i16vec2(8)), u16vec2(32768)))) & i16vec2(127)) | (i16vec2(u16vec2(_89) >> u16vec2(i16vec2(15))) << i16vec2(7)));
+        coop_output[_81] = _141.x;
+        coop_output[_83] = _141.y;
+        if (_82 < uint(coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(0).length()))
         {
-            _77 = _78;
+            _81 = _82;
         }
         else
         {
@@ -87,8 +90,8 @@ void main()
     coopmat<float, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _37;
     coopMatLoad(_37, _21._m0, 1024u, 64u, gl_CooperativeMatrixLayoutColumnMajor);
     coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _63 = coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(coopMatMulAdd(_30, _33, _37, 0));
-    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _127 = CoopMatSaturateFP8(_63);
-    coopMatStore(CoopMatFP16toFP8(_127), _25._m0, 0u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _150 = CoopMatSaturateFP8(_63);
+    coopMatStore(CoopMatFP16toFP8(_150), _25._m0, 0u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
 }
 
 
@@ -98,7 +101,7 @@ void main()
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 131
+; Bound: 154
 ; Schema: 0
 OpCapability Shader
 OpCapability Float16
@@ -121,8 +124,8 @@ OpName %19 "SSBO"
 OpName %23 "SSBO"
 OpName %44 "CoopMatSaturateFP8"
 OpName %46 "coop_output"
-OpName %70 "CoopMatFP16toFP8"
-OpName %73 "coop_output"
+OpName %74 "CoopMatFP16toFP8"
+OpName %77 "coop_output"
 OpDecorate %18 ArrayStride 1
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %19 Block
@@ -172,29 +175,45 @@ OpDecorate %25 NonReadable
 %58 = OpConstant %1 0x1.cp+8
 %66 = OpTypeCooperativeMatrixKHR %17 %6 %4 %4 %10
 %67 = OpTypeInt 16 1
-%68 = OpTypeFunction %66 %41
-%72 = OpTypePointer Function %66
-%83 = OpTypeInt 16 0
-%84 = OpConstant %83 15
-%86 = OpConstant %67 7
-%88 = OpConstant %83 1
-%90 = OpConstant %67 16384
-%92 = OpConstant %67 11
-%94 = OpConstant %67 1
-%97 = OpConstant %67 0
-%99 = OpConstant %67 2048
-%101 = OpConstant %67 -2048
-%103 = OpConstant %67 -1
-%107 = OpConstant %67 127
-%111 = OpConstant %67 8
-%116 = OpConstant %83 32768
-%122 = OpTypePointer Function %17
+%68 = OpTypeVector %40 2
+%69 = OpTypeVector %1 2
+%70 = OpTypeVector %67 2
+%71 = OpTypeVector %17 2
+%72 = OpTypeFunction %66 %41
+%76 = OpTypePointer Function %66
+%91 = OpConstant %67 15
+%92 = OpConstantComposite %70 %91 %91
+%94 = OpConstant %67 7
+%95 = OpConstantComposite %70 %94 %94
+%97 = OpConstant %67 1
+%98 = OpConstantComposite %70 %97 %97
+%100 = OpConstant %67 16384
+%101 = OpConstantComposite %70 %100 %100
+%103 = OpConstant %67 11
+%104 = OpConstantComposite %70 %103 %103
+%108 = OpConstant %67 0
+%109 = OpConstantComposite %70 %108 %108
+%111 = OpConstant %67 2048
+%112 = OpConstantComposite %70 %111 %111
+%114 = OpConstant %67 -2048
+%115 = OpConstantComposite %70 %114 %114
+%117 = OpConstant %67 -1
+%118 = OpConstantComposite %70 %117 %117
+%122 = OpConstant %67 127
+%123 = OpConstantComposite %70 %122 %122
+%127 = OpConstant %67 8
+%128 = OpConstantComposite %70 %127 %127
+%133 = OpTypeInt 16 0
+%134 = OpConstant %133 32768
+%135 = OpTypeVector %133 2
+%136 = OpConstantComposite %135 %134 %134
+%142 = OpTypePointer Function %17
 %15 = OpFunction %13 None %14
 %16 = OpLabel
 %63 = OpVariable %41 Function
-%127 = OpVariable %41 Function
-OpBranch %129
-%129 = OpLabel
+%150 = OpVariable %41 Function
+OpBranch %152
+%152 = OpLabel
 %28 = OpAccessChain %27 %21 %3 %3
 %30 = OpCooperativeMatrixLoadKHR %5 %28 %3 %29 NonPrivatePointer
 %31 = OpAccessChain %27 %21 %3 %32
@@ -206,9 +225,9 @@ OpBranch %129
 OpStore %63 %39
 %64 = OpFunctionCall %12 %44 %63
 %65 = OpAccessChain %27 %25 %3 %3
-OpStore %127 %64
-%128 = OpFunctionCall %66 %70 %127
-OpCooperativeMatrixStoreKHR %65 %128 %7 %4 NonPrivatePointer
+OpStore %150 %64
+%151 = OpFunctionCall %66 %74 %150
+OpCooperativeMatrixStoreKHR %65 %151 %7 %4 NonPrivatePointer
 OpReturn
 OpFunctionEnd
 %44 = OpFunction %12 None %42
@@ -232,51 +251,59 @@ OpBranchConditional %60 %48 %49
 %61 = OpLoad %12 %46
 OpReturnValue %61
 OpFunctionEnd
-%70 = OpFunction %66 None %68
-%69 = OpFunctionParameter %41
-%71 = OpLabel
-%73 = OpVariable %72 Function
-%74 = OpCooperativeMatrixLengthKHR %2 %66
-OpBranch %75
+%74 = OpFunction %66 None %72
+%73 = OpFunctionParameter %41
 %75 = OpLabel
-%77 = OpPhi %2 %3 %71 %78 %75
-%78 = OpIAdd %2 %77 %7
-%79 = OpInBoundsAccessChain %52 %69 %77
-%80 = OpLoad %1 %79
-%81 = OpBitcast %67 %80
-%82 = OpShiftRightLogical %67 %81 %84
-%85 = OpShiftLeftLogical %67 %82 %86
-%87 = OpShiftLeftLogical %67 %81 %88
-%89 = OpISub %67 %87 %90
-%91 = OpShiftRightArithmetic %67 %89 %92
-%93 = OpISub %67 %91 %94
-%95 = OpSNegate %67 %93
-%96 = OpExtInst %67 %55 SMax %95 %97
-%98 = OpBitwiseAnd %67 %93 %99
-%100 = OpBitwiseAnd %67 %93 %101
-%102 = OpBitwiseXor %67 %100 %103
-%104 = OpBitwiseAnd %67 %89 %102
-%105 = OpBitwiseOr %67 %104 %98
-%106 = OpBitwiseAnd %67 %105 %107
-%108 = OpShiftRightArithmetic %67 %105 %96
-%109 = OpBitwiseOr %67 %108 %106
-%110 = OpShiftRightLogical %67 %108 %111
-%112 = OpBitwiseAnd %67 %110 %94
-%113 = OpBitwiseOr %67 %112 %109
-%114 = OpShiftLeftLogical %67 %113 %111
-%115 = OpUGreaterThan %40 %114 %116
-%117 = OpSelect %67 %115 %94 %97
-%118 = OpIAdd %67 %110 %117
-%119 = OpBitwiseAnd %67 %118 %107
-%120 = OpBitwiseOr %67 %119 %85
-%121 = OpUConvert %17 %120
-%123 = OpInBoundsAccessChain %122 %73 %77
-OpStore %123 %121
-%124 = OpULessThan %40 %78 %74
-OpLoopMerge %76 %75 None
-OpBranchConditional %124 %75 %76
-%76 = OpLabel
-%125 = OpLoad %66 %73
-OpReturnValue %125
+%77 = OpVariable %76 Function
+%78 = OpCooperativeMatrixLengthKHR %2 %66
+OpBranch %79
+%79 = OpLabel
+%81 = OpPhi %2 %3 %75 %82 %79
+%82 = OpIAdd %2 %81 %10
+%83 = OpIAdd %2 %81 %7
+%84 = OpInBoundsAccessChain %52 %73 %81
+%85 = OpLoad %1 %84
+%86 = OpInBoundsAccessChain %52 %73 %83
+%87 = OpLoad %1 %86
+%88 = OpCompositeConstruct %69 %85 %87
+%89 = OpBitcast %70 %88
+%90 = OpShiftRightLogical %70 %89 %92
+%93 = OpShiftLeftLogical %70 %90 %95
+%96 = OpShiftLeftLogical %70 %89 %98
+%99 = OpISub %70 %96 %101
+%102 = OpShiftRightArithmetic %70 %99 %104
+%105 = OpISub %70 %102 %98
+%106 = OpSNegate %70 %105
+%107 = OpExtInst %70 %55 SMax %106 %109
+%110 = OpBitwiseAnd %70 %105 %112
+%113 = OpBitwiseAnd %70 %105 %115
+%116 = OpBitwiseXor %70 %113 %118
+%119 = OpBitwiseAnd %70 %99 %116
+%120 = OpBitwiseOr %70 %119 %110
+%121 = OpBitwiseAnd %70 %120 %123
+%124 = OpShiftRightArithmetic %70 %120 %107
+%125 = OpBitwiseOr %70 %124 %121
+%126 = OpShiftRightLogical %70 %124 %128
+%129 = OpBitwiseAnd %70 %126 %98
+%130 = OpBitwiseOr %70 %129 %125
+%131 = OpShiftLeftLogical %70 %130 %128
+%132 = OpUGreaterThan %68 %131 %136
+%137 = OpSelect %70 %132 %98 %109
+%138 = OpIAdd %70 %126 %137
+%139 = OpBitwiseAnd %70 %138 %123
+%140 = OpBitwiseOr %70 %139 %93
+%141 = OpUConvert %71 %140
+%143 = OpInBoundsAccessChain %142 %77 %81
+%144 = OpCompositeExtract %17 %141 0
+OpStore %143 %144
+%145 = OpInBoundsAccessChain %142 %77 %83
+%146 = OpCompositeExtract %17 %141 1
+OpStore %145 %146
+%147 = OpULessThan %40 %82 %78
+OpLoopMerge %80 %79 None
+OpBranchConditional %147 %79 %80
+%80 = OpLabel
+%148 = OpLoad %66 %77
+OpReturnValue %148
 OpFunctionEnd
 #endif

--- a/reference/shaders/ags/cs_wmma_f32_16x16x16_f16_quant_fp8.sm66.ssbo.comp
+++ b/reference/shaders/ags/cs_wmma_f32_16x16x16_f16_quant_fp8.sm66.ssbo.comp
@@ -60,12 +60,12 @@ coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> CoopMatFP1
     {
         uint _78 = _77 + 1u;
         int16_t _81 = float16BitsToInt16(_69[_77]);
-        int16_t _90 = (_81 << int16_t(1us)) - 16384s;
-        int16_t _94 = (_90 >> 11s) - 1s;
-        int16_t _106 = (_90 & ((_94 & (-2048s)) ^ (-1s))) | (_94 & 2048s);
-        i8vec2 _113 = unpack8(_106 >> max((-_94), 0s));
-        int8_t _116 = _113.y;
-        coop_output[_77] = ((uint8_t(_116) + ((uint8_t((_116 & int8_t(1)) | (_113.x | int8_t(_106 & 127s))) > uint8_t(128)) ? uint8_t(1) : uint8_t(0))) & uint8_t(127)) | (unpack8(_81).y & uint8_t(128));
+        int16_t _89 = (_81 << int16_t(1us)) - 16384s;
+        int16_t _93 = (_89 >> 11s) - 1s;
+        int16_t _105 = (_89 & ((_93 & (-2048s)) ^ (-1s))) | (_93 & 2048s);
+        int16_t _108 = _105 >> max((-_93), 0s);
+        int16_t _110 = int16_t(uint16_t(_108) >> uint16_t(8s));
+        coop_output[_77] = uint8_t(((_110 + int16_t(uint16_t(((_110 & 1s) | (_108 | (_105 & 127s))) << 8s) > 32768us)) & 127s) | (int16_t(uint16_t(_81) >> 15us) << 7s));
         if (_78 < uint(coopmat<uint8_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(0).length()))
         {
             _77 = _78;
@@ -87,8 +87,8 @@ void main()
     coopmat<float, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _37;
     coopMatLoad(_37, _21._m0, 1024u, 64u, gl_CooperativeMatrixLayoutColumnMajor);
     coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _63 = coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator>(coopMatMulAdd(_30, _33, _37, 0));
-    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _133 = CoopMatSaturateFP8(_63);
-    coopMatStore(CoopMatFP16toFP8(_133), _25._m0, 0u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
+    coopmat<float16_t, gl_ScopeSubgroup, 16u, 16u, gl_MatrixUseAccumulator> _127 = CoopMatSaturateFP8(_63);
+    coopMatStore(CoopMatFP16toFP8(_127), _25._m0, 0u, 16u, gl_CooperativeMatrixLayoutColumnMajor);
 }
 
 
@@ -98,7 +98,7 @@ void main()
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 137
+; Bound: 131
 ; Schema: 0
 OpCapability Shader
 OpCapability Float16
@@ -174,31 +174,27 @@ OpDecorate %25 NonReadable
 %67 = OpTypeInt 16 1
 %68 = OpTypeFunction %66 %41
 %72 = OpTypePointer Function %66
-%82 = OpTypeVector %17 2
-%86 = OpConstant %17 128
-%88 = OpTypeInt 16 0
-%89 = OpConstant %88 1
-%91 = OpConstant %67 16384
-%93 = OpConstant %67 11
-%95 = OpConstant %67 1
-%98 = OpConstant %67 0
-%100 = OpConstant %67 2048
-%102 = OpConstant %67 -2048
-%104 = OpConstant %67 -1
-%108 = OpConstant %67 127
-%109 = OpTypeInt 8 1
-%112 = OpTypeVector %109 2
-%118 = OpConstant %109 1
-%122 = OpConstant %17 1
-%123 = OpConstant %17 0
-%126 = OpConstant %17 127
-%128 = OpTypePointer Function %17
+%83 = OpTypeInt 16 0
+%84 = OpConstant %83 15
+%86 = OpConstant %67 7
+%88 = OpConstant %83 1
+%90 = OpConstant %67 16384
+%92 = OpConstant %67 11
+%94 = OpConstant %67 1
+%97 = OpConstant %67 0
+%99 = OpConstant %67 2048
+%101 = OpConstant %67 -2048
+%103 = OpConstant %67 -1
+%107 = OpConstant %67 127
+%111 = OpConstant %67 8
+%116 = OpConstant %83 32768
+%122 = OpTypePointer Function %17
 %15 = OpFunction %13 None %14
 %16 = OpLabel
 %63 = OpVariable %41 Function
-%133 = OpVariable %41 Function
-OpBranch %135
-%135 = OpLabel
+%127 = OpVariable %41 Function
+OpBranch %129
+%129 = OpLabel
 %28 = OpAccessChain %27 %21 %3 %3
 %30 = OpCooperativeMatrixLoadKHR %5 %28 %3 %29 NonPrivatePointer
 %31 = OpAccessChain %27 %21 %3 %32
@@ -210,9 +206,9 @@ OpBranch %135
 OpStore %63 %39
 %64 = OpFunctionCall %12 %44 %63
 %65 = OpAccessChain %27 %25 %3 %3
-OpStore %133 %64
-%134 = OpFunctionCall %66 %70 %133
-OpCooperativeMatrixStoreKHR %65 %134 %7 %4 NonPrivatePointer
+OpStore %127 %64
+%128 = OpFunctionCall %66 %70 %127
+OpCooperativeMatrixStoreKHR %65 %128 %7 %4 NonPrivatePointer
 OpReturn
 OpFunctionEnd
 %44 = OpFunction %12 None %42
@@ -248,41 +244,39 @@ OpBranch %75
 %79 = OpInBoundsAccessChain %52 %69 %77
 %80 = OpLoad %1 %79
 %81 = OpBitcast %67 %80
-%83 = OpBitcast %82 %81
-%84 = OpCompositeExtract %17 %83 1
-%85 = OpBitwiseAnd %17 %84 %86
-%87 = OpShiftLeftLogical %67 %81 %89
-%90 = OpISub %67 %87 %91
-%92 = OpShiftRightArithmetic %67 %90 %93
-%94 = OpISub %67 %92 %95
-%96 = OpSNegate %67 %94
-%97 = OpExtInst %67 %55 SMax %96 %98
-%99 = OpBitwiseAnd %67 %94 %100
-%101 = OpBitwiseAnd %67 %94 %102
-%103 = OpBitwiseXor %67 %101 %104
-%105 = OpBitwiseAnd %67 %90 %103
-%106 = OpBitwiseOr %67 %105 %99
-%107 = OpBitwiseAnd %67 %106 %108
-%110 = OpSConvert %109 %107
-%111 = OpShiftRightArithmetic %67 %106 %97
-%113 = OpBitcast %112 %111
-%114 = OpCompositeExtract %109 %113 0
-%115 = OpBitwiseOr %109 %114 %110
-%116 = OpCompositeExtract %109 %113 1
-%117 = OpBitwiseAnd %109 %116 %118
-%119 = OpBitwiseOr %109 %117 %115
-%120 = OpUGreaterThan %40 %119 %86
-%121 = OpSelect %17 %120 %122 %123
-%124 = OpIAdd %17 %116 %121
-%125 = OpBitwiseAnd %17 %124 %126
-%127 = OpBitwiseOr %17 %125 %85
-%129 = OpInBoundsAccessChain %128 %73 %77
-OpStore %129 %127
-%130 = OpULessThan %40 %78 %74
+%82 = OpShiftRightLogical %67 %81 %84
+%85 = OpShiftLeftLogical %67 %82 %86
+%87 = OpShiftLeftLogical %67 %81 %88
+%89 = OpISub %67 %87 %90
+%91 = OpShiftRightArithmetic %67 %89 %92
+%93 = OpISub %67 %91 %94
+%95 = OpSNegate %67 %93
+%96 = OpExtInst %67 %55 SMax %95 %97
+%98 = OpBitwiseAnd %67 %93 %99
+%100 = OpBitwiseAnd %67 %93 %101
+%102 = OpBitwiseXor %67 %100 %103
+%104 = OpBitwiseAnd %67 %89 %102
+%105 = OpBitwiseOr %67 %104 %98
+%106 = OpBitwiseAnd %67 %105 %107
+%108 = OpShiftRightArithmetic %67 %105 %96
+%109 = OpBitwiseOr %67 %108 %106
+%110 = OpShiftRightLogical %67 %108 %111
+%112 = OpBitwiseAnd %67 %110 %94
+%113 = OpBitwiseOr %67 %112 %109
+%114 = OpShiftLeftLogical %67 %113 %111
+%115 = OpUGreaterThan %40 %114 %116
+%117 = OpSelect %67 %115 %94 %97
+%118 = OpIAdd %67 %110 %117
+%119 = OpBitwiseAnd %67 %118 %107
+%120 = OpBitwiseOr %67 %119 %85
+%121 = OpUConvert %17 %120
+%123 = OpInBoundsAccessChain %122 %73 %77
+OpStore %123 %121
+%124 = OpULessThan %40 %78 %74
 OpLoopMerge %76 %75 None
-OpBranchConditional %130 %75 %76
+OpBranchConditional %124 %75 %76
 %76 = OpLabel
-%131 = OpLoad %66 %73
-OpReturnValue %131
+%125 = OpLoad %66 %73
+OpReturnValue %125
 OpFunctionEnd
 #endif


### PR DESCRIPTION
Help the compiler out by emitting vec2 16bit instructions, nir_opt_vectorize can't deal with this. Also avoid 8bit math, that's also only causing pain. 