### PR TITLE
Minor LoadLocalRootTableConstant changes

### DIFF
--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -686,11 +686,13 @@ static bool emit_nvapi_extn_op_hit_object_load_local_root_table_constant(Convert
 	auto &builder = impl.builder();
 
 	spv::Id uint32 = builder.makeUintType(32);
-	spv::Id uint64 = builder.makeUintType(64);
 
 	if (!impl.nvapi.hit_object_srb_ptr)
 	{
-		spv::Id srb_struct = builder.makeStructType({ uint32 }, "HitObjectSRB");
+		spv::Id srb_array = builder.makeRuntimeArray(uint32);
+		builder.addDecoration(srb_array, spv::DecorationArrayStride, sizeof(uint32_t));
+
+		spv::Id srb_struct = builder.makeStructType({ srb_array }, "HitObjectSRB");
 
 		builder.addDecoration(srb_struct, spv::DecorationBlock);
 		builder.addDecoration(srb_struct, spv::DecorationHitObjectShaderRecordBufferNV);
@@ -706,26 +708,23 @@ static bool emit_nvapi_extn_op_hit_object_load_local_root_table_constant(Convert
 	op->add_id(hit_object);
 	impl.add(op);
 
-	auto *cast_op = impl.allocate(spv::OpBitcast, uint64);
+	auto *cast_op = impl.allocate(spv::OpBitcast, builder.makeUintType(64));
 	cast_op->add_id(op->id);
 	impl.add(cast_op);
 
-	auto *convert_op = impl.allocate(spv::OpUConvert, uint64);
-	convert_op->add_id(offset);
+	auto *convert_op = impl.allocate(spv::OpConvertUToPtr, impl.nvapi.hit_object_srb_ptr);
+	convert_op->add_id(cast_op->id);
 	impl.add(convert_op);
 
-	auto *add_op = impl.allocate(spv::OpIAdd, uint64);
-	add_op->add_id(cast_op->id);
-	add_op->add_id(convert_op->id);
-	impl.add(add_op);
+	auto *index_op = impl.allocate(spv::OpShiftRightLogical, uint32);
+	index_op->add_id(offset);
+	index_op->add_id(builder.makeUintConstant(2));
+	impl.add(index_op);
 
-	convert_op = impl.allocate(spv::OpConvertUToPtr, impl.nvapi.hit_object_srb_ptr);
-	convert_op->add_id(add_op->id);
-	impl.add(convert_op);
-
-	auto *chain_op = impl.allocate(spv::OpAccessChain, impl.nvapi.hit_object_srb_member_ptr);
+	auto *chain_op = impl.allocate(spv::OpInBoundsAccessChain, impl.nvapi.hit_object_srb_member_ptr);
 	chain_op->add_id(convert_op->id);
 	chain_op->add_id(builder.makeUintConstant(0));
+	chain_op->add_id(index_op->id);
 	impl.add(chain_op);
 
 	auto *load_op = impl.allocate(spv::OpLoad, uint32);

--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -708,13 +708,9 @@ static bool emit_nvapi_extn_op_hit_object_load_local_root_table_constant(Convert
 	op->add_id(hit_object);
 	impl.add(op);
 
-	auto *cast_op = impl.allocate(spv::OpBitcast, builder.makeUintType(64));
+	auto *cast_op = impl.allocate(spv::OpBitcast, impl.nvapi.hit_object_srb_ptr);
 	cast_op->add_id(op->id);
 	impl.add(cast_op);
-
-	auto *convert_op = impl.allocate(spv::OpConvertUToPtr, impl.nvapi.hit_object_srb_ptr);
-	convert_op->add_id(cast_op->id);
-	impl.add(convert_op);
 
 	auto *index_op = impl.allocate(spv::OpShiftRightLogical, uint32);
 	index_op->add_id(offset);
@@ -722,7 +718,7 @@ static bool emit_nvapi_extn_op_hit_object_load_local_root_table_constant(Convert
 	impl.add(index_op);
 
 	auto *chain_op = impl.allocate(spv::OpInBoundsAccessChain, impl.nvapi.hit_object_srb_member_ptr);
-	chain_op->add_id(convert_op->id);
+	chain_op->add_id(cast_op->id);
 	chain_op->add_id(builder.makeUintConstant(0));
 	chain_op->add_id(index_op->id);
 	impl.add(chain_op);

--- a/opcodes/dxil/dxil_ray_tracing.cpp
+++ b/opcodes/dxil/dxil_ray_tracing.cpp
@@ -1008,13 +1008,9 @@ bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl 
 	op->add_id(hit_object);
 	impl.add(op);
 
-	auto *cast_op = impl.allocate(spv::OpBitcast, builder.makeUintType(64));
+	auto *cast_op = impl.allocate(spv::OpBitcast, impl.hit_object.shader_record_buffer_ptr);
 	cast_op->add_id(op->id);
 	impl.add(cast_op);
-
-	auto *convert_op = impl.allocate(spv::OpConvertUToPtr, impl.hit_object.shader_record_buffer_ptr);
-	convert_op->add_id(cast_op->id);
-	impl.add(convert_op);
 
 	auto *index_op = impl.allocate(spv::OpShiftRightLogical, uint32);
 	index_op->add_id(offset);
@@ -1022,7 +1018,7 @@ bool emit_hit_object_load_local_root_table_constant_instruction(Converter::Impl 
 	impl.add(index_op);
 
 	auto *chain_op = impl.allocate(spv::OpInBoundsAccessChain, impl.hit_object.shader_record_buffer_member_ptr);
-	chain_op->add_id(convert_op->id);
+	chain_op->add_id(cast_op->id);
 	chain_op->add_id(builder.makeUintConstant(0));
 	chain_op->add_id(index_op->id);
 	impl.add(chain_op);

--- a/reference/shaders/nvapi/hit-object.local-root-signature.noglsl.nvapi.ssbo.rgen
+++ b/reference/shaders/nvapi/hit-object.local-root-signature.noglsl.nvapi.ssbo.rgen
@@ -1,10 +1,9 @@
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 202
+; Bound: 200
 ; Schema: 0
 OpCapability Shader
-OpCapability Int64
 OpCapability UniformBufferArrayDynamicIndexing
 OpCapability SampledImageArrayDynamicIndexing
 OpCapability StorageBufferArrayDynamicIndexing
@@ -146,9 +145,8 @@ OpMemberDecorate %137 0 NonWritable
 %137 = OpTypeStruct %136
 %138 = OpTypePointer PhysicalStorageBuffer %137
 %139 = OpTypePointer PhysicalStorageBuffer %5
-%141 = OpTypeInt 64 0
-%147 = OpConstant %5 12
-%191 = OpTypePointer HitObjectAttributeNV %27
+%145 = OpConstant %5 12
+%189 = OpTypePointer HitObjectAttributeNV %27
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 %44 = OpVariable %43 Function
@@ -156,8 +154,8 @@ OpMemberDecorate %137 0 NonWritable
 %81 = OpVariable %43 Function
 %85 = OpVariable %43 Function
 %90 = OpVariable %43 Function
-OpBranch %200
-%200 = OpLabel
+OpBranch %198
+%198 = OpLabel
 OpHitObjectRecordEmptyNV %44
 %46 = OpBitcast %26 %47
 %48 = OpBitcast %26 %49
@@ -235,74 +233,73 @@ OpStore %131 %129
 %134 = OpAccessChain %94 %25 %45 %133
 OpStore %134 %132
 %140 = OpHitObjectGetShaderRecordBufferHandleNV %10 %90
-%142 = OpBitcast %141 %140
-%143 = OpConvertUToPtr %138 %142
-%144 = OpShiftRightLogical %5 %135 %68
-%145 = OpInBoundsAccessChain %139 %143 %45 %144
-%146 = OpLoad %5 %145 Aligned 4
-%148 = OpAccessChain %94 %25 %45 %147
-OpStore %148 %146
-%149 = OpHitObjectGetRayTMinNV %26 %90
+%141 = OpBitcast %138 %140
+%142 = OpShiftRightLogical %5 %135 %68
+%143 = OpInBoundsAccessChain %139 %141 %45 %142
+%144 = OpLoad %5 %143 Aligned 4
+%146 = OpAccessChain %94 %25 %45 %145
+OpStore %146 %144
+%147 = OpHitObjectGetRayTMinNV %26 %90
+%148 = OpBitcast %5 %147
+%149 = OpHitObjectGetRayTMaxNV %26 %90
 %150 = OpBitcast %5 %149
-%151 = OpHitObjectGetRayTMaxNV %26 %90
-%152 = OpBitcast %5 %151
-%153 = OpHitObjectGetWorldRayOriginNV %62 %90
-%154 = OpCompositeExtract %26 %153 0
+%151 = OpHitObjectGetWorldRayOriginNV %62 %90
+%152 = OpCompositeExtract %26 %151 0
+%153 = OpBitcast %5 %152
+%154 = OpCompositeExtract %26 %151 1
 %155 = OpBitcast %5 %154
-%156 = OpCompositeExtract %26 %153 1
+%156 = OpCompositeExtract %26 %151 2
 %157 = OpBitcast %5 %156
-%158 = OpCompositeExtract %26 %153 2
-%159 = OpBitcast %5 %158
-%160 = OpHitObjectGetWorldRayDirectionNV %62 %90
-%161 = OpCompositeExtract %26 %160 0
+%158 = OpHitObjectGetWorldRayDirectionNV %62 %90
+%159 = OpCompositeExtract %26 %158 0
+%160 = OpBitcast %5 %159
+%161 = OpCompositeExtract %26 %158 1
 %162 = OpBitcast %5 %161
-%163 = OpCompositeExtract %26 %160 1
+%163 = OpCompositeExtract %26 %158 2
 %164 = OpBitcast %5 %163
-%165 = OpCompositeExtract %26 %160 2
-%166 = OpBitcast %5 %165
-%167 = OpBitcast %26 %150
-%168 = OpBitcast %26 %152
-%169 = OpBitcast %26 %155
-%170 = OpBitcast %26 %157
-%171 = OpBitcast %26 %159
-%172 = OpBitcast %26 %162
-%173 = OpBitcast %26 %164
-%174 = OpBitcast %26 %166
-%175 = OpBitcast %5 %167
-%176 = OpAccessChain %94 %21 %45 %45
+%165 = OpBitcast %26 %148
+%166 = OpBitcast %26 %150
+%167 = OpBitcast %26 %153
+%168 = OpBitcast %26 %155
+%169 = OpBitcast %26 %157
+%170 = OpBitcast %26 %160
+%171 = OpBitcast %26 %162
+%172 = OpBitcast %26 %164
+%173 = OpBitcast %5 %165
+%174 = OpAccessChain %94 %21 %45 %45
+OpStore %174 %173
+%175 = OpBitcast %5 %166
+%176 = OpAccessChain %94 %21 %45 %67
 OpStore %176 %175
-%177 = OpBitcast %5 %168
-%178 = OpAccessChain %94 %21 %45 %67
+%177 = OpBitcast %5 %167
+%178 = OpAccessChain %94 %21 %45 %68
 OpStore %178 %177
-%179 = OpBitcast %5 %169
-%180 = OpAccessChain %94 %21 %45 %68
+%179 = OpBitcast %5 %168
+%180 = OpAccessChain %94 %21 %45 %69
 OpStore %180 %179
-%181 = OpBitcast %5 %170
-%182 = OpAccessChain %94 %21 %45 %69
+%181 = OpBitcast %5 %169
+%182 = OpAccessChain %94 %21 %45 %70
 OpStore %182 %181
-%183 = OpBitcast %5 %171
-%184 = OpAccessChain %94 %21 %45 %70
+%183 = OpBitcast %5 %170
+%184 = OpAccessChain %94 %21 %45 %6
 OpStore %184 %183
-%185 = OpBitcast %5 %172
-%186 = OpAccessChain %94 %21 %45 %6
+%185 = OpBitcast %5 %171
+%186 = OpAccessChain %94 %21 %45 %8
 OpStore %186 %185
-%187 = OpBitcast %5 %173
-%188 = OpAccessChain %94 %21 %45 %8
+%187 = OpBitcast %5 %172
+%188 = OpAccessChain %94 %21 %45 %121
 OpStore %188 %187
-%189 = OpBitcast %5 %174
-%190 = OpAccessChain %94 %21 %45 %121
-OpStore %190 %189
 OpHitObjectGetAttributesNV %90 %30
-%192 = OpInBoundsAccessChain %191 %30 %45
-%193 = OpLoad %27 %192
-%194 = OpCompositeExtract %26 %193 0
-%195 = OpBitcast %5 %194
-%196 = OpAccessChain %94 %21 %45 %124
-OpStore %196 %195
-%197 = OpCompositeExtract %26 %193 1
-%198 = OpBitcast %5 %197
-%199 = OpAccessChain %94 %21 %45 %127
-OpStore %199 %198
+%190 = OpInBoundsAccessChain %189 %30 %45
+%191 = OpLoad %27 %190
+%192 = OpCompositeExtract %26 %191 0
+%193 = OpBitcast %5 %192
+%194 = OpAccessChain %94 %21 %45 %124
+OpStore %194 %193
+%195 = OpCompositeExtract %26 %191 1
+%196 = OpBitcast %5 %195
+%197 = OpAccessChain %94 %21 %45 %127
+OpStore %197 %196
 OpReturn
 OpFunctionEnd
 

--- a/reference/shaders/nvapi/hit-object.local-root-signature.noglsl.nvapi.ssbo.rgen
+++ b/reference/shaders/nvapi/hit-object.local-root-signature.noglsl.nvapi.ssbo.rgen
@@ -65,6 +65,7 @@ OpDecorate %23 Block
 OpDecorate %25 DescriptorSet 0
 OpDecorate %25 Binding 2
 OpDecorate %25 NonReadable
+OpDecorate %136 ArrayStride 4
 OpDecorate %137 Block
 OpDecorate %137 HitObjectShaderRecordBufferNV
 OpMemberDecorate %137 0 Offset 0
@@ -141,10 +142,11 @@ OpMemberDecorate %137 0 NonWritable
 %130 = OpConstant %5 10
 %133 = OpConstant %5 11
 %135 = OpConstant %5 32
-%136 = OpTypeInt 64 0
-%137 = OpTypeStruct %5
+%136 = OpTypeRuntimeArray %5
+%137 = OpTypeStruct %136
 %138 = OpTypePointer PhysicalStorageBuffer %137
 %139 = OpTypePointer PhysicalStorageBuffer %5
+%141 = OpTypeInt 64 0
 %147 = OpConstant %5 12
 %191 = OpTypePointer HitObjectAttributeNV %27
 %3 = OpFunction %1 None %2
@@ -233,11 +235,10 @@ OpStore %131 %129
 %134 = OpAccessChain %94 %25 %45 %133
 OpStore %134 %132
 %140 = OpHitObjectGetShaderRecordBufferHandleNV %10 %90
-%141 = OpBitcast %136 %140
-%142 = OpUConvert %136 %135
-%143 = OpIAdd %136 %141 %142
-%144 = OpConvertUToPtr %138 %143
-%145 = OpAccessChain %139 %144 %45
+%142 = OpBitcast %141 %140
+%143 = OpConvertUToPtr %138 %142
+%144 = OpShiftRightLogical %5 %135 %68
+%145 = OpInBoundsAccessChain %139 %143 %45 %144
 %146 = OpLoad %5 %145 Aligned 4
 %148 = OpAccessChain %94 %25 %45 %147
 OpStore %148 %146

--- a/reference/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
+++ b/reference/shaders/stages/raygen-hitobject-shadertable.sm69.noglsl.local-root-signature.rgen
@@ -1,10 +1,9 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 69
+; Bound: 67
 ; Schema: 0
 OpCapability Shader
-OpCapability Int64
 OpCapability UniformBufferArrayDynamicIndexing
 OpCapability SampledImageArrayDynamicIndexing
 OpCapability StorageBufferArrayDynamicIndexing
@@ -95,13 +94,12 @@ OpMemberDecorate %46 0 NonWritable
 %46 = OpTypeStruct %45
 %47 = OpTypePointer PhysicalStorageBuffer %46
 %48 = OpTypePointer PhysicalStorageBuffer %5
-%50 = OpTypeInt 64 0
-%54 = OpConstant %5 2
+%52 = OpConstant %5 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 %39 = OpVariable %38 Function
-OpBranch %67
-%67 = OpLabel
+OpBranch %65
+%65 = OpLabel
 %27 = OpLoad %15 %17
 %35 = OpCompositeConstruct %34 %29 %31 %32
 %36 = OpCompositeConstruct %34 %30 %30 %29
@@ -110,25 +108,24 @@ OpHitObjectTraceRayEXT %39 %27 %28 %28 %28 %28 %28 %35 %29 %36 %33 %26
 %42 = OpLoad %22 %41
 %43 = OpHitObjectGetShaderBindingTableRecordIndexEXT %5 %39
 %49 = OpHitObjectGetShaderRecordBufferHandleEXT %10 %39
-%51 = OpBitcast %50 %49
-%52 = OpConvertUToPtr %47 %51
-%53 = OpShiftRightLogical %5 %44 %54
-%55 = OpInBoundsAccessChain %48 %52 %28 %53
-%56 = OpLoad %5 %55 Aligned 4
-%57 = OpIMul %5 %56 %43
-OpHitObjectSetShaderBindingTableRecordIndexEXT %39 %57
-%58 = OpInBoundsAccessChain %40 %25 %28
-OpStore %58 %42
+%50 = OpBitcast %47 %49
+%51 = OpShiftRightLogical %5 %44 %52
+%53 = OpInBoundsAccessChain %48 %50 %28 %51
+%54 = OpLoad %5 %53 Aligned 4
+%55 = OpIMul %5 %54 %43
+OpHitObjectSetShaderBindingTableRecordIndexEXT %39 %55
+%56 = OpInBoundsAccessChain %40 %25 %28
+OpStore %56 %42
 OpHitObjectExecuteShaderEXT %39 %25
-%59 = OpLoad %22 %58
-%60 = OpLoad %19 %21
-%61 = OpCompositeExtract %18 %59 0
-%62 = OpCompositeExtract %18 %59 1
-%63 = OpCompositeExtract %18 %59 2
-%64 = OpCompositeExtract %18 %59 3
-%65 = OpCompositeConstruct %10 %28 %28
-%66 = OpCompositeConstruct %22 %61 %62 %63 %64
-OpImageWrite %60 %65 %66
+%57 = OpLoad %22 %56
+%58 = OpLoad %19 %21
+%59 = OpCompositeExtract %18 %57 0
+%60 = OpCompositeExtract %18 %57 1
+%61 = OpCompositeExtract %18 %57 2
+%62 = OpCompositeExtract %18 %57 3
+%63 = OpCompositeConstruct %10 %28 %28
+%64 = OpCompositeConstruct %22 %59 %60 %61 %62
+OpImageWrite %58 %63 %64
 OpReturn
 OpFunctionEnd
 


### PR DESCRIPTION
Two small things:

* Backport of https://github.com/HansKristian-Work/dxil-spirv/commit/4b196fc41223c1463240283e510621619479d073 for `NvHitObject` (first commit).
* Removal of `OpConvertUToPtr` from both implementations (second and third commits).

If my understanding of https://github.khronos.org/SPIRV-Registry/extensions/KHR/SPV_KHR_physical_storage_buffer.html is correct, then the following allows us to use only `OpBitcast` for the pointer conversion:

> Modify OpBitcast to allow vector conversions to/from pointers, by changing this existing rule:
>
> > "If Result Type is a pointer, Operand must be a pointer or integer scalar. If Operand is a pointer, Result Type must be a pointer or integer scalar."
>
> to instead say:
>
> > "If either Result Type or Operand is a pointer, the other must be a pointer, an integer scalar, or an integer vector."