### PR TITLE
NvHitObject, part 1

### DIFF
--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -227,7 +227,8 @@ static bool emit_nvapi_extn_op_get_special(Converter::Impl &impl)
 	if (!impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0])
 		return false;
 
-	if (auto *c = llvm::dyn_cast<llvm::ConstantInt>(impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0]))
+	auto *c = llvm::dyn_cast<llvm::ConstantInt>(impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0]);
+	if (c != nullptr)
 	{
 		auto subopcode = uint32_t(c->getUniqueInteger().getZExtValue());
 		auto &builder = impl.builder();
@@ -279,7 +280,8 @@ static bool emit_nvapi_extn_op_rt_get_intersection_cluster_id(Converter::Impl &i
 	if (!impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0])
 		return false;
 
-	if (auto *ray_flags = llvm::dyn_cast<llvm::CallInst>(impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0]))
+	auto *ray_flags = llvm::dyn_cast<llvm::CallInst>(impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0]);
+	if (ray_flags != nullptr)
 	{
 		auto &builder = impl.builder();
 		spv::Id ray_object_id = 0;
@@ -306,31 +308,32 @@ bool NVAPIState::can_commit_opcode()
 	if (!fake_doorbell_inputs[NVAPI_ARGUMENT_OPCODE])
 		return false;
 
-	if (auto *c = llvm::dyn_cast<llvm::ConstantInt>(fake_doorbell_inputs[NVAPI_ARGUMENT_OPCODE]))
+	auto *c = llvm::dyn_cast<llvm::ConstantInt>(fake_doorbell_inputs[NVAPI_ARGUMENT_OPCODE]);
+	if (c != nullptr)
 	{
 		auto opcode = uint32_t(c->getUniqueInteger().getZExtValue());
 		switch (opcode)
 		{
 		case NV_EXTN_OP_SHFL:
-			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] &&
-			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 1] &&
-			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 2];
+			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] != nullptr &&
+			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 1] != nullptr &&
+			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 2] != nullptr;
 
 		case NV_EXTN_OP_FP16_ATOMIC:
 			return marked_uav &&
-			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] &&
-			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC1U + 0] &&
-			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC2U + 0];
+			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] != nullptr &&
+			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC1U + 0] != nullptr &&
+			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC2U + 0] != nullptr;
 
 		case NV_EXTN_OP_GET_SPECIAL:
-			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0];
+			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] != nullptr;
 
 		case NV_EXTN_OP_RT_GET_CLUSTER_ID:
 			return true;
 
 		case NV_EXTN_OP_RT_GET_CANDIDATE_CLUSTER_ID:
 		case NV_EXTN_OP_RT_GET_COMMITTED_CLUSTER_ID:
-			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0];
+			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] != nullptr;
 
 		default:
 			return false;
@@ -345,7 +348,8 @@ bool NVAPIState::commit_opcode(Converter::Impl &impl, bool analysis)
 	if (!fake_doorbell_inputs[NVAPI_ARGUMENT_OPCODE])
 		return false;
 
