### PR TITLE
Update dxbc-spirv

### DIFF
--- a/bc/module_dxbc_ir.cpp
+++ b/bc/module_dxbc_ir.cpp
@@ -613,7 +613,6 @@ private:
 	bool build_gep_store(const ir::Op &op);
 	bool build_composite_construct(const ir::Op &op);
 	bool build_composite_extract(const ir::Op &op);
-	bool build_composite_insert(const ir::Op &op);
 	bool build_descriptor_load(const ir::Op &op);
 	bool build_buffer_load(const ir::Op &op);
 	bool build_buffer_load_cbv(const ir::Op &op);
@@ -1309,14 +1308,6 @@ bool ParseContext::build_composite_extract(const ir::Op &op)
 	return true;
 }
 
-bool ParseContext::build_composite_insert(const ir::Op &op)
-{
-	auto *inst = context.construct<InsertElementInst>(
-	    get_value(op.getOperand(0)), get_value(op.getOperand(2)), get_value(op.getOperand(1)));
-	push_instruction(inst, op.getDef());
-	return true;
-}
-
 bool ParseContext::build_descriptor_load(const ir::Op &op)
 {
 	auto descriptor = ir::SsaDef(op.getOperand(0));
@@ -1540,7 +1531,6 @@ bool ParseContext::push_instruction(const ir::Op &op)
 	OPMAP(OutputStore, output_store);
 	OPMAP(CompositeConstruct, composite_construct);
 	OPMAP(CompositeExtract, composite_extract);
-	OPMAP(CompositeInsert, composite_insert);
 	OPMAP(DescriptorLoad, descriptor_load);
 	OPMAP(BufferLoad, buffer_load);
 	OPMAP(BufferStore, buffer_store);
@@ -3632,6 +3622,7 @@ bool ParseContext::emit_function_bodies()
 		case ir::OpCode::eDclSpecConstant:
 		case ir::OpCode::eDclPushData:
 		case ir::OpCode::eDclTmp:
+		case ir::OpCode::eDclInputTarget:
 		case ir::OpCode::eScopedIf:
 		case ir::OpCode::eScopedElse:
 		case ir::OpCode::eScopedEndIf:
@@ -3651,6 +3642,7 @@ bool ParseContext::emit_function_bodies()
 		case ir::OpCode::eMemoryLoad:
 		case ir::OpCode::eMemoryStore:
 		case ir::OpCode::eMemoryAtomic:
+		case ir::OpCode::eInputTargetLoad:
 		case ir::OpCode::ePointer:
 		case ir::OpCode::eFMulLegacy:
 		case ir::OpCode::eFMadLegacy:

--- a/meson.build
+++ b/meson.build
@@ -90,7 +90,13 @@ dxil_spirv_src = [
   'debug/logging.cpp',
 ]
 
-dxbc_spirv = subproject('dxbc-spirv')
+dxbc_spirv_options = {
+  'enable_sm3'    : false,
+  'enable_sm5'    : true,
+  'enable_spirv'  : false,
+}
+
+dxbc_spirv = subproject('dxbc-spirv', default_options : dxbc_spirv_options)
 
 dxbc_spirv_include_dirs = include_directories([
   'subprojects/dxbc-spirv'

--- a/reference-dxbc/test_resource_rov.asm
+++ b/reference-dxbc/test_resource_rov.asm
@@ -2,7 +2,7 @@ SPIR-V:
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 44
+; Bound: 40
 ; Schema: 0
                OpCapability Shader
                OpCapability StorageImageWriteWithoutFormat
@@ -40,9 +40,9 @@ SPIR-V:
        %main = OpFunction %void None %2
 
           %4 = OpLabel
-                 OpBranch %42
+                 OpBranch %38
 
-         %42 = OpLabel
+         %38 = OpLabel
          %12 =   OpLoad %6 %8
          %14 =   OpAccessChain %_ptr_Input_float %_ %uint_1
          %17 =   OpLoad %float %14
@@ -57,16 +57,10 @@ SPIR-V:
          %29 =   OpCompositeExtract %float %25 1
          %30 =   OpCompositeExtract %float %25 2
          %31 =   OpCompositeExtract %float %25 3
-         %32 =   OpCompositeConstruct %v4float %28 %29 %30 %31
          %33 =   OpFMul %float %28 %float_2
-         %35 =   OpCompositeInsert %v4float %33 %32 0
-         %36 =   OpCompositeExtract %float %35 0
-         %37 =   OpCompositeExtract %float %35 1
-         %38 =   OpCompositeExtract %float %35 2
-         %39 =   OpCompositeExtract %float %35 3
-         %40 =   OpCompositeConstruct %v2uint %22 %18
-         %41 =   OpCompositeConstruct %v4float %36 %37 %38 %39
-                 OpImageWrite %12 %40 %41 MakeTexelAvailable|NonPrivateTexel %uint_5
+         %36 =   OpCompositeConstruct %v2uint %22 %18
+         %37 =   OpCompositeConstruct %v4float %33 %29 %30 %31
+                 OpImageWrite %12 %36 %37 MakeTexelAvailable|NonPrivateTexel %uint_5
                  OpEndInvocationInterlockEXT
                  OpReturn
                OpFunctionEnd

--- a/reference-dxbc/test_resource_rov.glsl
+++ b/reference-dxbc/test_resource_rov.glsl
@@ -23,10 +23,7 @@ void main()
     uint _22 = uint(int(gl_FragCoord.x));
     SPIRV_Cross_beginInvocationInterlock();
     vec4 _25 = imageLoad(_8, ivec2(uvec2(_22, _18)));
-    float _28 = _25.x;
-    vec4 _32 = vec4(_28, _25.yzw);
-    _32.x = _28 * 2.0;
-    imageStore(_8, ivec2(uvec2(_22, _18)), vec4(_32));
+    imageStore(_8, ivec2(uvec2(_22, _18)), vec4(_25.x * 2.0, _25.yzw));
     SPIRV_Cross_endInvocationInterlock();
 }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -137,6 +137,8 @@ target_include_directories(dxbc-spirv
 target_include_directories(dxbc-spirv-test PUBLIC ${DXBC_SPV_SOURCE_DIR}/tests)
 target_compile_features(dxbc-spirv PUBLIC cxx_std_17)
 target_compile_features(dxbc-spirv-test PUBLIC cxx_std_17)
+target_compile_definitions(dxbc-spirv PUBLIC "DXBC_SPV_ENABLE_SM5")
+target_compile_definitions(dxbc-spirv-test PUBLIC "DXBC_SPV_ENABLE_SM5")
 set_target_properties(dxbc-spirv PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
     target_compile_options(dxbc-spirv PRIVATE -fvisibility=hidden)


### PR DESCRIPTION
Couple things have changed:
- SM3 bring-up is done so all the compiler warnings coming from that should be gone
- Code gen has changed a bit again because we fix up a bunch of non-`precise` SM3 floor/ceil/trunc patterns (at least the floor pattern is somewhat prevalent even in SM5 content), some stupid comparison patterns, and some boolean stuff involving floats.
- The IR now supports input attachments, but we ignore that here, it's only used for some DXVK internals.
- `CompositeInsert` was nuked out of existence.

Tested with test suite, Death Stranding, Dead Space, Yumia and a whole bunch of D3D11 stuff.

Edit: Should actually figure out how to build w/o SM3 and spir-v code with meson to speed up compile times.