### PR TITLE
Fix call argument iteration with native LLVM

### DIFF
--- a/bc/instruction.hpp
+++ b/bc/instruction.hpp
@@ -181,6 +181,10 @@ public:
 	CallInst(FunctionType *function_type, Function *callee, Vector<Value *> params);
 	Function *getCalledFunction() const;
 
+	// LLVM stores callee as the last operand. LLVM API exposes these functions to handle arguments propely.
+	unsigned getNumArgOperands() const { return getNumOperands(); }
+	Value *getArgOperand(unsigned index) const { return getOperand(index); }
+
 	LLVMBC_DEFAULT_VALUE_KIND_IMPL
 
 private:

--- a/opcodes/dxil/dxil_sampling.cpp
+++ b/opcodes/dxil/dxil_sampling.cpp
@@ -2201,7 +2201,7 @@ static spv::Id emit_accessed_lod(DXIL::Op opcode, Converter::Impl &impl, const l
 		// Normally, that clamp value will be integer, which should be fine.
 		// This comes after [0, levels - 1] clamp, since if we clamp LOD to out of bounds of view,
 		// we end up accessing OOB.
-		auto *clamp_value = instruction->getOperand(instruction->getNumOperands() - 1);
+		auto *clamp_value = instruction->getArgOperand(instruction->getNumArgOperands() - 1);
 		if (!llvm::isa<llvm::UndefValue>(clamp_value))
 		{
 			auto *clamp_lod = impl.allocate(spv::OpExtInst, f32_type);

--- a/opcodes/opcodes_llvm_builtins.cpp
+++ b/opcodes/opcodes_llvm_builtins.cpp
@@ -2782,8 +2782,8 @@ bool emit_call_instruction(Converter::Impl &impl, const llvm::CallInst &inst)
 {
 	auto *call = impl.allocate(spv::OpFunctionCall, &inst);
 	call->add_id(impl.get_id_for_value(inst.getCalledFunction()));
-	for (uint32_t i = 0; i < inst.getNumOperands(); i++)
-		call->add_id(impl.get_id_for_value(inst.getOperand(i)));
+	for (uint32_t i = 0; i < inst.getNumArgOperands(); i++)
+		call->add_id(impl.get_id_for_value(inst.getArgOperand(i)));
 	impl.add(call);
 	return true;
 }


### PR DESCRIPTION
CallInst operand layout differs between the two BC parsers.

* The native LLVM stores the callee as the trailing operand.
* The built-in BC parser keeps the callee in a separate field so its operands are exactly the call arguments.

Add getNumArgOperands()/getArgOperand() to the CallInst, mirroring the LLVM API, and use them in relevant places so the argument range is correct regardless of which parser is compiled in.