### PR TITLE
Update dxbc-spirv.

### DIFF
--- a/bc/module_dxbc_ir.cpp
+++ b/bc/module_dxbc_ir.cpp
@@ -1510,7 +1510,7 @@ bool ParseContext::build_barrier(const ir::Op &op)
 
 	if (memory_type & ir::MemoryType::eLds)
 		memory_flags |= DXIL::MemoryTypeGroupSharedBit;
-	if (memory_type & (ir::MemoryType::eUavBuffer | ir::MemoryType::eUavImage))
+	if (memory_type & ir::MemoryType::eUav)
 		memory_flags |= DXIL::MemoryTypeUavBit;
 
 	auto *inst = build_dxil_call(DXIL::Op::BarrierByMemoryType, void_type, void_type,
@@ -4011,6 +4011,14 @@ Module *parseDXBCBinary(LLVMContext &context, const void* data, size_t size)
 	options.bufferOptions.useRawForTypedAtomic = false;
 
 	options.scalarizeOptions.subDwordVectors = true;
+
+	options.syncOptions.insertRovLocks = false;
+	options.syncOptions.insertLdsBarriers = false;
+	options.syncOptions.insertUavBarriers = false;
+
+	options.derivativeOptions.hoistNontrivialDerivativeOps = true;
+	options.derivativeOptions.hoistNontrivialImplicitLodOps = false;
+	options.derivativeOptions.hoistDescriptorLoads = false;
 
 	auto builder = dxbc::compileShaderToLegalizedIr(data, size, options);
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(dxbc-spirv STATIC
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_container.h
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_disasm.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_disasm.h
+        ${DXBC_SPV_SOURCE_DIR}/ir/ir_divergence.cpp
+        ${DXBC_SPV_SOURCE_DIR}/ir/ir_divergence.h
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_dominance.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_dominance.h
         ${DXBC_SPV_SOURCE_DIR}/ir/ir_utils.cpp
@@ -49,8 +51,12 @@ add_library(dxbc-spirv STATIC
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_cfg_convert.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_cse.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_cse.h
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_derivative.cpp
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_derivative.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_lower_consume.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_lower_consume.h
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_lower_io.cpp
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_lower_io.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_lower_min16.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_lower_min16.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_propagate_types.cpp
@@ -64,6 +70,8 @@ add_library(dxbc-spirv STATIC
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_ssa.cpp
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_ssa.h
         ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_ssa_utils.h
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_sync.cpp
+        ${DXBC_SPV_SOURCE_DIR}/ir/passes/ir_pass_sync.h
         ${DXBC_SPV_SOURCE_DIR}/util/util_bit.h
         ${DXBC_SPV_SOURCE_DIR}/util/util_debug.h
         ${DXBC_SPV_SOURCE_DIR}/util/util_flags.h
@@ -92,6 +100,8 @@ add_library(dxbc-spirv-test STATIC
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_arithmetic.h
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_buffer_kind.cpp
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_buffer_kind.h
+        ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_lower_io.cpp
+        ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_lower_io.h
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_scalarize.cpp
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_pass_scalarize.h
         ${DXBC_SPV_SOURCE_DIR}/tests/api/test_api_arithmetic.cpp


### PR DESCRIPTION
Introduces derivative hoisting and fixes a whole slew of minor bugs.

TLDR on the former: We very aggressively move `deriv_rtx/y` ops into quad-uniform control flow by default since FXC will always move these ops into the control flow that consumes them, so we end up with dumb patterns like this all the time where the developer clearly had different intentions:
```
if_z r2.x
  deriv_rtx_coarse r1.xy, r0.xy
  deriv_rty_coarse r1.zw r0.xy
  sample_d r0.xyzw, r0.xy, t0.xyzw, s0, r1.xy, r1.zw
endif
```

For implicit lod ops, by default we only do this if the texture coordinate is directly derived from a shader input since otherwise we'd generate far too many false positives. Specifically for D3D12 I also decided not to move `textureQueryLod` if there is no quad-uniform descriptor load dominating it, since that may not necessarily be safe, but I have yet to see that instruction be a problem anyway.

I also implemented a pass to aggressively insert LDS / UAV barriers, but that's primarily intended for DXVK use.