-	if (auto *c = llvm::dyn_cast<llvm::ConstantInt>(fake_doorbell_inputs[NVAPI_ARGUMENT_OPCODE]))
+	auto *c = llvm::dyn_cast<llvm::ConstantInt>(fake_doorbell_inputs[NVAPI_ARGUMENT_OPCODE]);
+	if (c != nullptr)
 	{
 		auto opcode = uint32_t(c->getUniqueInteger().getZExtValue());
 		switch (opcode)
@@ -527,9 +531,10 @@ bool emit_nvapi_buffer_load(Converter::Impl &impl, const llvm::CallInst *instruc
 bool NVAPIState::mark_uav_write(const llvm::CallInst *instruction)
 {
 	auto *mark = fake_doorbell_inputs[NVAPI_ARGUMENT_MARK_UAV_REF];
-	if (mark)
+	if (mark != nullptr)
 	{
-		if (const auto *c = llvm::dyn_cast<llvm::ConstantInt>(mark))
+		const auto *c = llvm::dyn_cast<llvm::ConstantInt>(mark);
+		if (c != nullptr)
 		{
 			if (c->getUniqueInteger().getZExtValue() == 1)
 			{

--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -226,24 +226,24 @@ static bool emit_nvapi_extn_op_get_special(Converter::Impl &impl)
 
 		switch (subopcode)
 		{
-			case NV_SPECIALOP_GLOBAL_TIMER_LO:
-			case NV_SPECIALOP_GLOBAL_TIMER_HI:
-			{
-				builder.addExtension("SPV_KHR_shader_clock");
-				builder.addCapability(spv::Capability::CapabilityShaderClockKHR);
+		case NV_SPECIALOP_GLOBAL_TIMER_LO:
+		case NV_SPECIALOP_GLOBAL_TIMER_HI:
+		{
+			builder.addExtension("SPV_KHR_shader_clock");
+			builder.addCapability(spv::CapabilityShaderClockKHR);
 
-				auto *read_op = impl.allocate(spv::OpReadClockKHR, builder.makeVectorType(builder.makeUintType(32), 2));
-				read_op->add_id(builder.makeUintConstant(1));
-				impl.add(read_op);
+			auto *read_op = impl.allocate(spv::OpReadClockKHR, builder.makeVectorType(builder.makeUintType(32), 2));
+			read_op->add_id(builder.makeUintConstant(1));
+			impl.add(read_op);
 
-				auto *extract_op = impl.allocate(spv::OpCompositeExtract, builder.makeUintType(32));
-				extract_op->add_id(read_op->id);
-				extract_op->add_literal(subopcode - NV_SPECIALOP_GLOBAL_TIMER_LO);
-				impl.add(extract_op);
+			auto *extract_op = impl.allocate(spv::OpCompositeExtract, builder.makeUintType(32));
+			extract_op->add_id(read_op->id);
+			extract_op->add_literal(subopcode - NV_SPECIALOP_GLOBAL_TIMER_LO);
+			impl.add(extract_op);
 
-				impl.nvapi.fake_doorbell_outputs[0] = extract_op->id;
-				return true;
-			}
+			impl.nvapi.fake_doorbell_outputs[0] = extract_op->id;
+			return true;
+		}
 		}
 	}
 

--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -140,21 +140,16 @@ void NVAPIState::notify_doorbell(Converter::Impl &impl, const llvm::CallInst *in
 	}
 }
 
-static bool get_argument(Converter::Impl &impl, uint32_t offset, spv::Id *id)
+static spv::Id get_argument(Converter::Impl &impl, uint32_t offset)
 {
-	if (!impl.nvapi.fake_doorbell_inputs[offset])
-		return false;
-	*id = impl.get_id_for_value(impl.nvapi.fake_doorbell_inputs[offset]);
-	return true;
+	return impl.get_id_for_value(impl.nvapi.fake_doorbell_inputs[offset]);
 }
 
 static bool emit_nvapi_extn_op_shuffle(Converter::Impl &impl)
 {
 	// Dummy throwaway implementation.
-	uint32_t val, lane;
-	if (!get_argument(impl, NVAPI_ARGUMENT_SRC0U + 0, &val) ||
-	    !get_argument(impl, NVAPI_ARGUMENT_SRC0U + 1, &lane))
-		return false;
+	spv::Id val = get_argument(impl, NVAPI_ARGUMENT_SRC0U + 0);
+	spv::Id lane = get_argument(impl, NVAPI_ARGUMENT_SRC0U + 1);
 
 	auto &builder = impl.builder();
 	builder.addCapability(spv::CapabilityGroupNonUniformShuffle);
@@ -175,11 +170,10 @@ static bool emit_nvapi_extn_op_fp16x2_atomic(Converter::Impl &impl)
 		return false;
 
 	// Dummy throwaway implementation to demonstrate UAV reference plumbing.
-	uint32_t addr, val, type;
-	if (!get_argument(impl, NVAPI_ARGUMENT_SRC0U + 0, &addr) ||
-	    !get_argument(impl, NVAPI_ARGUMENT_SRC1U + 0, &val) ||
-	    !get_argument(impl, NVAPI_ARGUMENT_SRC2U + 0, &type))
-		return false;
+	spv::Id addr = get_argument(impl, NVAPI_ARGUMENT_SRC0U + 0);
+	spv::Id val = get_argument(impl, NVAPI_ARGUMENT_SRC1U + 0);
+	spv::Id type = get_argument(impl, NVAPI_ARGUMENT_SRC2U + 0);
+	(void)type;
 
 	auto &builder = impl.builder();
 
@@ -224,9 +218,6 @@ static bool emit_nvapi_extn_op_fp16x2_atomic(Converter::Impl &impl)
 
 static bool emit_nvapi_extn_op_get_special(Converter::Impl &impl)
 {
-	if (!impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0])
-		return false;
-
 	auto *c = llvm::dyn_cast<llvm::ConstantInt>(impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0]);
 	if (c != nullptr)
 	{
@@ -277,9 +268,6 @@ static bool emit_nvapi_extn_op_rt_get_cluster_id(Converter::Impl &impl)
 
 static bool emit_nvapi_extn_op_rt_get_intersection_cluster_id(Converter::Impl &impl, spv::RayQueryIntersection intersection)
 {
-	if (!impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0])
-		return false;
-
 	auto *ray_flags = llvm::dyn_cast<llvm::CallInst>(impl.nvapi.fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0]);
 	if (ray_flags != nullptr)
 	{

--- a/third_party/glslang-spirv/SpvBuilder.cpp
+++ b/third_party/glslang-spirv/SpvBuilder.cpp
@@ -196,6 +196,21 @@ Id Builder::makeRayQueryType()
     return type->getResultId();
 }
 
+Id Builder::makeHitObjectNVType()
+{
+    Instruction *type;
+    if (!hit_object_nv_type)
+    {
+        type = new Instruction(getUniqueId(), NoType, OpTypeHitObjectNV);
+        hit_object_nv_type = type;
+        constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
+        module.mapInstruction(type);
+    } else
+        type = hit_object_nv_type;
+
+    return type->getResultId();
+}
+
 Id Builder::makePointer(StorageClass storageClass, Id pointee)
 {
     // try to find it

--- a/third_party/glslang-spirv/SpvBuilder.h
+++ b/third_party/glslang-spirv/SpvBuilder.h
@@ -134,6 +134,7 @@ public:
     Id makeImageType(Id sampledType, Dim, bool depth, bool arrayed, bool ms, unsigned sampled, ImageFormat format);
     Id makeAccelerationStructureType();
     Id makeRayQueryType();
+    Id makeHitObjectNVType();
     Id makeSamplerType();
     Id makeSampledImageType(Id imageType);
 
@@ -686,6 +687,7 @@ protected:
     dxil_spv::Vector<Instruction*> coopmatTypes;
     Instruction *acceleration_structure_type = nullptr;
     Instruction *ray_query_type = nullptr;
+    Instruction *hit_object_nv_type = nullptr;
 
     // stack of switches
     std::stack<Block*> switchMerges;


### PR DESCRIPTION
Enough to create simple hit objects and extract most scalars out of them.

The bitcast/conversion dance around floats and bools is slightly annoying but unfortunately I don't have any ideas about improving it.

Notably, I'm not assigning to `handle_to_storage_class` when creating `HitObjectNV` variables (like for example `emit_allocate_ray_query` does), because at the point they are allocated, I don't have the instruction they will be rewritten with yet. Doesn't seem to be a problem in practice though…?