### PR TITLE
Fix nested loops sharing a merge block when no ladder candidate is found

### DIFF
--- a/cfg_structurizer.cpp
+++ b/cfg_structurizer.cpp
@@ -7114,11 +7114,24 @@ bool CFGStructurizer::find_loops(unsigned pass)
 					//     dominated_merge->name.c_str());
 				//}
 
-				// We will use this block as a ladder.
-				node->loop_ladder_block = dominated_merge;
-				node->loop_merge_block = merge;
+				// If this merge target is already claimed by another header, adopting it would emit
+				// two OpLoopMerge to the same block (invalid SPIR-V). When we dominate a private ladder,
+				// merge to that instead and freeze so pass 1 preserves it rather than re-sharing merge.
+				if (dominated_merge && !merge->headers.empty() && node->dominates(dominated_merge))
+				{
+					node->loop_ladder_block = nullptr;
+					node->loop_merge_block = dominated_merge;
+					node->freeze_structured_analysis = true;
+					const_cast<CFGNode *>(node->loop_merge_block)->add_unique_header(node);
+				}
+				else
+				{
+					// We will use this block as a ladder.
+					node->loop_ladder_block = dominated_merge;
+					node->loop_merge_block = merge;
 
-				const_cast<CFGNode *>(node->loop_merge_block)->add_unique_header(node);
+					const_cast<CFGNode *>(node->loop_merge_block)->add_unique_header(node);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Structurizer emits invalid SPIR-V on some shaders - two loop headers sharing one merge block, which spirv-val rejects ("Block is already a merge block for another header"). Happens on nested loops that log "There is no candidate for ladder merging".

Cause: when analyze_loop_merge finds no dominated ladder candidate, find_loops falls back to the common post-dominator for loop_merge_block, and two nested loops sharing it both claim it. split_merge_blocks fixes this in pass 0, but pass 1 re-runs find_loops and re-creates the collision, and split_merge_blocks only runs in pass 0. (Running it in pass 1 too asserts later in insert_phi on a null frontier.)

Fix: at the emit site, if the merge block is already claimed by another header and we dominate a private ladder, merge to the ladder and freeze the loop so pass 1 preserves it instead of re-sharing.

Testing: broken shaders now pass spirv-val; full reference suite clean except wave-multi-prefix-op, which already mismatches on baseline here (DXC version thing).

Came from real shaders - RenoDX HDR passes on a DX12 game via vkd3d-proton. nvidia's compiler was hard-crashing on the invalid SPIR-V, RADV/NVK were fine. Rebuilt with the fix and the game renders fine now.

Repro: have the full DXIL (real game shader, ~54KB), can attach. Didn't reduce it down - you'll know better what you want in the suite.
