### PR TITLE
Update dxbc-spirv.

### DIFF
--- a/bc/module_dxbc_ir.cpp
+++ b/bc/module_dxbc_ir.cpp
@@ -4000,6 +4000,11 @@ Module *parseDXBCBinary(LLVMContext &context, const void* data, size_t size)
 	options.resourceOptions.structuredCbv = false;
 	options.resourceOptions.structuredSrvUav = false;
 
+	options.bufferOptions.useTypedForRaw = false;
+	options.bufferOptions.useTypedForStructured = false;
+	options.bufferOptions.useTypedForSparseFeedback = true;
+	options.bufferOptions.useRawForTypedAtomic = false;
+
 	options.scalarizeOptions.subDwordVectors = true;
 
 	auto builder = dxbc::compileShaderToLegalizedIr(data, size, options);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(dxbc-spirv STATIC
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_validation.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_arithmetic.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_arithmetic.h
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_buffer_kind.cpp
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_buffer_kind.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_cfg_cleanup.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_cfg_cleanup.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_cfg_convert.cpp
@@ -90,6 +92,8 @@ add_library(dxbc-spirv-test STATIC
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_resources.h
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_arithmetic.cpp
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_arithmetic.h
+        ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_buffer_kind.cpp
+        ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_buffer_kind.h
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_scalarize.cpp
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_scalarize.h
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_arithmetic.cpp


### PR DESCRIPTION
Fixes the sparse buffer feedback test by converting those buffers to typed, as well as an unrelated bug that caused Atelier Yumia to crash.