### PR TITLE
Add support for SM 6.9 HitObject instructions used by SER

### DIFF
--- a/opcodes/converter_impl.hpp
+++ b/opcodes/converter_impl.hpp
@@ -1076,5 +1076,11 @@ struct Converter::Impl
 
 	static NodeInputData get_node_input(llvm::MDNode *meta);
 	static NodeOutputData get_node_output(llvm::MDNode *meta);
+
+	struct
+	{
+		spv::Id shader_record_buffer_ptr = 0;
+		spv::Id shader_record_buffer_member_ptr = 0;
+	} hit_object;
 };
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -845,4 +845,29 @@ bool emit_hit_object_make_nop_instruction(Converter::Impl &impl, const llvm::Cal
 	return true;
 }
 
+bool emit_hit_object_invoke_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(inst->getOperand(1));
+	auto *ray_payload = inst->getOperand(2);
+
+	bool needs_temp_copy = impl.get_needs_temp_storage_copy(ray_payload);
+	spv::Id ray_payload_var_id = needs_temp_copy
+		? emit_temp_storage_copy(impl, ray_payload, spv::StorageClassRayPayloadKHR)
+		: impl.get_id_for_value(ray_payload);
+
+	auto *op = impl.allocate(spv::OpHitObjectExecuteShaderEXT);
+	op->add_ids({
+	    hit_object,
+	    ray_payload_var_id
+	});
+	impl.add(op);
+
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -892,4 +892,64 @@ bool emit_maybe_reoder_thread_instruction(Converter::Impl &impl, const llvm::Cal
 	return true;
 }
 
+bool emit_hit_object_get_value_instruction(Converter::Impl &impl, const llvm::CallInst *instruction,
+                                           spv::Op opcode, uint32_t vecsize)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(instruction->getOperand(1));
+
+	if (vecsize == 1)
+	{
+		auto *op = impl.allocate(opcode, instruction);
+		op->add_id(hit_object);
+		impl.add(op);
+	}
+	else
+	{
+		auto *op = impl.allocate(opcode, builder.makeVectorType(impl.get_type_id(instruction->getType()), vecsize));
+		op->add_id(hit_object);
+		impl.add(op);
+		auto *extract_op = impl.allocate(spv::OpCompositeExtract, instruction);
+		extract_op->add_id(op->id);
+
+		uint32_t index = 0;
+		if (!get_constant_operand(instruction, 2, &index))
+			return false;
+		extract_op->add_literal(index);
+		impl.add(extract_op);
+	}
+	return true;
+}
+
+bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, const llvm::CallInst *instruction,
+                                                  spv::Op opcode)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(instruction->getOperand(1));
+
+	auto *op = impl.allocate(opcode, builder.makeMatrixType(impl.get_type_id(instruction->getType()), 4, 3));
+	op->add_id(hit_object);
+	impl.add(op);
+
+	auto *extract_op = impl.allocate(spv::OpCompositeExtract, instruction);
+	uint32_t row = 0, col = 0;
+	if (!get_constant_operand(instruction, 2, &row))
+		return false;
+	if (!get_constant_operand(instruction, 3, &col))
+		return false;
+	extract_op->add_id(op->id);
+	extract_op->add_literal(col);
+	extract_op->add_literal(row);
+	impl.add(extract_op);
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -973,4 +973,70 @@ bool emit_hit_object_set_shader_table_index_instruction(Converter::Impl &impl, c
 	impl.rewrite_value(instruction, hit_object);
 	return true;
 }
+
+bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl &impl,
+                                                                const llvm::CallInst *instruction)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(instruction->getOperand(1));
+	spv::Id offset = impl.get_id_for_value(instruction->getOperand(2));
+
+	spv::Id uint32 = builder.makeUintType(32);
+	spv::Id uint64 = builder.makeUintType(64);
+
+	if (!impl.hit_object.shader_record_buffer_ptr)
+	{
+		spv::Id srb_struct = builder.makeStructType({ uint32 }, "HitObjectSRB");
+
+		builder.addDecoration(srb_struct, spv::DecorationBlock);
+		builder.addDecoration(srb_struct, spv::DecorationHitObjectShaderRecordBufferEXT);
+
+		builder.addMemberDecoration(srb_struct, 0, spv::DecorationOffset, 0);
+		builder.addMemberDecoration(srb_struct, 0, spv::DecorationNonWritable);
+
+		impl.hit_object.shader_record_buffer_ptr = builder.makePointer(spv::StorageClassPhysicalStorageBuffer, srb_struct);
+		impl.hit_object.shader_record_buffer_member_ptr = builder.makePointer(spv::StorageClassPhysicalStorageBuffer, uint32);
+	}
+
+	auto *op = impl.allocate(spv::OpHitObjectGetShaderRecordBufferHandleEXT, builder.makeVectorType(uint32, 2));
+	op->add_id(hit_object);
+	impl.add(op);
+
+	auto *cast_op = impl.allocate(spv::OpBitcast, uint64);
+	cast_op->add_id(op->id);
+	impl.add(cast_op);
+
+	auto *convert_op = impl.allocate(spv::OpUConvert, uint64);
+	convert_op->add_id(offset);
+	impl.add(convert_op);
+
+	auto *add_op = impl.allocate(spv::OpIAdd, uint64);
+	add_op->add_id(cast_op->id);
+	add_op->add_id(convert_op->id);
+	impl.add(add_op);
+
+	convert_op = impl.allocate(spv::OpConvertUToPtr, impl.hit_object.shader_record_buffer_ptr);
+	convert_op->add_id(add_op->id);
+	impl.add(convert_op);
+
+	auto *chain_op = impl.allocate(spv::OpAccessChain, impl.hit_object.shader_record_buffer_member_ptr);
+	chain_op->add_id(convert_op->id);
+	chain_op->add_id(builder.makeUintConstant(0));
+	impl.add(chain_op);
+
+	auto *load_op = impl.allocate(spv::OpLoad, uint32);
+	load_op->add_id(chain_op->id);
+	load_op->add_literal(spv::MemoryAccessAlignedMask);
+	load_op->add_literal(sizeof(uint32_t));
+	impl.add(load_op);
+
+	impl.rewrite_value(instruction, load_op->id);
+	return true;
+
+	return true;
+}
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -727,4 +727,60 @@ bool emit_hit_object_trace_ray_instruction(Converter::Impl &impl, const llvm::Ca
 	return true;
 }
 
+bool emit_hit_object_from_ray_query_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id ray_query = impl.get_id_for_value(inst->getOperand(1));
+
+	spv::Id hit_object = impl.create_variable(spv::StorageClassFunction, builder.makeHitObjectType());
+	spv::Id sbt_record_index = builder.makeUintConstant(0);
+	spv::Id empty_attributes = impl.create_variable(spv::StorageClassHitObjectAttributeEXT, builder.makeVoidType());
+
+	auto *op = impl.allocate(spv::OpHitObjectRecordFromQueryEXT);
+	op->add_ids({
+	    hit_object,
+		ray_query,
+		sbt_record_index,
+		empty_attributes
+	});
+	impl.add(op);
+
+	impl.rewrite_value(inst, hit_object);
+
+	return true;
+}
+
+bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id ray_query = impl.get_id_for_value(inst->getOperand(1));
+	spv::Id hit_kind = impl.get_id_for_value(inst->getOperand(2));
+	spv::Id attributes = impl.get_id_for_value(inst->getOperand(3));
+
+	spv::Id hit_object = impl.create_variable(spv::StorageClassFunction, builder.makeHitObjectType());
+	spv::Id sbt_record_index = builder.makeUintConstant(0);
+
+	auto *op = impl.allocate(spv::OpHitObjectRecordFromQueryEXT);
+	op->add_ids({
+	    hit_object,
+		ray_query,
+		sbt_record_index,
+		attributes,
+		hit_kind
+	});
+	impl.add(op);
+
+	impl.rewrite_value(inst, hit_object);
+
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -827,4 +827,22 @@ bool emit_hit_object_make_miss_instruction(Converter::Impl &impl, const llvm::Ca
 	return true;
 }
 
+bool emit_hit_object_make_nop_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.create_variable(spv::StorageClassFunction, builder.makeHitObjectType());
+
+	auto *op = impl.allocate(spv::OpHitObjectRecordEmptyEXT);
+	op->add_id(hit_object);
+	impl.add(op);
+
+	impl.rewrite_value(inst, hit_object);
+
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -986,11 +986,13 @@ bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl 
 	spv::Id offset = impl.get_id_for_value(instruction->getOperand(2));
 
 	spv::Id uint32 = builder.makeUintType(32);
-	spv::Id uint64 = builder.makeUintType(64);
 
 	if (!impl.hit_object.shader_record_buffer_ptr)
 	{
-		spv::Id srb_struct = builder.makeStructType({ uint32 }, "HitObjectSRB");
+		spv::Id srb_array = builder.makeRuntimeArray(uint32);
+		builder.addDecoration(srb_array, spv::DecorationArrayStride, sizeof(uint32_t));
+
+		spv::Id srb_struct = builder.makeStructType({ srb_array }, "HitObjectSRB");
 
 		builder.addDecoration(srb_struct, spv::DecorationBlock);
 		builder.addDecoration(srb_struct, spv::DecorationHitObjectShaderRecordBufferEXT);
@@ -1006,26 +1008,23 @@ bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl 
 	op->add_id(hit_object);
 	impl.add(op);
 
-	auto *cast_op = impl.allocate(spv::OpBitcast, uint64);
+	auto *cast_op = impl.allocate(spv::OpBitcast, builder.makeUintType(64));
 	cast_op->add_id(op->id);
 	impl.add(cast_op);
 
-	auto *convert_op = impl.allocate(spv::OpUConvert, uint64);
-	convert_op->add_id(offset);
+	auto *convert_op = impl.allocate(spv::OpConvertUToPtr, impl.hit_object.shader_record_buffer_ptr);
+	convert_op->add_id(cast_op->id);
 	impl.add(convert_op);
 
-	auto *add_op = impl.allocate(spv::OpIAdd, uint64);
-	add_op->add_id(cast_op->id);
-	add_op->add_id(convert_op->id);
-	impl.add(add_op);
+	auto *index_op = impl.allocate(spv::OpShiftRightLogical, uint32);
+	index_op->add_id(offset);
+	index_op->add_id(builder.makeUintConstant(2));
+	impl.add(index_op);
 
-	convert_op = impl.allocate(spv::OpConvertUToPtr, impl.hit_object.shader_record_buffer_ptr);
-	convert_op->add_id(add_op->id);
-	impl.add(convert_op);
-
-	auto *chain_op = impl.allocate(spv::OpAccessChain, impl.hit_object.shader_record_buffer_member_ptr);
+	auto *chain_op = impl.allocate(spv::OpInBoundsAccessChain, impl.hit_object.shader_record_buffer_member_ptr);
 	chain_op->add_id(convert_op->id);
 	chain_op->add_id(builder.makeUintConstant(0));
+	chain_op->add_id(index_op->id);
 	impl.add(chain_op);
 
 	auto *load_op = impl.allocate(spv::OpLoad, uint32);
@@ -1035,8 +1034,6 @@ bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl 
 	impl.add(load_op);
 
 	impl.rewrite_value(instruction, load_op->id);
-	return true;
-
 	return true;
 }
 

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -952,4 +952,25 @@ bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, const l
 	return true;
 }
 
