### PR TITLE
Add some RDNA1-compatible fallback paths.

### DIFF
--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -5280,9 +5280,12 @@ void Converter::Impl::emit_builtin_decoration(spv::Id id, DXIL::Semantic semanti
 		}
 		else
 		{
-			builder.addDecoration(id, spv::DecorationBuiltIn, spv::BuiltInShadingRateKHR);
+			if (!options.quirks.ignore_primitive_shading_rate)
+			{
+				builder.addDecoration(id, spv::DecorationBuiltIn, spv::BuiltInShadingRateKHR);
+				requires_flat_input = true;
+			}
 			spirv_module.register_builtin_shader_input(id, spv::BuiltInShadingRateKHR);
-			requires_flat_input = true;
 		}
 		builder.addExtension("SPV_KHR_fragment_shading_rate");
 		builder.addCapability(spv::CapabilityFragmentShadingRateKHR);
@@ -5292,16 +5295,25 @@ void Converter::Impl::emit_builtin_decoration(spv::Id id, DXIL::Semantic semanti
 	case DXIL::Semantic::InternalBarycentricsNoPerspective:
 	{
 		if (options.khr_barycentrics_enabled)
-			builder.addExtension("SPV_KHR_fragment_shader_barycentric");
-		else
-			builder.addExtension("SPV_NV_fragment_shader_barycentric");
+		{
+			auto builtin =
+			    semantic == DXIL::Semantic::Barycentrics ? spv::BuiltInBaryCoordKHR : spv::BuiltInBaryCoordNoPerspKHR;
 
-		// These enums all alias.
-		builder.addCapability(spv::CapabilityFragmentBarycentricKHR);
-		auto builtin = semantic == DXIL::Semantic::Barycentrics ?
-		               spv::BuiltInBaryCoordKHR : spv::BuiltInBaryCoordNoPerspKHR;
-		builder.addDecoration(id, spv::DecorationBuiltIn, builtin);
-		spirv_module.register_builtin_shader_input(id, builtin);
+			builder.addExtension("SPV_KHR_fragment_shader_barycentric");
+			builder.addCapability(spv::CapabilityFragmentBarycentricKHR);
+			builder.addDecoration(id, spv::DecorationBuiltIn, builtin);
+			spirv_module.register_builtin_shader_input(id, builtin);
+		}
+		else
+		{
+			// TODO: We're not dealing with centroid vs per-sample decorations here.
+			auto builtin =
+			    semantic == DXIL::Semantic::Barycentrics ? spv::BuiltInBaryCoordSmoothAMD : spv::BuiltInBaryCoordNoPerspAMD;
+
+			builder.addExtension("SPV_AMD_shader_explicit_vertex_parameter");
+			builder.addDecoration(id, spv::DecorationBuiltIn, builtin);
+			spirv_module.register_builtin_shader_input(id, builtin);
+		}
 		break;
 	}
 
@@ -5643,6 +5655,19 @@ bool Converter::Impl::emit_stage_input_variables()
 		if (execution_model == spv::ExecutionModelTessellationEvaluation && system_value != DXIL::Semantic::DomainLocation)
 			system_value = DXIL::Semantic::User;
 
+		bool masked_input = false;
+		if (system_value == DXIL::Semantic::ShadingRate && options.quirks.ignore_primitive_shading_rate)
+			masked_input = true;
+
+		if (!options.khr_barycentrics_enabled)
+		{
+			if (system_value == DXIL::Semantic::Barycentrics ||
+				system_value == DXIL::Semantic::InternalBarycentricsNoPerspective)
+			{
+				cols = 2;
+			}
+		}
+
 		spv::Id type_id = get_type_id(effective_element_type, rows, cols);
 		if (system_value == DXIL::Semantic::Position)
 		{
@@ -5683,7 +5708,7 @@ bool Converter::Impl::emit_stage_input_variables()
 			type_id =
 			    builder.makeArrayType(type_id, builder.makeUintConstant(stage_input_vertices), 0);
 		}
-		else if (per_vertex)
+		else if (per_vertex && options.khr_barycentrics_enabled)
 		{
 			// TODO: Does this change for barycentrics with lines?
 			type_id = builder.makeArrayType(type_id, builder.makeUintConstant(3), 0);
@@ -5698,17 +5723,23 @@ bool Converter::Impl::emit_stage_input_variables()
 			variable_name += dxil_spv::to_string(semantic_index);
 		}
 
-		spv::Id variable_id = create_variable(spv::StorageClassInput, type_id, variable_name.c_str());
+		spv::Id variable_id = create_variable(masked_input ? spv::StorageClassPrivate : spv::StorageClassInput, type_id,
+		                                      variable_name.c_str());
 		input_elements_meta[element_id] = { variable_id, actual_element_type, system_value != DXIL::Semantic::User ? start_row : 0, system_value };
 
 		if (per_vertex)
 		{
 			if (options.khr_barycentrics_enabled)
+			{
 				builder.addExtension("SPV_KHR_fragment_shader_barycentric");
+				builder.addCapability(spv::CapabilityFragmentBarycentricKHR);
+				builder.addDecoration(variable_id, spv::DecorationPerVertexKHR);
+			}
 			else
-				builder.addExtension("SPV_NV_fragment_shader_barycentric");
-			builder.addCapability(spv::CapabilityFragmentBarycentricKHR);
-			builder.addDecoration(variable_id, spv::DecorationPerVertexKHR);
+			{
+				builder.addExtension("SPV_AMD_shader_explicit_vertex_parameter");
+				builder.addDecoration(variable_id, spv::DecorationExplicitInterpAMD);
+			}
 		}
 
 		if (effective_element_type != actual_element_type && component_type_is_16bit(actual_element_type))

--- a/opcodes/dxil/dxil_resources.cpp
+++ b/opcodes/dxil/dxil_resources.cpp
@@ -114,6 +114,55 @@ static spv::Id get_builtin_load_type(Converter::Impl &impl, const Converter::Imp
 		return impl.get_effective_input_output_type_id(meta.component_type);
 }
 
+static bool emit_amd_bary_coord_load(Converter::Impl &impl, const llvm::CallInst *instruction, spv::Id var_id)
+{
+	auto &builder = impl.builder();
+
+	uint32_t col = 0;
+	if (!get_constant_operand(instruction, 3, &col) || col > 2)
+	{
+		LOGE("Bary coord index must be constant {0, 1, 2}.\n");
+		return false;
+	}
+
+	/* Need to swizzle the bary coord appropriately. */
+	auto *bary = impl.allocate(spv::OpLoad, builder.makeVectorType(builder.makeFloatType(32), 2));
+	bary->add_id(var_id);
+	impl.add(bary);
+
+	if (col >= 1)
+	{
+		auto *ext = impl.allocate(spv::OpCompositeExtract, instruction);
+		ext->add_id(bary->id);
+		ext->add_literal(col - 1);
+		impl.add(ext);
+	}
+	else
+	{
+		auto *bary_i = impl.allocate(spv::OpCompositeExtract, builder.makeFloatType(32));
+		bary_i->add_id(bary->id);
+		bary_i->add_literal(0);
+		impl.add(bary_i);
+
+		auto *bary_j = impl.allocate(spv::OpCompositeExtract, builder.makeFloatType(32));
+		bary_j->add_id(bary->id);
+		bary_j->add_literal(1);
+		impl.add(bary_j);
+
+		auto *sub_i = impl.allocate(spv::OpFSub, builder.makeFloatType(32));
+		sub_i->add_id(builder.makeFloatConstant(1.0f));
+		sub_i->add_id(bary_i->id);
+		impl.add(sub_i);
+
+		auto *sub_j = impl.allocate(spv::OpFSub, instruction);
+		sub_j->add_id(sub_i->id);
+		sub_j->add_id(bary_j->id);
+		impl.add(sub_j);
+	}
+
+	return true;
+}
+
 bool emit_load_input_instruction(Converter::Impl &impl, const llvm::CallInst *instruction, bool spirv_semantics)
 {
 	auto &builder = impl.builder();
@@ -130,6 +179,18 @@ bool emit_load_input_instruction(Converter::Impl &impl, const llvm::CallInst *in
 	uint32_t var_id = meta.id;
 	uint32_t ptr_id;
 
+	if (impl.options.quirks.ignore_primitive_shading_rate && meta.semantic == DXIL::Semantic::ShadingRate)
+	{
+		impl.rewrite_value(instruction, builder.makeUintConstant(0));
+		return true;
+	}
+	else if ((meta.semantic == DXIL::Semantic::Barycentrics ||
+	          meta.semantic == DXIL::Semantic::InternalBarycentricsNoPerspective) &&
+	         !impl.options.khr_barycentrics_enabled)
+	{
+		return emit_amd_bary_coord_load(impl, instruction, var_id);
+	}
+
 	spv::Id input_type_id = builder.getDerefTypeId(var_id);
 
 	bool array_index = false;
@@ -141,7 +202,8 @@ bool emit_load_input_instruction(Converter::Impl &impl, const llvm::CallInst *in
 		if (impl.execution_model == spv::ExecutionModelTessellationControl ||
 		    impl.execution_model == spv::ExecutionModelGeometry ||
 		    impl.execution_model == spv::ExecutionModelTessellationEvaluation ||
-		    impl.llvm_attribute_at_vertex_indices.count(input_element_index) != 0)
+		    (impl.llvm_attribute_at_vertex_indices.count(input_element_index) != 0 &&
+		     impl.options.khr_barycentrics_enabled))
 		{
 			input_type_id = builder.getContainedTypeId(input_type_id);
 			array_index = true;
@@ -193,9 +255,34 @@ bool emit_load_input_instruction(Converter::Impl &impl, const llvm::CallInst *in
 	// Need to deal with signed vs unsigned here.
 	spv::Id load_type = get_builtin_load_type(impl, meta);
 
-	Operation *op = impl.allocate(spv::OpLoad, instruction, load_type);
-	op->add_id(ptr_id);
-	impl.add(op);
+	if (impl.llvm_attribute_at_vertex_indices.count(input_element_index) != 0 &&
+		!impl.options.khr_barycentrics_enabled)
+	{
+		builder.addCapability(spv::CapabilityInterpolationFunction);
+		constexpr uint32_t InterpolateAtVertexAMD = 1;
+		spv::Id ext_id = builder.import("SPV_AMD_shader_explicit_vertex_parameter");
+		auto *op = impl.allocate(spv::OpExtInst, instruction, load_type);
+		op->add_id(ext_id);
+		op->add_literal(InterpolateAtVertexAMD);
+		op->add_id(ptr_id);
+
+		uint32_t vid = 0;
+		if (!llvm::isa<llvm::UndefValue>(instruction->getOperand(4)) &&
+		    (!get_constant_operand(instruction, 4, &vid) || vid > 2))
+		{
+			LOGE("InterpolateAtVertexAMD only takes constant vid {0, 1, 2}.\n");
+			return false;
+		}
+
+		op->add_id(builder.makeUintConstant(vid));
+		impl.add(op);
+	}
+	else
+	{
+		auto *op = impl.allocate(spv::OpLoad, instruction, load_type);
+		op->add_id(ptr_id);
+		impl.add(op);
+	}
 
 	fixup_builtin_load(impl, var_id, instruction, spirv_semantics);
 


### PR DESCRIPTION
Drop NV_barycentrics. It's completely irrelevant these days. Ignore ShadingRate in fragment shader too if that quirk is enabled.