### PR TITLE
Fix OMM issue with RayQuery

### DIFF
--- a/dxil_converter.cpp
+++ b/dxil_converter.cpp
@@ -7236,8 +7236,9 @@ bool Converter::Impl::emit_execution_modes_ray_query()
 		builder.addCapability(spv::CapabilityRayTraversalPrimitiveCullingKHR);
 
 		bool omm_possible =
-				(options.opacity_micromap_enabled && options.ray_query_force_omm_execution_mode) ||
-				shader_analysis.ray_query.requires_opacity_micromap_tracing;
+				options.opacity_micromap_enabled &&
+				(options.ray_query_force_omm_execution_mode ||
+				 shader_analysis.ray_query.requires_opacity_micromap_tracing);
 
 		if (omm_possible)
 		{
@@ -7264,7 +7265,8 @@ bool Converter::Impl::emit_execution_modes_ray_tracing()
 	if (options.ray_tracing_primitive_culling_enabled && shader_analysis.can_require_primitive_culling)
 		builder.addCapability(spv::CapabilityRayTraversalPrimitiveCullingKHR);
 
-	if ((options.opacity_micromap_enabled || shader_analysis.ray_query.requires_opacity_micromap_tracing) &&
+	if (options.opacity_micromap_enabled &&
+		(options.opacity_micromap_rtpso_has_omm || shader_analysis.ray_query.requires_opacity_micromap_tracing) &&
 		shader_analysis.can_require_opacity_micromap)
 	{
 		emit_opacity_micromap_capability(*this);
@@ -9547,6 +9549,8 @@ void Converter::Impl::set_option(const OptionBase &cap)
 		    static_cast<const OptionOpacityMicromap &>(cap).enabled;
 		options.ray_query_force_omm_execution_mode =
 		    static_cast<const OptionOpacityMicromap &>(cap).ray_query_force_omm_execution_mode;
+		options.opacity_micromap_rtpso_has_omm =
+		    static_cast<const OptionOpacityMicromap &>(cap).rtpso_has_omm;
 		break;
 
 	case Option::BranchControl:

--- a/dxil_converter.hpp
+++ b/dxil_converter.hpp
@@ -274,8 +274,9 @@ enum class Option : uint32_t
 	MixedDotProduct = 50,
 	ComputeShaderDerivativesQuad = 51,
 	SSBOAddressingBehavior = 52,
-	OpacityMicromap = 53,
+	// Older OpacityMicromap. It was never used by vkd3d-proton and has been retired.
 	FloatControls2 = 54,
+	OpacityMicromap = 55,
 	Count
 };
 
@@ -638,11 +639,14 @@ struct OptionOpacityMicromap : OptionBase
 	{
 	}
 
-	// Flags if SPV_KHR_opacity_micromap is supported and enabled for the pipeline in question, i.e.
+	// Flags if SPV_KHR_opacity_micromap is supported
+	bool enabled = false;
+
+	// Flags if the pipeline in question supports OMM, i.e.
 	// D3D12_RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS.
 	// If ForceOpacityMicromap2StateKHR can potentially be used with this enabled,
 	// CapabilityRayTracingOpacityMicromapKHR is turned on.
-	bool enabled = false;
+	bool rtpso_has_omm = false;
 
 	// In Ray Query with KHR_omm,
 	// accessing OMMs without appropriate execution modes is UB.
@@ -653,7 +657,7 @@ struct OptionOpacityMicromap : OptionBase
 	// - Force it with this flag. It will present that every RayQuery object is marked with the SM 6.9 flag.
 	//   This flag is intended to be used with NVAPI OMM,
 	//   but also to workaround potential UB scenarios apps will introduce in the wild.
-	//   Enabled must also be set for this to take effect.
+	//   `enabled` must also be set for this to take effect.
 	bool ray_query_force_omm_execution_mode = false;
 };
 

--- a/dxil_spirv.cpp
+++ b/dxil_spirv.cpp
@@ -249,6 +249,7 @@ struct Arguments
 	bool force_precise = false;
 	bool opacity_micromap = false;
 	bool ray_query_force_omm = false;
+	bool rtpso_has_omm = false;
 	bool force_flatten = false;
 	bool force_loop = false;
 	bool force_branch = false;
@@ -869,6 +870,9 @@ int main(int argc, char **argv)
 	cbs.add("--ray-query-force-opacity-micromap", [&](CLIParser &) {
 		args.ray_query_force_omm = true;
 	});
+	cbs.add("--rtpso-has-opacity-micromap", [&](CLIParser &) {
+		args.rtpso_has_omm = true;
+	});
 	cbs.add("--force-flatten", [&](CLIParser &) {
 		args.force_flatten = true;
 	});
@@ -1215,6 +1219,7 @@ int main(int argc, char **argv)
 		const dxil_spv_option_opacity_micromap omm = {
 			{ DXIL_SPV_OPTION_OPACITY_MICROMAP },
 			args.opacity_micromap ? DXIL_SPV_TRUE : DXIL_SPV_FALSE,
+			args.rtpso_has_omm ? DXIL_SPV_TRUE : DXIL_SPV_FALSE,
 			args.ray_query_force_omm ? DXIL_SPV_TRUE : DXIL_SPV_FALSE
 		};
 		dxil_spv_converter_add_option(converter, &omm.base);

--- a/dxil_spirv_c.cpp
+++ b/dxil_spirv_c.cpp
@@ -1264,6 +1264,7 @@ dxil_spv_result dxil_spv_converter_add_option(dxil_spv_converter converter, cons
 		auto *omm = reinterpret_cast<const dxil_spv_option_opacity_micromap *>(option);
 		helper.enabled = omm->enabled;
 		helper.ray_query_force_omm_execution_mode = omm->ray_query_force_omm_execution_mode;
+		helper.rtpso_has_omm = omm->rtpso_has_omm;
 
 		converter->options.emplace_back(duplicate(helper));
 		break;

--- a/dxil_spirv_c.h
+++ b/dxil_spirv_c.h
@@ -493,8 +493,9 @@ typedef enum dxil_spv_option
 	DXIL_SPV_OPTION_MIXED_FLOAT_DOT_PRODUCT = 50,
 	DXIL_SPV_OPTION_COMPUTE_SHADER_DERIVATIVES_QUAD = 51,
 	DXIL_SPV_OPTION_SSBO_ADDRESSING_BEHAVIOR = 52,
-	DXIL_SPV_OPTION_OPACITY_MICROMAP = 53,
+	/* 53 = older KHR opacity micromap option that was never used by vkd3d-proton. */
 	DXIL_SPV_OPTION_FLOAT_CONTROLS_2 = 54,
+	DXIL_SPV_OPTION_OPACITY_MICROMAP = 55,
 	DXIL_SPV_OPTION_INT_MAX = 0x7fffffff
 } dxil_spv_option;
 
@@ -737,6 +738,7 @@ typedef struct dxil_spv_option_opacity_micromap
 {
 	dxil_spv_option_base base;
 	dxil_spv_bool enabled;
+	dxil_spv_bool rtpso_has_omm;
 	dxil_spv_bool ray_query_force_omm_execution_mode;
 } dxil_spv_option_opacity_micromap;
 

--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -776,6 +776,7 @@ struct Converter::Impl
 			bool assume_uniform_scale = false;
 		} grad_opt;
 		bool opacity_micromap_enabled = false;
+		bool opacity_micromap_rtpso_has_omm = false;
 		unsigned physical_address_descriptor_stride = 1;
 		unsigned physical_address_descriptor_offset = 0;
 		unsigned force_subgroup_size = 0;

--- a/test_shaders.py
+++ b/test_shaders.py
@@ -282,8 +282,10 @@ def cross_compile_dxil(shader, args, paths, is_asm):
         hlsl_cmd += ['--mixed-float-dot-product']
     if is_asm or ('.assume-32bit-wrap.' in shader):
         hlsl_cmd += ['--assume-ssbo-32bit-wrapping']
-    if '.omm.' in shader:
+    if '.omm.' in shader or '.rq-omm.' in shader:
         hlsl_cmd += ['--opacity-micromap']
+    if '.omm.' in shader:
+        hlsl_cmd += ['--rtpso-has-opacity-micromap']
     if '.rq-omm.' in shader:
         hlsl_cmd += ['--ray-query-force-opacity-micromap']
 


### PR DESCRIPTION
The enabled flag has to be independent of if the shader's pipeline object enable OMM.