+bool emit_hit_object_set_shader_table_index_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(instruction->getOperand(1));
+	spv::Id shader_table_index = impl.get_id_for_value(instruction->getOperand(2));
+
+	auto *op = impl.allocate(spv::OpHitObjectSetShaderBindingTableRecordIndexEXT);
+	op->add_ids({
+	    hit_object,
+	    shader_table_index
+	});
+	impl.add(op);
+	// HitObject_SetShaderTableIndex returns new hit object, but OpHitObjectSetShaderBindingTableRecordIndexEXT does not
+	// Remap output to input.
+	impl.rewrite_value(instruction, hit_object);
+	return true;
+}
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -783,4 +783,48 @@ bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl
 	return true;
 }
 
+bool emit_hit_object_make_miss_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.create_variable(spv::StorageClassFunction, builder.makeHitObjectType());
+
+	spv::Id ray_flags = impl.get_id_for_value(inst->getOperand(1));
+	spv::Id miss_shader_index = impl.get_id_for_value(inst->getOperand(2));
+
+	spv::Id ray_origin[3];
+	spv::Id ray_dir[3];
+
+	for (unsigned i = 0; i < 3; i++)
+	{
+		ray_origin[i] = impl.get_id_for_value(inst->getOperand(3 + i));
+		ray_dir[i] = impl.get_id_for_value(inst->getOperand(7 + i));
+	}
+
+	spv::Id tmin = impl.get_id_for_value(inst->getOperand(6));
+	spv::Id tmax = impl.get_id_for_value(inst->getOperand(10));
+
+	spv::Id ray_origin_vec = impl.build_vector(builder.makeFloatType(32), ray_origin, 3);
+	spv::Id ray_dir_vec = impl.build_vector(builder.makeFloatType(32), ray_dir, 3);
+
+	auto *op = impl.allocate(spv::OpHitObjectRecordMissEXT);
+	op->add_ids({
+	    hit_object,
+	    ray_flags,
+	    miss_shader_index,
+	    ray_origin_vec,
+	    tmin,
+	    ray_dir_vec,
+	    tmax,
+	});
+	impl.add(op);
+
+	impl.rewrite_value(inst, hit_object);
+
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -662,4 +662,69 @@ bool emit_ray_query_candidate_procedural_primitive_non_opaque_instruction(Conver
 	impl.add(not_op);
 	return true;
 }
+
+bool emit_hit_object_trace_ray_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id acceleration_structure = impl.get_id_for_value(inst->getOperand(1));
+	spv::Id ray_flags = impl.get_id_for_value(inst->getOperand(2));
+	spv::Id instance_inclusion_mask = impl.get_id_for_value(inst->getOperand(3));
+	spv::Id ray_contribution_to_hit_group = impl.get_id_for_value(inst->getOperand(4));
+	spv::Id multiplier_for_geometry = impl.get_id_for_value(inst->getOperand(5));
+	spv::Id miss_shader_index = impl.get_id_for_value(inst->getOperand(6));
+
+	spv::Id ray_origin[3];
+	spv::Id ray_dir[3];
+
+	for (unsigned i = 0; i < 3; i++)
+	{
+		ray_origin[i] = impl.get_id_for_value(inst->getOperand(7 + i));
+		ray_dir[i] = impl.get_id_for_value(inst->getOperand(11 + i));
+	}
+
+	spv::Id tmin = impl.get_id_for_value(inst->getOperand(10));
+	spv::Id tmax = impl.get_id_for_value(inst->getOperand(14));
+
+	spv::Id ray_origin_vec = impl.build_vector(builder.makeFloatType(32), ray_origin, 3);
+	spv::Id ray_dir_vec = impl.build_vector(builder.makeFloatType(32), ray_dir, 3);
+
+	auto *ray_payload = inst->getOperand(15);
+
+	bool needs_temp_copy = impl.get_needs_temp_storage_copy(ray_payload);
+	spv::Id ray_payload_var_id = needs_temp_copy
+		? emit_temp_storage_copy(impl, ray_payload, spv::StorageClassRayPayloadKHR)
+		: impl.get_id_for_value(ray_payload);
+
+	spv::Id hit_object = impl.create_variable(spv::StorageClassFunction, builder.makeHitObjectType());
+
+	auto *op = impl.allocate(spv::OpHitObjectTraceRayEXT);
+	op->add_ids({
+	    hit_object,
+	    acceleration_structure,
+	    ray_flags,
+	    instance_inclusion_mask,
+	    ray_contribution_to_hit_group,
+	    multiplier_for_geometry,
+	    miss_shader_index,
+	    ray_origin_vec,
+	    tmin,
+	    ray_dir_vec,
+	    tmax,
+	    ray_payload_var_id
+	});
+	impl.add(op);
+
+	// In this instance, the ray_payload_var_id is our temp.
+	if (needs_temp_copy)
+		emit_temp_storage_resolve(impl, ray_payload, ray_payload_var_id);
+
+	impl.rewrite_value(inst, hit_object);
+
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -870,4 +870,26 @@ bool emit_hit_object_invoke_instruction(Converter::Impl &impl, const llvm::CallI
 	return true;
 }
 
+bool emit_maybe_reoder_thread_instruction(Converter::Impl &impl, const llvm::CallInst *inst)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(inst->getOperand(1));
+	spv::Id hint = impl.get_id_for_value(inst->getOperand(2));
+	spv::Id bits = impl.get_id_for_value(inst->getOperand(3));
+
+	auto *op = impl.allocate(spv::OpReorderThreadWithHitObjectEXT);
+	op->add_ids({
+		hit_object,
+		hint,
+		bits
+	});
+	impl.add(op);
+
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -1039,4 +1039,24 @@ bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl 
 
 	return true;
 }
+
+bool emit_hit_object_attributes_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
+{
+	auto &builder = impl.builder();
+
+	builder.addExtension("SPV_EXT_shader_invocation_reorder");
+	builder.addCapability(spv::CapabilityShaderInvocationReorderEXT);
+
+	spv::Id hit_object = impl.get_id_for_value(instruction->getOperand(1));
+	spv::Id attributes = impl.get_id_for_value(instruction->getOperand(2));
+
+	auto *op = impl.allocate(spv::OpHitObjectGetAttributesEXT);
+	op->add_ids({
+	    hit_object,
+	    attributes
+	});
+	impl.add(op);
+	return true;
+}
+
 }

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -120,4 +120,6 @@ inline bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, 
 
 bool emit_hit_object_set_shader_table_index_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+bool emit_hit_object_attributes_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 } // namespace dxil_spv
+

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -118,4 +118,6 @@ inline bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, 
 	return emit_hit_object_get_matrix_value_instruction(impl, instruction, opcode);
 }
 
+bool emit_hit_object_set_shader_table_index_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -104,4 +104,18 @@ bool emit_hit_object_make_nop_instruction(Converter::Impl &impl, const llvm::Cal
 bool emit_hit_object_invoke_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_maybe_reoder_thread_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 
+bool emit_hit_object_get_value_instruction(Converter::Impl &impl, const llvm::CallInst *instruction, spv::Op op, uint32_t vecsize);
+template <spv::Op opcode, uint32_t vecsize>
+inline bool emit_hit_object_get_value_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
+{
+	return emit_hit_object_get_value_instruction(impl, instruction, opcode, vecsize);
+}
+
+bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, const llvm::CallInst *instruction, spv::Op op);
+template <spv::Op opcode>
+inline bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
+{
+	return emit_hit_object_get_matrix_value_instruction(impl, instruction, opcode);
+}
+
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -100,5 +100,6 @@ bool emit_hit_object_trace_ray_instruction(Converter::Impl &impl, const llvm::Ca
 bool emit_hit_object_from_ray_query_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
 bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
 bool emit_hit_object_make_miss_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+bool emit_hit_object_make_nop_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -119,5 +119,5 @@ inline bool emit_hit_object_get_matrix_value_instruction(Converter::Impl &impl, 
 }
 
 bool emit_hit_object_set_shader_table_index_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
-
+bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -97,5 +97,7 @@ inline bool emit_ray_query_get_matrix_value_instruction(Converter::Impl &impl, c
 }
 
 bool emit_hit_object_trace_ray_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+bool emit_hit_object_from_ray_query_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
+bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
 
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -99,5 +99,6 @@ inline bool emit_ray_query_get_matrix_value_instruction(Converter::Impl &impl, c
 bool emit_hit_object_trace_ray_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_hit_object_from_ray_query_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
 bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
+bool emit_hit_object_make_miss_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -102,5 +102,6 @@ bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl
 bool emit_hit_object_make_miss_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_hit_object_make_nop_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_hit_object_invoke_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+bool emit_maybe_reoder_thread_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -95,4 +95,7 @@ inline bool emit_ray_query_get_matrix_value_instruction(Converter::Impl &impl, c
 {
 	return emit_ray_query_get_matrix_value_instruction(impl, instruction, opcode, intersection);
 }
+
+bool emit_hit_object_trace_ray_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+
 } // namespace dxil_spv

--- a/opcodes/dxil/dxil_ray_tracing.hpp
+++ b/opcodes/dxil/dxil_ray_tracing.hpp
@@ -101,5 +101,6 @@ bool emit_hit_object_from_ray_query_instruction(Converter::Impl &impl, const llv
 bool emit_hit_object_from_ray_query_with_attrs_instruction(Converter::Impl &impl, const llvm::CallInst *instuction);
 bool emit_hit_object_make_miss_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 bool emit_hit_object_make_nop_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
+bool emit_hit_object_invoke_instruction(Converter::Impl &impl, const llvm::CallInst *instruction);
 
 } // namespace dxil_spv

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -297,6 +297,7 @@ struct DXILDispatcher
 		OP(HitObject_FromRayQueryWithAttrs) = emit_hit_object_from_ray_query_with_attrs_instruction;
 		OP(HitObject_MakeMiss) = emit_hit_object_make_miss_instruction;
 		OP(HitObject_MakeNop) = emit_hit_object_make_nop_instruction;
+		OP(HitObject_Invoke) = emit_hit_object_invoke_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;
@@ -1042,6 +1043,7 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 
 	case DXIL::Op::TraceRay:
 	case DXIL::Op::HitObject_TraceRay:
+	case DXIL::Op::HitObject_Invoke:
 	{
 		// Mark alloca'd variables which should be considered as payloads rather than StorageClassFunction.
 		// Moved to secondary pass to help NVAPI analysis since it uses TraceRay for nefarious needs,
@@ -1049,7 +1051,8 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 		if (analyze_nvapi_trace_ray(impl, instruction))
 			break;
 
-		update_storage_class(impl, instruction->getOperand(15), spv::StorageClassRayPayloadKHR);
+		unsigned pos = (op == DXIL::Op::HitObject_Invoke) ? 2 : 15;
+		update_storage_class(impl, instruction->getOperand(pos), spv::StorageClassRayPayloadKHR);
 
 		analyze_ray_tracing_flags(impl, instruction->getOperand(2));
 		break;

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -292,6 +292,7 @@ struct DXILDispatcher
 		OP(AcceptHitAndEndSearch) = emit_ray_tracing_accept_hit_and_end_search;
 		OP(IgnoreHit) = emit_ray_tracing_ignore_hit;
 		OP(CallShader) = emit_ray_tracing_call_shader;
+		OP(HitObject_TraceRay) = emit_hit_object_trace_ray_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;
@@ -502,6 +503,7 @@ bool dxil_instruction_has_side_effects(const llvm::CallInst *instruction)
 	case DXIL::Op::RayQuery_CommitNonOpaqueTriangleHit:
 	case DXIL::Op::RayQuery_CommitProceduralPrimitiveHit:
 	case DXIL::Op::TextureStoreSample:
+	case DXIL::Op::HitObject_TraceRay:
 		ret = true;
 		break;
 
@@ -976,6 +978,24 @@ static void analyze_ray_tracing_flags(Converter::Impl &impl, const llvm::Value *
 	}
 }
 
+static void update_storage_class(Converter::Impl &impl, const llvm::Value *value, spv::StorageClass desired_class)
+{
+	if (const auto *alloca_inst = llvm::dyn_cast<llvm::AllocaInst>(value))
+	{
+		auto storage = impl.get_effective_storage_class(alloca_inst, spv::StorageClassFunction);
+		if (storage != spv::StorageClassFunction && storage != desired_class)
+		{
+			impl.handle_to_storage_class[alloca_inst] = spv::StorageClassFunction;
+			if (!impl.get_needs_temp_storage_copy(alloca_inst))
+				impl.needs_temp_storage_copy.insert(alloca_inst);
+		}
+		else if (!impl.get_needs_temp_storage_copy(alloca_inst))
+		{
+			impl.handle_to_storage_class[alloca_inst] = desired_class;
+		}
+	}
+}
+
 bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::CallInst *instruction)
 {
 	// The opcode is encoded as a constant integer.
@@ -1017,6 +1037,7 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 		break;
 
 	case DXIL::Op::TraceRay:
+	case DXIL::Op::HitObject_TraceRay:
 	{
 		// Mark alloca'd variables which should be considered as payloads rather than StorageClassFunction.
 		// Moved to secondary pass to help NVAPI analysis since it uses TraceRay for nefarious needs,
@@ -1024,20 +1045,7 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 		if (analyze_nvapi_trace_ray(impl, instruction))
 			break;
 
-		if (const auto *alloca_inst = llvm::dyn_cast<llvm::AllocaInst>(instruction->getOperand(15)))
-		{
-			auto storage = impl.get_effective_storage_class(alloca_inst, spv::StorageClassFunction);
-			if (storage != spv::StorageClassFunction && storage != spv::StorageClassRayPayloadKHR)
-			{
-				impl.handle_to_storage_class[alloca_inst] = spv::StorageClassFunction;
-				if (!impl.get_needs_temp_storage_copy(alloca_inst))
-					impl.needs_temp_storage_copy.insert(alloca_inst);
-			}
-			else if (!impl.get_needs_temp_storage_copy(alloca_inst))
-			{
-				impl.handle_to_storage_class[alloca_inst] = spv::StorageClassRayPayloadKHR;
-			}
-		}
+		update_storage_class(impl, instruction->getOperand(15), spv::StorageClassRayPayloadKHR);
 
 		analyze_ray_tracing_flags(impl, instruction->getOperand(2));
 		break;
@@ -1051,20 +1059,7 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 		if (analyze_nvapi_call_shader(impl, instruction))
 			break;
 
-		if (const auto *alloca_inst = llvm::dyn_cast<llvm::AllocaInst>(instruction->getOperand(2)))
-		{
-			auto storage = impl.get_effective_storage_class(alloca_inst, spv::StorageClassFunction);
-			if (storage != spv::StorageClassFunction && storage != spv::StorageClassCallableDataKHR)
-			{
-				impl.handle_to_storage_class[alloca_inst] = spv::StorageClassFunction;
-				if (!impl.get_needs_temp_storage_copy(alloca_inst))
-					impl.needs_temp_storage_copy.insert(alloca_inst);
-			}
-			else if (!impl.get_needs_temp_storage_copy(alloca_inst))
-			{
-				impl.handle_to_storage_class[alloca_inst] = spv::StorageClassCallableDataKHR;
-			}
-		}
+		update_storage_class(impl, instruction->getOperand(2), spv::StorageClassCallableDataKHR);
 		break;
 	}
 

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -320,6 +320,7 @@ struct DXILDispatcher
 		OP(HitObject_PrimitiveIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetPrimitiveIndexEXT, 1>;
 		OP(HitObject_HitKind) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetHitKindEXT, 1>;
 		OP(HitObject_ShaderTableIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetShaderBindingTableRecordIndexEXT, 1>;
+		OP(HitObject_SetShaderTableIndex) = emit_hit_object_set_shader_table_index_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;
@@ -531,6 +532,7 @@ bool dxil_instruction_has_side_effects(const llvm::CallInst *instruction)
 	case DXIL::Op::RayQuery_CommitProceduralPrimitiveHit:
 	case DXIL::Op::TextureStoreSample:
 	case DXIL::Op::HitObject_TraceRay:
+	case DXIL::Op::HitObject_SetShaderTableIndex:
 		ret = true;
 		break;
 

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -293,6 +293,8 @@ struct DXILDispatcher
 		OP(IgnoreHit) = emit_ray_tracing_ignore_hit;
 		OP(CallShader) = emit_ray_tracing_call_shader;
 		OP(HitObject_TraceRay) = emit_hit_object_trace_ray_instruction;
+		OP(HitObject_FromRayQuery) = emit_hit_object_from_ray_query_instruction;
+		OP(HitObject_FromRayQueryWithAttrs) = emit_hit_object_from_ray_query_with_attrs_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;
@@ -1062,6 +1064,10 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 		update_storage_class(impl, instruction->getOperand(2), spv::StorageClassCallableDataKHR);
 		break;
 	}
+
+	case DXIL::Op::HitObject_FromRayQueryWithAttrs:
+		update_storage_class(impl, instruction->getOperand(3), spv::StorageClassHitObjectAttributeEXT);
+		break;
 
 	default:
 		break;

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -296,6 +296,7 @@ struct DXILDispatcher
 		OP(HitObject_FromRayQuery) = emit_hit_object_from_ray_query_instruction;
 		OP(HitObject_FromRayQueryWithAttrs) = emit_hit_object_from_ray_query_with_attrs_instruction;
 		OP(HitObject_MakeMiss) = emit_hit_object_make_miss_instruction;
+		OP(HitObject_MakeNop) = emit_hit_object_make_nop_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -322,6 +322,7 @@ struct DXILDispatcher
 		OP(HitObject_ShaderTableIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetShaderBindingTableRecordIndexEXT, 1>;
 		OP(HitObject_SetShaderTableIndex) = emit_hit_object_set_shader_table_index_instruction;
 		OP(HitObject_LoadLocalRootTableConstant) = emit_hit_object_load_local_root_table_constant_instruction;
+		OP(HitObject_Attributes) = emit_hit_object_attributes_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;
@@ -1094,6 +1095,10 @@ bool analyze_dxil_instruction_secondary_pass(Converter::Impl &impl, const llvm::
 		update_storage_class(impl, instruction->getOperand(2), spv::StorageClassCallableDataKHR);
 		break;
 	}
+
+	case DXIL::Op::HitObject_Attributes:
+		update_storage_class(impl, instruction->getOperand(2), spv::StorageClassHitObjectAttributeEXT);
+		break;
 
 	case DXIL::Op::HitObject_FromRayQueryWithAttrs:
 		update_storage_class(impl, instruction->getOperand(3), spv::StorageClassHitObjectAttributeEXT);

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -298,6 +298,7 @@ struct DXILDispatcher
 		OP(HitObject_MakeMiss) = emit_hit_object_make_miss_instruction;
 		OP(HitObject_MakeNop) = emit_hit_object_make_nop_instruction;
 		OP(HitObject_Invoke) = emit_hit_object_invoke_instruction;
+		OP(MaybeReorderThread) = emit_maybe_reoder_thread_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -321,6 +321,7 @@ struct DXILDispatcher
 		OP(HitObject_HitKind) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetHitKindEXT, 1>;
 		OP(HitObject_ShaderTableIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetShaderBindingTableRecordIndexEXT, 1>;
 		OP(HitObject_SetShaderTableIndex) = emit_hit_object_set_shader_table_index_instruction;
+		OP(HitObject_LoadLocalRootTableConstant) = emit_hit_object_load_local_root_table_constant_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -295,6 +295,7 @@ struct DXILDispatcher
 		OP(HitObject_TraceRay) = emit_hit_object_trace_ray_instruction;
 		OP(HitObject_FromRayQuery) = emit_hit_object_from_ray_query_instruction;
 		OP(HitObject_FromRayQueryWithAttrs) = emit_hit_object_from_ray_query_with_attrs_instruction;
+		OP(HitObject_MakeMiss) = emit_hit_object_make_miss_instruction;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;

--- a/opcodes/opcodes_dxil_builtins.cpp
+++ b/opcodes/opcodes_dxil_builtins.cpp
@@ -292,6 +292,8 @@ struct DXILDispatcher
 		OP(AcceptHitAndEndSearch) = emit_ray_tracing_accept_hit_and_end_search;
 		OP(IgnoreHit) = emit_ray_tracing_ignore_hit;
 		OP(CallShader) = emit_ray_tracing_call_shader;
+
+		// Hit object + shader invocation reordering
 		OP(HitObject_TraceRay) = emit_hit_object_trace_ray_instruction;
 		OP(HitObject_FromRayQuery) = emit_hit_object_from_ray_query_instruction;
 		OP(HitObject_FromRayQueryWithAttrs) = emit_hit_object_from_ray_query_with_attrs_instruction;
@@ -299,6 +301,25 @@ struct DXILDispatcher
 		OP(HitObject_MakeNop) = emit_hit_object_make_nop_instruction;
 		OP(HitObject_Invoke) = emit_hit_object_invoke_instruction;
 		OP(MaybeReorderThread) = emit_maybe_reoder_thread_instruction;
+
+		OP(HitObject_IsMiss) = emit_hit_object_get_value_instruction<spv::OpHitObjectIsMissEXT, 1>;
+		OP(HitObject_IsHit) = emit_hit_object_get_value_instruction<spv::OpHitObjectIsHitEXT, 1>;
+		OP(HitObject_IsNop) = emit_hit_object_get_value_instruction<spv::OpHitObjectIsEmptyEXT, 1>;
+		OP(HitObject_RayFlags) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetRayFlagsEXT, 1>;
+		OP(HitObject_RayTMin) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetRayTMinEXT, 1>;
+		OP(HitObject_RayTCurrent) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetRayTMaxEXT, 1>;
+		OP(HitObject_WorldRayOrigin) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetWorldRayOriginEXT, 3>;
+		OP(HitObject_WorldRayDirection) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetWorldRayDirectionEXT, 3>;
+		OP(HitObject_ObjectRayOrigin) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetObjectRayOriginEXT, 3>;
+		OP(HitObject_ObjectRayDirection) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetObjectRayDirectionEXT, 3>;
+		OP(HitObject_ObjectToWorld3x4) = emit_hit_object_get_matrix_value_instruction<spv::OpHitObjectGetObjectToWorldEXT>;
+		OP(HitObject_WorldToObject3x4) = emit_hit_object_get_matrix_value_instruction<spv::OpHitObjectGetWorldToObjectEXT>;
+		OP(HitObject_GeometryIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetGeometryIndexEXT, 1>;
+		OP(HitObject_InstanceIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetInstanceCustomIndexEXT, 1>;
+		OP(HitObject_InstanceID) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetInstanceIdEXT, 1>;
+		OP(HitObject_PrimitiveIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetPrimitiveIndexEXT, 1>;
+		OP(HitObject_HitKind) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetHitKindEXT, 1>;
+		OP(HitObject_ShaderTableIndex) = emit_hit_object_get_value_instruction<spv::OpHitObjectGetShaderBindingTableRecordIndexEXT, 1>;
 
 		// Ray query
 		OP(AllocateRayQuery) = emit_allocate_ray_query;

--- a/reference/shaders/stages/raygen-hitobject-attr.sm69.noglsl.rgen
+++ b/reference/shaders/stages/raygen-hitobject-attr.sm69.noglsl.rgen
@@ -1,0 +1,213 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 171
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability ShaderInvocationReorderEXT
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_EXT_shader_invocation_reorder"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %3 "main" %8 %12 %16 %20
+OpName %3 "main"
+OpName %8 "AS"
+OpName %12 "IMG"
+OpName %14 ""
+OpName %18 ""
+OpDecorate %8 DescriptorSet 40
+OpDecorate %8 Binding 30
+OpDecorate %12 DescriptorSet 20
+OpDecorate %12 Binding 10
+OpDecorate %12 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 1
+%6 = OpTypeAccelerationStructureKHR
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeVector %9 4
+%14 = OpTypeStruct %13
+%15 = OpTypePointer RayPayloadKHR %14
+%16 = OpVariable %15 RayPayloadKHR
+%17 = OpTypeVector %9 2
+%18 = OpTypeStruct %17
+%19 = OpTypePointer HitObjectAttributeEXT %18
+%20 = OpVariable %19 HitObjectAttributeEXT
+%22 = OpTypeInt 32 0
+%23 = OpConstant %22 0
+%24 = OpConstant %9 1
+%25 = OpConstant %9 0
+%26 = OpConstant %9 2
+%27 = OpConstant %9 3
+%28 = OpConstant %9 4
+%29 = OpTypeVector %9 3
+%32 = OpTypeHitObjectEXT
+%33 = OpTypePointer Function %32
+%35 = OpTypeBool
+%37 = OpTypePointer RayPayloadKHR %13
+%86 = OpTypeMatrix %29 4
+%143 = OpTypePointer HitObjectAttributeEXT %17
+%155 = OpConstantComposite %13 %24 %25 %25 %24
+%156 = OpConstantComposite %13 %25 %24 %25 %24
+%163 = OpTypeVector %22 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%34 = OpVariable %33 Function
+%42 = OpUndef %29
+%139 = OpUndef %13
+OpBranch %166
+%166 = OpLabel
+%21 = OpLoad %6 %8
+%30 = OpCompositeConstruct %29 %24 %26 %27
+%31 = OpCompositeConstruct %29 %25 %25 %24
+OpHitObjectTraceRayEXT %34 %21 %23 %23 %23 %23 %23 %30 %24 %31 %28 %16
+%36 = OpHitObjectIsHitEXT %35 %34
+OpSelectionMerge %169 None
+OpBranchConditional %36 %168 %167
+%168 = OpLabel
+%38 = OpInBoundsAccessChain %37 %16 %23
+%39 = OpLoad %13 %38
+%40 = OpHitObjectGetRayTMinEXT %9 %34
+%41 = OpCompositeInsert %29 %40 %42 0
+%43 = OpVectorShuffle %29 %41 %42 0 0 0
+%44 = OpHitObjectGetRayTMaxEXT %9 %34
+%45 = OpCompositeInsert %29 %44 %43 1
+%46 = OpHitObjectGetWorldRayOriginEXT %29 %34
+%47 = OpCompositeExtract %9 %46 0
+%48 = OpCompositeInsert %29 %47 %42 0
+%49 = OpHitObjectGetWorldRayOriginEXT %29 %34
+%50 = OpCompositeExtract %9 %49 1
+%51 = OpCompositeInsert %29 %50 %48 1
+%52 = OpHitObjectGetWorldRayOriginEXT %29 %34
+%53 = OpCompositeExtract %9 %52 2
+%54 = OpCompositeInsert %29 %53 %51 2
+%55 = OpFAdd %29 %54 %45
+%56 = OpHitObjectGetWorldRayDirectionEXT %29 %34
+%57 = OpCompositeExtract %9 %56 0
+%58 = OpCompositeInsert %29 %57 %42 0
+%59 = OpHitObjectGetWorldRayDirectionEXT %29 %34
+%60 = OpCompositeExtract %9 %59 1
+%61 = OpCompositeInsert %29 %60 %58 1
+%62 = OpHitObjectGetWorldRayDirectionEXT %29 %34
+%63 = OpCompositeExtract %9 %62 2
+%64 = OpCompositeInsert %29 %63 %61 2
+%65 = OpFAdd %29 %55 %64
+%66 = OpHitObjectGetObjectRayOriginEXT %29 %34
+%67 = OpCompositeExtract %9 %66 0
+%68 = OpCompositeInsert %29 %67 %42 0
+%69 = OpHitObjectGetObjectRayOriginEXT %29 %34
+%70 = OpCompositeExtract %9 %69 1
+%71 = OpCompositeInsert %29 %70 %68 1
+%72 = OpHitObjectGetObjectRayOriginEXT %29 %34
+%73 = OpCompositeExtract %9 %72 2
+%74 = OpCompositeInsert %29 %73 %71 2
+%75 = OpFAdd %29 %65 %74
+%76 = OpHitObjectGetObjectRayDirectionEXT %29 %34
+%77 = OpCompositeExtract %9 %76 0
+%78 = OpCompositeInsert %29 %77 %42 0
+%79 = OpHitObjectGetObjectRayDirectionEXT %29 %34
+%80 = OpCompositeExtract %9 %79 1
+%81 = OpCompositeInsert %29 %80 %78 1
+%82 = OpHitObjectGetObjectRayDirectionEXT %29 %34
+%83 = OpCompositeExtract %9 %82 2
+%84 = OpCompositeInsert %29 %83 %81 2
+%85 = OpFAdd %29 %75 %84
+%87 = OpHitObjectGetObjectToWorldEXT %86 %34
+%88 = OpCompositeExtract %9 %87 0 0
+%89 = OpCompositeInsert %29 %88 %42 0
+%90 = OpHitObjectGetObjectToWorldEXT %86 %34
+%91 = OpCompositeExtract %9 %90 1 0
+%92 = OpCompositeInsert %29 %91 %89 1
+%93 = OpHitObjectGetObjectToWorldEXT %86 %34
+%94 = OpCompositeExtract %9 %93 2 0
+%95 = OpCompositeInsert %29 %94 %92 2
+%96 = OpFAdd %29 %85 %95
+%97 = OpHitObjectGetObjectToWorldEXT %86 %34
+%98 = OpCompositeExtract %9 %97 0 1
+%99 = OpCompositeInsert %29 %98 %89 1
+%100 = OpHitObjectGetObjectToWorldEXT %86 %34
+%101 = OpCompositeExtract %9 %100 0 2
+%102 = OpCompositeInsert %29 %101 %99 2
+%103 = OpFAdd %29 %96 %102
+%104 = OpHitObjectGetWorldToObjectEXT %86 %34
+%105 = OpCompositeExtract %9 %104 0 0
+%106 = OpCompositeInsert %29 %105 %42 0
+%107 = OpHitObjectGetWorldToObjectEXT %86 %34
+%108 = OpCompositeExtract %9 %107 1 0
+%109 = OpCompositeInsert %29 %108 %106 1
+%110 = OpHitObjectGetWorldToObjectEXT %86 %34
+%111 = OpCompositeExtract %9 %110 2 0
+%112 = OpCompositeInsert %29 %111 %109 2
+%113 = OpFAdd %29 %103 %112
+%114 = OpHitObjectGetWorldToObjectEXT %86 %34
+%115 = OpCompositeExtract %9 %114 0 1
+%116 = OpCompositeInsert %29 %115 %106 1
+%117 = OpHitObjectGetWorldToObjectEXT %86 %34
+%118 = OpCompositeExtract %9 %117 0 2
+%119 = OpCompositeInsert %29 %118 %116 2
+%120 = OpFAdd %29 %113 %119
+%121 = OpHitObjectGetRayFlagsEXT %22 %34
+%122 = OpHitObjectGetInstanceCustomIndexEXT %22 %34
+%123 = OpIAdd %22 %122 %121
+%124 = OpHitObjectGetInstanceIdEXT %22 %34
+%125 = OpIAdd %22 %123 %124
+%126 = OpHitObjectGetGeometryIndexEXT %22 %34
+%127 = OpIAdd %22 %125 %126
+%128 = OpHitObjectGetPrimitiveIndexEXT %22 %34
+%129 = OpIAdd %22 %127 %128
+%130 = OpHitObjectGetHitKindEXT %22 %34
+%131 = OpIAdd %22 %129 %130
+%132 = OpHitObjectGetShaderBindingTableRecordIndexEXT %22 %34
+%133 = OpIAdd %22 %131 %132
+OpHitObjectGetAttributesEXT %34 %20
+%134 = OpCompositeExtract %9 %120 0
+%135 = OpCompositeExtract %9 %120 1
+%136 = OpCompositeExtract %9 %120 2
+%137 = OpConvertUToF %9 %133
+%138 = OpCompositeInsert %13 %134 %139 0
+%140 = OpCompositeInsert %13 %135 %138 1
+%141 = OpCompositeInsert %13 %136 %140 2
+%142 = OpCompositeInsert %13 %137 %141 3
+%144 = OpInBoundsAccessChain %143 %20 %23
+%145 = OpLoad %17 %144
+%146 = OpCompositeExtract %9 %145 0
+%147 = OpCompositeExtract %9 %39 2
+%148 = OpCompositeInsert %13 %146 %139 0
+%149 = OpCompositeInsert %13 %146 %148 1
+%150 = OpCompositeInsert %13 %147 %149 2
+%151 = OpCompositeInsert %13 %24 %150 3
+%152 = OpFAdd %13 %151 %142
+OpBranch %169
+%167 = OpLabel
+%153 = OpHitObjectIsMissEXT %35 %34
+%154 = OpSelect %13 %153 %155 %156
+OpBranch %169
+%169 = OpLabel
+%157 = OpPhi %13 %152 %168 %154 %167
+%158 = OpLoad %10 %12
+%159 = OpCompositeExtract %9 %157 0
+%160 = OpCompositeExtract %9 %157 1
+%161 = OpCompositeExtract %9 %157 2
+%162 = OpCompositeExtract %9 %157 3
+%164 = OpCompositeConstruct %163 %23 %23
+%165 = OpCompositeConstruct %13 %159 %160 %161 %162
+OpImageWrite %158 %164 %165
+OpReturn
+OpFunctionEnd
+

--- a/reference/shaders/stages/raygen-hitobject-rayquery.sm69.noglsl.rgen
+++ b/reference/shaders/stages/raygen-hitobject-rayquery.sm69.noglsl.rgen
@@ -1,0 +1,219 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 133
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayQueryKHR
+OpCapability RayTraversalPrimitiveCullingKHR
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability ShaderInvocationReorderEXT
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_EXT_shader_invocation_reorder"
+OpExtension "SPV_KHR_ray_query"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %3 "main" %8 %12 %16 %17 %21 %25 %35 %91
+OpName %3 "main"
+OpName %8 "AS"
+OpName %12 "IMG"
+OpName %14 ""
+OpName %19 ""
+OpName %106 "frontier_phi_10.pred.7.ladder.11.ladder"
+OpName %107 "frontier_phi_10.pred.7.ladder"
+OpName %108 "frontier_phi_10.pred"
+OpName %109 "frontier_phi_10.pred.7.ladder.11.ladder"
+OpName %110 "frontier_phi_10.pred.7.ladder"
+OpName %111 "frontier_phi_10.pred"
+OpName %112 "frontier_phi_8.5.ladder"
+OpDecorate %8 DescriptorSet 40
+OpDecorate %8 Binding 30
+OpDecorate %12 DescriptorSet 20
+OpDecorate %12 Binding 10
+OpDecorate %12 NonReadable
+OpDecorate %25 BuiltIn LaunchIdKHR
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 1
+%6 = OpTypeAccelerationStructureKHR
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeVector %9 3
+%14 = OpTypeStruct %13
+%15 = OpTypePointer RayPayloadKHR %14
+%16 = OpVariable %15 RayPayloadKHR
+%17 = OpVariable %15 RayPayloadKHR
+%18 = OpTypeVector %9 2
+%19 = OpTypeStruct %18
+%20 = OpTypePointer HitObjectAttributeEXT %19
+%21 = OpVariable %20 HitObjectAttributeEXT
+%22 = OpTypeInt 32 0
+%23 = OpTypeVector %22 3
+%24 = OpTypePointer Input %23
+%25 = OpVariable %24 Input
+%26 = OpTypePointer Input %22
+%28 = OpConstant %22 0
+%31 = OpConstant %22 1
+%33 = OpTypeRayQueryKHR
+%34 = OpTypePointer Private %33
+%35 = OpVariable %34 Private
+%37 = OpConstant %22 132
+%38 = OpConstant %22 255
+%39 = OpConstant %9 1
+%40 = OpConstant %9 5
+%41 = OpConstant %9 2
+%42 = OpConstant %9 6
+%43 = OpConstant %9 3
+%44 = OpConstant %9 7
+%46 = OpConstant %9 4
+%48 = OpConstant %9 8
+%49 = OpTypeBool
+%58 = OpConstant %22 2
+%63 = OpTypePointer HitObjectAttributeEXT %18
+%65 = OpTypeHitObjectEXT
+%66 = OpTypePointer Function %65
+%69 = OpTypePointer RayPayloadKHR %13
+%71 = OpConstantNull %13
+%77 = OpConstant %9 0.100000001
+%78 = OpConstant %9 0.200000003
+%79 = OpConstant %9 0.300000012
+%80 = OpConstantComposite %13 %77 %78 %79
+%85 = OpTypeVector %22 2
+%87 = OpTypeVector %9 4
+%90 = OpTypePointer HitObjectAttributeEXT %1
+%91 = OpVariable %90 HitObjectAttributeEXT
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%67 = OpVariable %66 Function
+%89 = OpVariable %66 Function
+%52 = OpUndef %18
+%68 = OpUndef %22
+OpBranch %113
+%113 = OpLabel
+%27 = OpAccessChain %26 %25 %28
+%29 = OpLoad %22 %27
+%30 = OpAccessChain %26 %25 %31
+%32 = OpLoad %22 %30
+%36 = OpLoad %6 %8
+%45 = OpCompositeConstruct %13 %39 %41 %43
+%47 = OpCompositeConstruct %13 %40 %42 %44
+OpRayQueryInitializeKHR %35 %36 %37 %38 %45 %46 %47 %48
+%50 = OpRayQueryProceedKHR %49 %35
+OpSelectionMerge %126 None
+OpBranchConditional %50 %114 %126
+%114 = OpLabel
+OpBranch %115
+%115 = OpLabel
+%59 = OpPhi %18 %52 %114 %53 %124
+%60 = OpPhi %22 %28 %114 %55 %124
+%61 = OpRayQueryGetIntersectionTypeKHR %22 %35 %28
+%62 = OpIEqual %49 %61 %28
+OpLoopMerge %125 %124 None
+OpBranch %116
+%116 = OpLabel
+OpSelectionMerge %123 None
+OpBranchConditional %62 %122 %117
+%122 = OpLabel
+OpRayQueryConfirmIntersectionKHR %35
+OpBranch %123
+%117 = OpLabel
+%74 = OpIEqual %49 %61 %31
+OpSelectionMerge %121 None
+OpBranchConditional %74 %118 %121
+%118 = OpLabel
+%96 = OpRayQueryGetIntersectionPrimitiveIndexKHR %22 %35 %28
+%97 = OpUGreaterThan %49 %96 %58
+OpSelectionMerge %120 None
+OpBranchConditional %97 %120 %119
+%119 = OpLabel
+%98 = OpRayQueryGetRayTMinKHR %9 %35
+OpRayQueryGenerateIntersectionKHR %35 %98
+%99 = OpRayQueryGetIntersectionObjectRayOriginKHR %13 %35 %28
+%100 = OpCompositeExtract %9 %99 0
+%101 = OpCompositeInsert %18 %100 %52 0
+%102 = OpRayQueryGetIntersectionObjectRayOriginKHR %13 %35 %28
+%103 = OpCompositeExtract %9 %102 1
+%93 = OpCompositeInsert %18 %103 %101 1
+%104 = OpRayQueryGetIntersectionObjectRayDirectionKHR %13 %35 %28
+%105 = OpCompositeExtract %9 %104 2
+%94 = OpConvertFToU %22 %105
+OpBranch %120
+%120 = OpLabel
+%106 = OpPhi %18 %59 %118 %93 %119
+%109 = OpPhi %22 %60 %118 %94 %119
+OpBranch %121
+%121 = OpLabel
+%107 = OpPhi %18 %59 %117 %106 %120
+%110 = OpPhi %22 %60 %117 %109 %120
+OpBranch %123
+%123 = OpLabel
+%108 = OpPhi %18 %59 %122 %107 %121
+%111 = OpPhi %22 %60 %122 %110 %121
+%53 = OpCopyObject %18 %108
+%55 = OpCopyObject %22 %111
+OpBranch %124
+%124 = OpLabel
+%95 = OpRayQueryProceedKHR %49 %35
+OpBranchConditional %95 %115 %125
+%125 = OpLabel
+OpBranch %126
+%126 = OpLabel
+%51 = OpPhi %18 %52 %113 %53 %125
+%54 = OpPhi %22 %28 %113 %55 %125
+%56 = OpRayQueryGetIntersectionTypeKHR %22 %35 %31
+%57 = OpIEqual %49 %56 %58
+OpSelectionMerge %131 None
+OpBranchConditional %57 %130 %127
+%130 = OpLabel
+%64 = OpInBoundsAccessChain %63 %21 %28
+OpStore %64 %51
+OpHitObjectRecordFromQueryEXT %67 %35 %28 %21 %54
+OpHitObjectSetShaderBindingTableRecordIndexEXT %67 %28
+OpReorderThreadWithHitObjectEXT %67 %68 %28
+%70 = OpInBoundsAccessChain %69 %17 %28
+OpStore %70 %71
+OpHitObjectExecuteShaderEXT %67 %17
+%72 = OpLoad %13 %70
+OpBranch %131
+%127 = OpLabel
+%73 = OpIEqual %49 %56 %31
+OpSelectionMerge %129 None
+OpBranchConditional %73 %128 %129
+%128 = OpLabel
+OpHitObjectRecordFromQueryEXT %89 %35 %28 %91
+OpHitObjectSetShaderBindingTableRecordIndexEXT %89 %31
+OpReorderThreadWithHitObjectEXT %89 %68 %28
+%92 = OpInBoundsAccessChain %69 %16 %28
+OpStore %92 %71
+OpHitObjectExecuteShaderEXT %89 %16
+%76 = OpLoad %13 %92
+OpBranch %129
+%129 = OpLabel
+%112 = OpPhi %13 %76 %128 %80 %127
+OpBranch %131
+%131 = OpLabel
+%75 = OpPhi %13 %72 %130 %112 %129
+%81 = OpCompositeExtract %9 %75 0
+%82 = OpCompositeExtract %9 %75 1
+%83 = OpCompositeExtract %9 %75 2
+%84 = OpLoad %10 %12
+%86 = OpCompositeConstruct %85 %29 %32
+%88 = OpCompositeConstruct %87 %81 %82 %83 %39
+OpImageWrite %84 %86 %88
+OpReturn
+OpFunctionEnd
+

--- a/reference/shaders/stages/raygen-hitobject-reorder.sm69.noglsl.rgen
+++ b/reference/shaders/stages/raygen-hitobject-reorder.sm69.noglsl.rgen
@@ -1,0 +1,88 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 48
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayTraversalPrimitiveCullingKHR
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability ShaderInvocationReorderEXT
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_EXT_shader_invocation_reorder"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %3 "main" %8 %12 %16 %17
+OpName %3 "main"
+OpName %8 "AS"
+OpName %12 "IMG"
+OpName %14 ""
+OpDecorate %8 DescriptorSet 40
+OpDecorate %8 Binding 30
+OpDecorate %12 DescriptorSet 20
+OpDecorate %12 Binding 10
+OpDecorate %12 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 1
+%6 = OpTypeAccelerationStructureKHR
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeVector %9 4
+%14 = OpTypeStruct %13
+%15 = OpTypePointer RayPayloadKHR %14
+%16 = OpVariable %15 RayPayloadKHR
+%17 = OpVariable %15 RayPayloadKHR
+%19 = OpTypeInt 32 0
+%20 = OpConstant %19 0
+%21 = OpConstant %9 1
+%22 = OpConstant %9 0
+%23 = OpConstant %9 2
+%24 = OpConstant %9 3
+%25 = OpConstant %9 4
+%26 = OpTypeVector %9 3
+%29 = OpTypeHitObjectEXT
+%30 = OpTypePointer Function %29
+%32 = OpTypePointer RayPayloadKHR %13
+%43 = OpTypeVector %19 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%31 = OpVariable %30 Function
+%35 = OpUndef %19
+OpBranch %46
+%46 = OpLabel
+%18 = OpLoad %6 %8
+%27 = OpCompositeConstruct %26 %21 %23 %24
+%28 = OpCompositeConstruct %26 %22 %22 %21
+OpHitObjectTraceRayEXT %31 %18 %20 %20 %20 %20 %20 %27 %21 %28 %25 %17
+%33 = OpInBoundsAccessChain %32 %17 %20
+%34 = OpLoad %13 %33
+OpReorderThreadWithHitObjectEXT %31 %35 %20
+%36 = OpInBoundsAccessChain %32 %16 %20
+OpStore %36 %34
+OpHitObjectExecuteShaderEXT %31 %16
+%37 = OpLoad %13 %36
+%38 = OpLoad %10 %12
+%39 = OpCompositeExtract %9 %37 0
+%40 = OpCompositeExtract %9 %37 1
+%41 = OpCompositeExtract %9 %37 2
+%42 = OpCompositeExtract %9 %37 3
+%44 = OpCompositeConstruct %43 %20 %20
+%45 = OpCompositeConstruct %13 %39 %40 %41 %42
+OpImageWrite %38 %44 %45
+OpReturn
+OpFunctionEnd
+

--- a/reference/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
+++ b/reference/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
@@ -1,0 +1,132 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 68
+; Schema: 0
+OpCapability Shader
+OpCapability Int64
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayTraversalPrimitiveCullingKHR
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability PhysicalStorageBufferAddresses
+OpCapability ShaderInvocationReorderEXT
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_EXT_shader_invocation_reorder"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint RayGenerationKHR %3 "main" %13 %17 %21 %25 %26
+OpName %3 "main"
+OpName %11 "SBTBlock"
+OpName %13 "SBT"
+OpName %17 "AS"
+OpName %21 "IMG"
+OpName %23 ""
+OpName %46 "HitObjectSRB"
+OpDecorate %7 ArrayStride 4
+OpDecorate %9 ArrayStride 4
+OpDecorate %11 Block
+OpMemberDecorate %11 0 Offset 0
+OpMemberDecorate %11 1 Offset 20
+OpMemberDecorate %11 2 Offset 48
+OpMemberDecorate %11 3 Offset 56
+OpMemberDecorate %11 4 Offset 64
+OpMemberDecorate %11 5 Offset 72
+OpMemberDecorate %11 6 Offset 80
+OpMemberDecorate %11 7 Offset 88
+OpMemberDecorate %11 8 Offset 96
+OpMemberDecorate %11 9 Offset 104
+OpMemberDecorate %11 10 Offset 112
+OpDecorate %17 DescriptorSet 40
+OpDecorate %17 Binding 30
+OpDecorate %21 DescriptorSet 20
+OpDecorate %21 Binding 10
+OpDecorate %21 NonReadable
+OpDecorate %46 Block
+OpDecorate %46 HitObjectShaderRecordBufferEXT
+OpMemberDecorate %46 0 Offset 0
+OpMemberDecorate %46 0 NonWritable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpConstant %5 5
+%7 = OpTypeArray %5 %6
+%8 = OpConstant %5 6
+%9 = OpTypeArray %5 %8
+%10 = OpTypeVector %5 2
+%11 = OpTypeStruct %7 %9 %10 %10 %10 %10 %10 %10 %10 %10 %10
+%12 = OpTypePointer ShaderRecordBufferKHR %11
+%13 = OpVariable %12 ShaderRecordBufferKHR
+%14 = OpTypeInt 32 1
+%15 = OpTypeAccelerationStructureKHR
+%16 = OpTypePointer UniformConstant %15
+%17 = OpVariable %16 UniformConstant
+%18 = OpTypeFloat 32
+%19 = OpTypeImage %18 2D 0 0 0 2 Unknown
+%20 = OpTypePointer UniformConstant %19
+%21 = OpVariable %20 UniformConstant
+%22 = OpTypeVector %18 4
+%23 = OpTypeStruct %22
+%24 = OpTypePointer RayPayloadKHR %23
+%25 = OpVariable %24 RayPayloadKHR
+%26 = OpVariable %24 RayPayloadKHR
+%28 = OpConstant %5 0
+%29 = OpConstant %18 1
+%30 = OpConstant %18 0
+%31 = OpConstant %18 2
+%32 = OpConstant %18 3
+%33 = OpConstant %18 4
+%34 = OpTypeVector %18 3
+%37 = OpTypeHitObjectEXT
+%38 = OpTypePointer Function %37
+%40 = OpTypePointer RayPayloadKHR %22
+%44 = OpConstant %5 4
+%45 = OpTypeInt 64 0
+%46 = OpTypeStruct %5
+%47 = OpTypePointer PhysicalStorageBuffer %46
+%48 = OpTypePointer PhysicalStorageBuffer %5
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%39 = OpVariable %38 Function
+OpBranch %66
+%66 = OpLabel
+%27 = OpLoad %15 %17
+%35 = OpCompositeConstruct %34 %29 %31 %32
+%36 = OpCompositeConstruct %34 %30 %30 %29
+OpHitObjectTraceRayEXT %39 %27 %28 %28 %28 %28 %28 %35 %29 %36 %33 %26
+%41 = OpInBoundsAccessChain %40 %26 %28
+%42 = OpLoad %22 %41
+%43 = OpHitObjectGetShaderBindingTableRecordIndexEXT %5 %39
+%49 = OpHitObjectGetShaderRecordBufferHandleEXT %10 %39
+%50 = OpBitcast %45 %49
+%51 = OpUConvert %45 %44
+%52 = OpIAdd %45 %50 %51
+%53 = OpConvertUToPtr %47 %52
+%54 = OpAccessChain %48 %53 %28
+%55 = OpLoad %5 %54 Aligned 4
+%56 = OpIMul %5 %55 %43
+OpHitObjectSetShaderBindingTableRecordIndexEXT %39 %56
+%57 = OpInBoundsAccessChain %40 %25 %28
+OpStore %57 %42
+OpHitObjectExecuteShaderEXT %39 %25
+%58 = OpLoad %22 %57
+%59 = OpLoad %19 %21
+%60 = OpCompositeExtract %18 %58 0
+%61 = OpCompositeExtract %18 %58 1
+%62 = OpCompositeExtract %18 %58 2
+%63 = OpCompositeExtract %18 %58 3
+%64 = OpCompositeConstruct %10 %28 %28
+%65 = OpCompositeConstruct %22 %60 %61 %62 %63
+OpImageWrite %59 %64 %65
+OpReturn
+OpFunctionEnd
+

--- a/reference/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
+++ b/reference/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 68
+; Bound: 69
 ; Schema: 0
 OpCapability Shader
 OpCapability Int64
@@ -51,6 +51,7 @@ OpDecorate %17 Binding 30
 OpDecorate %21 DescriptorSet 20
 OpDecorate %21 Binding 10
 OpDecorate %21 NonReadable
+OpDecorate %45 ArrayStride 4
 OpDecorate %46 Block
 OpDecorate %46 HitObjectShaderRecordBufferEXT
 OpMemberDecorate %46 0 Offset 0
@@ -90,15 +91,17 @@ OpMemberDecorate %46 0 NonWritable
 %38 = OpTypePointer Function %37
 %40 = OpTypePointer RayPayloadKHR %22
 %44 = OpConstant %5 4
-%45 = OpTypeInt 64 0
-%46 = OpTypeStruct %5
+%45 = OpTypeRuntimeArray %5
+%46 = OpTypeStruct %45
 %47 = OpTypePointer PhysicalStorageBuffer %46
 %48 = OpTypePointer PhysicalStorageBuffer %5
+%50 = OpTypeInt 64 0
+%54 = OpConstant %5 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 %39 = OpVariable %38 Function
-OpBranch %66
-%66 = OpLabel
+OpBranch %67
+%67 = OpLabel
 %27 = OpLoad %15 %17
 %35 = OpCompositeConstruct %34 %29 %31 %32
 %36 = OpCompositeConstruct %34 %30 %30 %29
@@ -107,26 +110,25 @@ OpHitObjectTraceRayEXT %39 %27 %28 %28 %28 %28 %28 %35 %29 %36 %33 %26
 %42 = OpLoad %22 %41
 %43 = OpHitObjectGetShaderBindingTableRecordIndexEXT %5 %39
 %49 = OpHitObjectGetShaderRecordBufferHandleEXT %10 %39
-%50 = OpBitcast %45 %49
-%51 = OpUConvert %45 %44
-%52 = OpIAdd %45 %50 %51
-%53 = OpConvertUToPtr %47 %52
-%54 = OpAccessChain %48 %53 %28
-%55 = OpLoad %5 %54 Aligned 4
-%56 = OpIMul %5 %55 %43
-OpHitObjectSetShaderBindingTableRecordIndexEXT %39 %56
-%57 = OpInBoundsAccessChain %40 %25 %28
-OpStore %57 %42
+%51 = OpBitcast %50 %49
+%52 = OpConvertUToPtr %47 %51
+%53 = OpShiftRightLogical %5 %44 %54
+%55 = OpInBoundsAccessChain %48 %52 %28 %53
+%56 = OpLoad %5 %55 Aligned 4
+%57 = OpIMul %5 %56 %43
+OpHitObjectSetShaderBindingTableRecordIndexEXT %39 %57
+%58 = OpInBoundsAccessChain %40 %25 %28
+OpStore %58 %42
 OpHitObjectExecuteShaderEXT %39 %25
-%58 = OpLoad %22 %57
-%59 = OpLoad %19 %21
-%60 = OpCompositeExtract %18 %58 0
-%61 = OpCompositeExtract %18 %58 1
-%62 = OpCompositeExtract %18 %58 2
-%63 = OpCompositeExtract %18 %58 3
-%64 = OpCompositeConstruct %10 %28 %28
-%65 = OpCompositeConstruct %22 %60 %61 %62 %63
-OpImageWrite %59 %64 %65
+%59 = OpLoad %22 %58
+%60 = OpLoad %19 %21
+%61 = OpCompositeExtract %18 %59 0
+%62 = OpCompositeExtract %18 %59 1
+%63 = OpCompositeExtract %18 %59 2
+%64 = OpCompositeExtract %18 %59 3
+%65 = OpCompositeConstruct %10 %28 %28
+%66 = OpCompositeConstruct %22 %61 %62 %63 %64
+OpImageWrite %60 %65 %66
 OpReturn
 OpFunctionEnd
 

--- a/reference/shaders/stages/raygen-hitobject.sm69.noglsl.rgen
+++ b/reference/shaders/stages/raygen-hitobject.sm69.noglsl.rgen
@@ -1,0 +1,108 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 65
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayTraversalPrimitiveCullingKHR
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpCapability ShaderInvocationReorderEXT
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_EXT_shader_invocation_reorder"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %3 "main" %8 %12 %15 %16 %20 %21
+OpName %3 "main"
+OpName %8 "AS"
+OpName %12 "IMG"
+OpName %13 ""
+OpName %18 ""
+OpDecorate %8 DescriptorSet 40
+OpDecorate %8 Binding 30
+OpDecorate %12 DescriptorSet 20
+OpDecorate %12 Binding 10
+OpDecorate %12 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 1
+%6 = OpTypeAccelerationStructureKHR
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeStruct %9
+%14 = OpTypePointer RayPayloadKHR %13
+%15 = OpVariable %14 RayPayloadKHR
+%16 = OpVariable %14 RayPayloadKHR
+%17 = OpTypeVector %9 4
+%18 = OpTypeStruct %17
+%19 = OpTypePointer RayPayloadKHR %18
+%20 = OpVariable %19 RayPayloadKHR
+%21 = OpVariable %19 RayPayloadKHR
+%23 = OpTypeInt 32 0
+%24 = OpConstant %23 0
+%25 = OpConstant %9 1
+%26 = OpConstant %9 0
+%27 = OpConstant %9 2
+%28 = OpConstant %9 3
+%29 = OpConstant %9 4
+%30 = OpTypeVector %9 3
+%33 = OpTypeHitObjectEXT
+%34 = OpTypePointer Function %33
+%36 = OpTypePointer RayPayloadKHR %17
+%42 = OpConstant %23 1
+%46 = OpTypePointer RayPayloadKHR %9
+%60 = OpTypeVector %23 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%35 = OpVariable %34 Function
+%45 = OpVariable %34 Function
+%52 = OpUndef %17
+OpBranch %63
+%63 = OpLabel
+%22 = OpLoad %6 %8
+%31 = OpCompositeConstruct %30 %25 %27 %28
+%32 = OpCompositeConstruct %30 %26 %26 %25
+OpHitObjectTraceRayEXT %35 %22 %24 %24 %24 %24 %24 %31 %25 %32 %29 %21
+%37 = OpInBoundsAccessChain %36 %21 %24
+%38 = OpLoad %17 %37
+%39 = OpInBoundsAccessChain %36 %20 %24
+OpStore %39 %38
+OpHitObjectExecuteShaderEXT %35 %20
+%40 = OpLoad %17 %39
+%41 = OpLoad %6 %8
+%43 = OpCompositeConstruct %30 %25 %27 %28
+%44 = OpCompositeConstruct %30 %26 %26 %25
+OpHitObjectTraceRayEXT %45 %41 %24 %42 %24 %24 %24 %43 %25 %44 %29 %16
+%47 = OpInBoundsAccessChain %46 %16 %24
+%48 = OpLoad %9 %47
+%49 = OpInBoundsAccessChain %46 %15 %24
+OpStore %49 %48
+OpHitObjectExecuteShaderEXT %45 %15
+%50 = OpLoad %9 %49
+%51 = OpCompositeInsert %17 %50 %52 0
+%53 = OpVectorShuffle %17 %51 %52 0 0 0 0
+%54 = OpFAdd %17 %53 %40
+%55 = OpLoad %10 %12
+%56 = OpCompositeExtract %9 %54 0
+%57 = OpCompositeExtract %9 %54 1
+%58 = OpCompositeExtract %9 %54 2
+%59 = OpCompositeExtract %9 %54 3
+%61 = OpCompositeConstruct %60 %24 %24
+%62 = OpCompositeConstruct %17 %56 %57 %58 %59
+OpImageWrite %55 %61 %62
+OpReturn
+OpFunctionEnd
+

--- a/reference/shaders/stages/raygen.sm69.rgen
+++ b/reference/shaders/stages/raygen.sm69.rgen
@@ -1,0 +1,124 @@
+#version 460
+#extension GL_EXT_ray_tracing : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+struct _13
+{
+    float _m0;
+};
+
+struct _17
+{
+    vec4 _m0;
+};
+
+vec4 _42;
+
+layout(set = 40, binding = 30) uniform accelerationStructureEXT AS;
+layout(set = 20, binding = 10) uniform writeonly image2D IMG;
+layout(location = 0) rayPayloadEXT _13 _15;
+layout(location = 1) rayPayloadEXT _17 _19;
+
+void main()
+{
+    traceRayEXT(AS, 0u, 0u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 1);
+    traceRayEXT(AS, 0u, 1u, 0u, 0u, 0u, vec3(1.0, 2.0, 3.0), 1.0, vec3(0.0, 0.0, 1.0), 4.0, 0);
+    vec4 _41;
+    _41.x = _15._m0;
+    imageStore(IMG, ivec2(uvec2(0u)), vec4(_41.xxxx + _19._m0));
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 55
+; Schema: 0
+OpCapability Shader
+OpCapability UniformBufferArrayDynamicIndexing
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageWriteWithoutFormat
+OpCapability RayTracingKHR
+OpCapability RuntimeDescriptorArray
+OpCapability UniformBufferArrayNonUniformIndexing
+OpCapability SampledImageArrayNonUniformIndexing
+OpCapability StorageBufferArrayNonUniformIndexing
+OpCapability StorageImageArrayNonUniformIndexing
+OpExtension "SPV_EXT_descriptor_indexing"
+OpExtension "SPV_KHR_ray_tracing"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %3 "main" %8 %12 %15 %19
+OpName %3 "main"
+OpName %8 "AS"
+OpName %12 "IMG"
+OpName %13 ""
+OpName %17 ""
+OpDecorate %8 DescriptorSet 40
+OpDecorate %8 Binding 30
+OpDecorate %12 DescriptorSet 20
+OpDecorate %12 Binding 10
+OpDecorate %12 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 1
+%6 = OpTypeAccelerationStructureKHR
+%7 = OpTypePointer UniformConstant %6
+%8 = OpVariable %7 UniformConstant
+%9 = OpTypeFloat 32
+%10 = OpTypeImage %9 2D 0 0 0 2 Unknown
+%11 = OpTypePointer UniformConstant %10
+%12 = OpVariable %11 UniformConstant
+%13 = OpTypeStruct %9
+%14 = OpTypePointer RayPayloadKHR %13
+%15 = OpVariable %14 RayPayloadKHR
+%16 = OpTypeVector %9 4
+%17 = OpTypeStruct %16
+%18 = OpTypePointer RayPayloadKHR %17
+%19 = OpVariable %18 RayPayloadKHR
+%21 = OpTypeInt 32 0
+%22 = OpConstant %21 0
+%23 = OpConstant %9 1
+%24 = OpConstant %9 0
+%25 = OpConstant %9 2
+%26 = OpConstant %9 3
+%27 = OpConstant %9 4
+%28 = OpTypeVector %9 3
+%31 = OpTypePointer RayPayloadKHR %16
+%35 = OpConstant %21 1
+%38 = OpTypePointer RayPayloadKHR %9
+%50 = OpTypeVector %21 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%42 = OpUndef %16
+OpBranch %53
+%53 = OpLabel
+%20 = OpLoad %6 %8
+%29 = OpCompositeConstruct %28 %23 %25 %26
+%30 = OpCompositeConstruct %28 %24 %24 %23
+OpTraceRayKHR %20 %22 %22 %22 %22 %22 %29 %23 %30 %27 %19
+%32 = OpInBoundsAccessChain %31 %19 %22
+%33 = OpLoad %16 %32
+%34 = OpLoad %6 %8
+%36 = OpCompositeConstruct %28 %23 %25 %26
+%37 = OpCompositeConstruct %28 %24 %24 %23
+OpTraceRayKHR %34 %22 %35 %22 %22 %22 %36 %23 %37 %27 %15
+%39 = OpInBoundsAccessChain %38 %15 %22
+%40 = OpLoad %9 %39
+%41 = OpCompositeInsert %16 %40 %42 0
+%43 = OpVectorShuffle %16 %41 %42 0 0 0 0
+%44 = OpFAdd %16 %43 %33
+%45 = OpLoad %10 %12
+%46 = OpCompositeExtract %9 %44 0
+%47 = OpCompositeExtract %9 %44 1
+%48 = OpCompositeExtract %9 %44 2
+%49 = OpCompositeExtract %9 %44 3
+%51 = OpCompositeConstruct %50 %22 %22
+%52 = OpCompositeConstruct %16 %46 %47 %48 %49
+OpImageWrite %45 %51 %52
+OpReturn
+OpFunctionEnd
+#endif

--- a/shaders/stages/raygen-hitobject-attr.sm69.noglsl.rgen
+++ b/shaders/stages/raygen-hitobject-attr.sm69.noglsl.rgen
@@ -1,0 +1,62 @@
+using namespace dx;
+
+struct [raypayload] Payload
+{
+	float4 color : write(closesthit, miss) : read(caller);
+};
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload payload;
+	HitObject hit = HitObject::TraceRay(AS, RAY_FLAG_NONE, 0, 0, 0, 0, ray, payload);
+
+	float4 color;
+	if (hit.IsHit())
+	{
+		float3 temp_f3 = hit.GetRayTMin();
+		temp_f3.y = hit.GetRayTCurrent();
+		temp_f3 += hit.GetWorldRayOrigin();
+		temp_f3 += hit.GetWorldRayDirection();
+		temp_f3 += hit.GetObjectRayOrigin();
+		temp_f3 += hit.GetObjectRayDirection();
+		temp_f3 += hit.GetObjectToWorld3x4()[0].xyz;
+		temp_f3 += hit.GetObjectToWorld4x3()[0];
+		temp_f3 += hit.GetWorldToObject3x4()[0].xyz;
+		temp_f3 += hit.GetWorldToObject4x3()[0];
+
+		uint temp_u = hit.GetRayFlags();
+		temp_u += hit.GetInstanceIndex();
+		temp_u += hit.GetInstanceID();
+		temp_u += hit.GetGeometryIndex();
+		temp_u += hit.GetPrimitiveIndex();
+		temp_u += hit.GetHitKind();
+		temp_u += hit.GetShaderTableIndex();
+
+		BuiltInTriangleIntersectionAttributes attr;
+		hit.GetAttributes(attr);
+
+		color = float4(temp_f3, temp_u);
+		color += float4(attr.barycentrics.x, attr.barycentrics.x, payload.color.z, 1);
+	}
+	else if (hit.IsMiss())
+	{
+		color = float4(1, 0, 0, 1);
+	}
+	else if (hit.IsNop())
+	{
+		color = float4(0, 1, 0, 1);
+	}
+
+
+	IMG[int2(0, 0)] = color;
+}

--- a/shaders/stages/raygen-hitobject-rayquery.sm69.noglsl.rgen
+++ b/shaders/stages/raygen-hitobject-rayquery.sm69.noglsl.rgen
@@ -1,0 +1,81 @@
+using namespace dx;
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+struct [RayPayload] RayPayload
+{
+    float3 value : read (caller): write(caller, closesthit);
+};
+
+struct Attributes
+{
+    float2 uv;
+};
+
+
+[shader("raygeneration")]
+void RayGeneration()
+{
+    uint2 pixel = DispatchRaysIndex().xy;
+
+    RayQuery<RAY_FLAG_CULL_NON_OPAQUE> q;
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.TMin = 4;
+	ray.Direction = float3(5, 6, 7);
+	ray.TMax = 8;
+
+	q.TraceRayInline(AS, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, 0xFF, ray);
+
+	Attributes committedAttributes;
+	uint committedCustomHitKind = 0;
+
+	while (q.Proceed())
+	{
+		if (q.CandidateType() == CANDIDATE_NON_OPAQUE_TRIANGLE)
+		{
+			q.CommitNonOpaqueTriangleHit();
+		}
+		else if (q.CandidateType() == CANDIDATE_PROCEDURAL_PRIMITIVE)
+		{
+			Attributes candidateAttributes;
+
+			if (q.CandidatePrimitiveIndex() > 2)
+			{
+				continue;
+			}
+
+			q.CommitProceduralPrimitiveHit(q.RayTMin());
+
+			committedAttributes.uv = q.CandidateObjectRayOrigin().xy;
+			committedCustomHitKind = q.CandidateObjectRayDirection().z;
+		}
+	}
+
+	RayPayload payload;
+	payload.value = 0.0f;
+
+	COMMITTED_STATUS status = q.CommittedStatus();
+
+	if (status == COMMITTED_PROCEDURAL_PRIMITIVE_HIT)
+	{
+		HitObject hit = HitObject::FromRayQuery(q, committedCustomHitKind, committedAttributes);
+		hit.SetShaderTableIndex(0);
+		MaybeReorderThread(hit);
+		HitObject::Invoke(hit, payload);
+	}
+	else if (status == COMMITTED_TRIANGLE_HIT)
+	{
+		HitObject hit = HitObject::FromRayQuery(q);
+		hit.SetShaderTableIndex(1);
+		MaybeReorderThread(hit);
+		HitObject::Invoke(hit, payload);
+	}
+	else
+	{
+		payload.value = float3(0.1, 0.2, 0.3);
+	}
+
+	IMG[pixel] = float4(payload.value, 1);
+}

--- a/shaders/stages/raygen-hitobject-reorder.sm69.noglsl.rgen
+++ b/shaders/stages/raygen-hitobject-reorder.sm69.noglsl.rgen
@@ -1,0 +1,26 @@
+using namespace dx;
+
+struct [raypayload] Payload
+{
+	float4 color : write(closesthit, miss) : read(caller);
+};
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload payload;
+	HitObject hit = HitObject::TraceRay(AS, RAY_FLAG_NONE, 0, 0, 0, 0, ray, payload);
+	MaybeReorderThread(hit);
+	HitObject::Invoke(hit, payload);
+
+	IMG[int2(0, 0)] = payload.color;
+}

--- a/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
+++ b/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
@@ -1,0 +1,32 @@
+using namespace dx;
+
+struct [raypayload] Payload
+{
+	float4 color : write(closesthit, miss) : read(caller);
+};
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	const uint2 pixelIndex = DispatchRaysIndex().xy;
+
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload payload;
+	HitObject hit = HitObject::TraceRay(AS, RAY_FLAG_NONE, 0, 0, 0, 0, ray, payload);
+
+	uint index = hit.GetShaderTableIndex();
+	uint value = hit.LoadLocalRootTableConstant(4);
+	hit.SetShaderTableIndex(index * value);
+
+	HitObject::Invoke(hit, payload);
+
+	IMG[int2(0, 0)] = payload.color;
+}

--- a/shaders/stages/raygen-hitobject.sm69.noglsl.rgen
+++ b/shaders/stages/raygen-hitobject.sm69.noglsl.rgen
@@ -1,0 +1,33 @@
+using namespace dx;
+
+struct [raypayload] Payload
+{
+	float4 color : write(closesthit, miss) : read(caller);
+};
+
+struct [raypayload] Payload1
+{
+	float color : write(closesthit, miss) : read(caller);
+};
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload payload0;
+	Payload1 payload1;
+	HitObject hit0 = HitObject::TraceRay(AS, RAY_FLAG_NONE, 0, 0, 0, 0, ray, payload0);
+	HitObject::Invoke(hit0, payload0);
+	HitObject hit1 = HitObject::TraceRay(AS, RAY_FLAG_NONE, 1, 0, 0, 0, ray, payload1);
+	HitObject::Invoke(hit1, payload1);
+
+	IMG[int2(0, 0)] = payload0.color + payload1.color;
+}

--- a/shaders/stages/raygen.sm69.rgen
+++ b/shaders/stages/raygen.sm69.rgen
@@ -1,0 +1,29 @@
+struct [raypayload] Payload
+{
+	float4 color : write(closesthit, miss) : read(caller);
+};
+
+struct [raypayload] Payload1
+{
+	float color : write(closesthit, miss) : read(caller);
+};
+
+RaytracingAccelerationStructure AS : register(t30, space40);
+RWTexture2D<float4> IMG : register(u10, space20);
+
+[shader("raygeneration")]
+void RayGen()
+{
+	RayDesc ray;
+	ray.Origin = float3(1, 2, 3);
+	ray.Direction = float3(0, 0, 1);
+	ray.TMin = 1.0;
+	ray.TMax = 4.0;
+
+	Payload payload0;
+	Payload1 payload1;
+	TraceRay(AS, RAY_FLAG_NONE, 0, 0, 0, 0, ray, payload0);
+	TraceRay(AS, RAY_FLAG_NONE, 1, 0, 0, 0, ray, payload1);
+
+	IMG[int2(0, 0)] = payload0.color + payload1.color;
+}

--- a/third_party/glslang-spirv/SpvBuilder.cpp
+++ b/third_party/glslang-spirv/SpvBuilder.cpp
@@ -225,6 +225,22 @@ Id Builder::makeHitObjectNVType()
     return type->getResultId();
 }
 
+Id Builder::makeHitObjectType()
+{
+    Instruction *type;
+    if (!hit_object_type)
+    {
+        type = new Instruction(getUniqueId(), NoType, OpTypeHitObjectEXT);
+        hit_object_type = type;
+        constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
+        module.mapInstruction(type);
+    } else
+        type = hit_object_type;
+
+    return type->getResultId();
+}
+
+
 Id Builder::makePointer(StorageClass storageClass, Id pointee)
 {
     // try to find it

--- a/third_party/glslang-spirv/SpvBuilder.h
+++ b/third_party/glslang-spirv/SpvBuilder.h
@@ -137,6 +137,7 @@ public:
     Id makeAccelerationStructureType();
     Id makeRayQueryType();
     Id makeHitObjectNVType();
+    Id makeHitObjectType();
     Id makeSamplerType();
     Id makeSampledImageType(Id imageType);
 
@@ -692,6 +693,7 @@ protected:
     Instruction *acceleration_structure_type = nullptr;
     Instruction *ray_query_type = nullptr;
     Instruction *hit_object_nv_type = nullptr;
+    Instruction *hit_object_type = nullptr;
 
     // stack of switches
     std::stack<Block*> switchMerges;


### PR DESCRIPTION
Implementations are based on existing NVAPI extension implementation.