### PR TITLE
Disable NVAPI fp16atomic opcode implementation

### DIFF
--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -882,6 +882,7 @@ bool NVAPIState::can_commit_opcode()
 			return fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] != nullptr;
 
 		default:
+			LOGE("NVAPI opcode %u not supported.\n", opcode);
 			return false;
 		}
 	}

--- a/opcodes/dxil/dxil_nvapi.cpp
+++ b/opcodes/dxil/dxil_nvapi.cpp
@@ -808,7 +808,9 @@ bool NVAPIState::can_commit_opcode()
 			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 2] != nullptr;
 
 		case NV_EXTN_OP_FP16_ATOMIC:
-			return marked_uav &&
+			LOGE("NVAPI opcode %u not fully implemented.\n", opcode);
+			return false && // emit_nvapi_extn_op_fp16x2_atomic is currently just a dummy implementation
+			       marked_uav &&
 			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC0U + 0] != nullptr &&
 			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC1U + 0] != nullptr &&
 			       fake_doorbell_inputs[NVAPI_ARGUMENT_SRC2U + 0] != nullptr;

--- a/reference/shaders/nvapi/bringup.nvapi.ssbo.rgen
+++ b/reference/shaders/nvapi/bringup.nvapi.ssbo.rgen
@@ -8,20 +8,9 @@ layout(set = 0, binding = 0, std430) writeonly buffer BlahSSBO
     uint _m0[];
 } Blah;
 
-layout(set = 0, binding = 1, std430) writeonly buffer BABSSBO
-{
-    uint _m0[];
-} BAB;
-
-layout(set = 0, binding = 2) uniform writeonly image1D RWTex;
-
 void main()
 {
     Blah._m0[gl_LaunchIDEXT.x] = subgroupShuffle(gl_LaunchIDEXT.x, 9u);
-    uint _33 = atomicAdd(BAB._m0[64u], 9u);
-    Blah._m0[100u] = _33;
-    imageStore(RWTex, int(gl_LaunchIDEXT.x), vec4(2.0));
-    Blah._m0[101u] = 42u;
 }
 
 
@@ -30,15 +19,13 @@ void main()
 ; SPIR-V
 ; Version: 1.4
 ; Generator: Unknown(30017); 21022
-; Bound: 47
+; Bound: 25
 ; Schema: 0
 OpCapability Shader
 OpCapability UniformBufferArrayDynamicIndexing
 OpCapability SampledImageArrayDynamicIndexing
 OpCapability StorageBufferArrayDynamicIndexing
 OpCapability StorageImageArrayDynamicIndexing
-OpCapability Image1D
-OpCapability StorageImageWriteWithoutFormat
 OpCapability GroupNonUniformShuffle
 OpCapability RayTracingKHR
 OpCapability RuntimeDescriptorArray
@@ -49,29 +36,17 @@ OpCapability StorageImageArrayNonUniformIndexing
 OpExtension "SPV_EXT_descriptor_indexing"
 OpExtension "SPV_KHR_ray_tracing"
 OpMemoryModel Logical GLSL450
-OpEntryPoint RayGenerationKHR %3 "main" %9 %13 %17 %20
+OpEntryPoint RayGenerationKHR %3 "main" %9 %12
 OpName %3 "main"
 OpName %7 "BlahSSBO"
 OpName %9 "Blah"
-OpName %11 "BABSSBO"
-OpName %13 "BAB"
-OpName %17 "RWTex"
 OpDecorate %6 ArrayStride 4
 OpMemberDecorate %7 0 Offset 0
 OpDecorate %7 Block
 OpDecorate %9 DescriptorSet 0
 OpDecorate %9 Binding 0
 OpDecorate %9 NonReadable
-OpDecorate %10 ArrayStride 4
-OpMemberDecorate %11 0 Offset 0
-OpDecorate %11 Block
-OpDecorate %13 DescriptorSet 0
-OpDecorate %13 Binding 1
-OpDecorate %13 NonReadable
-OpDecorate %17 DescriptorSet 0
-OpDecorate %17 Binding 2
-OpDecorate %17 NonReadable
-OpDecorate %20 BuiltIn LaunchIdKHR
+OpDecorate %12 BuiltIn LaunchIdKHR
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -79,48 +54,23 @@ OpDecorate %20 BuiltIn LaunchIdKHR
 %7 = OpTypeStruct %6
 %8 = OpTypePointer StorageBuffer %7
 %9 = OpVariable %8 StorageBuffer
-%10 = OpTypeRuntimeArray %5
-%11 = OpTypeStruct %10
-%12 = OpTypePointer StorageBuffer %11
-%13 = OpVariable %12 StorageBuffer
-%14 = OpTypeFloat 32
-%15 = OpTypeImage %14 1D 0 0 0 2 Unknown
-%16 = OpTypePointer UniformConstant %15
-%17 = OpVariable %16 UniformConstant
-%18 = OpTypeVector %5 3
-%19 = OpTypePointer Input %18
-%20 = OpVariable %19 Input
-%21 = OpTypePointer Input %5
-%23 = OpConstant %5 0
-%26 = OpConstant %5 9
-%28 = OpConstant %5 3
-%29 = OpTypePointer StorageBuffer %5
-%31 = OpConstant %5 64
-%34 = OpConstant %5 1
-%35 = OpConstant %5 100
-%38 = OpConstant %5 10
-%39 = OpConstant %14 2
-%40 = OpTypeVector %14 4
-%41 = OpConstantComposite %40 %39 %39 %39 %39
-%42 = OpConstant %5 42
-%43 = OpConstant %5 101
+%10 = OpTypeVector %5 3
+%11 = OpTypePointer Input %10
+%12 = OpVariable %11 Input
+%13 = OpTypePointer Input %5
+%15 = OpConstant %5 0
+%18 = OpConstant %5 9
+%20 = OpConstant %5 3
+%21 = OpTypePointer StorageBuffer %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %45
-%45 = OpLabel
-%22 = OpAccessChain %21 %20 %23
-%24 = OpLoad %5 %22
-%27 = OpGroupNonUniformShuffle %5 %28 %24 %26
-%30 = OpAccessChain %29 %9 %23 %24
-OpStore %30 %27
-%32 = OpAccessChain %29 %13 %23 %31
-%33 = OpAtomicIAdd %5 %32 %34 %23 %26
-%36 = OpAccessChain %29 %9 %23 %35
-OpStore %36 %33
-%37 = OpLoad %15 %17
-OpImageWrite %37 %24 %41
-%44 = OpAccessChain %29 %9 %23 %43
-OpStore %44 %42
+OpBranch %23
+%23 = OpLabel
+%14 = OpAccessChain %13 %12 %15
+%16 = OpLoad %5 %14
+%19 = OpGroupNonUniformShuffle %5 %20 %16 %18
+%22 = OpAccessChain %21 %9 %15 %16
+OpStore %22 %19
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/nvapi/shuffle.nvapi.ssbo.comp
+++ b/reference/shaders/nvapi/shuffle.nvapi.ssbo.comp
@@ -7,20 +7,9 @@ layout(set = 0, binding = 0, std430) writeonly buffer SSBO
     uint _m0[];
 } _9;
 
-layout(set = 0, binding = 1, std430) writeonly buffer _11_13
-{
-    uint _m0[];
-} _13;
-
-layout(set = 0, binding = 2) uniform writeonly image1D _17;
-
 void main()
 {
     _9._m0[gl_GlobalInvocationID.x] = subgroupShuffle(gl_GlobalInvocationID.x, 9u);
-    uint _34 = atomicAdd(_13._m0[64u], 9u);
-    _9._m0[100u] = _34;
-    imageStore(_17, int(gl_GlobalInvocationID.x), vec4(2.0));
-    _9._m0[101u] = 42u;
 }
 
 
@@ -29,34 +18,22 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 47
+; Bound: 25
 ; Schema: 0
 OpCapability Shader
-OpCapability Image1D
-OpCapability StorageImageWriteWithoutFormat
 OpCapability GroupNonUniformShuffle
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %3 "main" %22
+OpEntryPoint GLCompute %3 "main" %13
 OpExecutionMode %3 LocalSize 32 1 1
 OpName %3 "main"
 OpName %7 "SSBO"
-OpName %11 "SSBO"
 OpDecorate %6 ArrayStride 4
 OpMemberDecorate %7 0 Offset 0
 OpDecorate %7 Block
 OpDecorate %9 DescriptorSet 0
 OpDecorate %9 Binding 0
 OpDecorate %9 NonReadable
-OpDecorate %10 ArrayStride 4
-OpMemberDecorate %11 0 Offset 0
-OpDecorate %11 Block
-OpDecorate %13 DescriptorSet 0
-OpDecorate %13 Binding 1
-OpDecorate %13 NonReadable
-OpDecorate %17 DescriptorSet 0
-OpDecorate %17 Binding 2
-OpDecorate %17 NonReadable
-OpDecorate %22 BuiltIn GlobalInvocationId
+OpDecorate %13 BuiltIn GlobalInvocationId
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %5 = OpTypeInt 32 0
@@ -64,48 +41,23 @@ OpDecorate %22 BuiltIn GlobalInvocationId
 %7 = OpTypeStruct %6
 %8 = OpTypePointer StorageBuffer %7
 %9 = OpVariable %8 StorageBuffer
-%10 = OpTypeRuntimeArray %5
-%11 = OpTypeStruct %10
-%12 = OpTypePointer StorageBuffer %11
-%13 = OpVariable %12 StorageBuffer
-%14 = OpTypeFloat 32
-%15 = OpTypeImage %14 1D 0 0 0 2 Unknown
-%16 = OpTypePointer UniformConstant %15
-%17 = OpVariable %16 UniformConstant
-%20 = OpTypeVector %5 3
-%21 = OpTypePointer Input %20
-%22 = OpVariable %21 Input
-%23 = OpTypePointer Input %5
-%25 = OpConstant %5 0
-%27 = OpConstant %5 9
-%29 = OpConstant %5 3
-%30 = OpTypePointer StorageBuffer %5
-%32 = OpConstant %5 64
-%35 = OpConstant %5 1
-%36 = OpConstant %5 100
-%38 = OpConstant %5 10
-%39 = OpConstant %14 2
-%40 = OpTypeVector %14 4
-%41 = OpConstantComposite %40 %39 %39 %39 %39
-%42 = OpConstant %5 42
-%43 = OpConstant %5 101
+%11 = OpTypeVector %5 3
+%12 = OpTypePointer Input %11
+%13 = OpVariable %12 Input
+%14 = OpTypePointer Input %5
+%16 = OpConstant %5 0
+%18 = OpConstant %5 9
+%20 = OpConstant %5 3
+%21 = OpTypePointer StorageBuffer %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %45
-%45 = OpLabel
-%18 = OpLoad %15 %17
-%24 = OpAccessChain %23 %22 %25
-%26 = OpLoad %5 %24
-%28 = OpGroupNonUniformShuffle %5 %29 %26 %27
-%31 = OpAccessChain %30 %9 %25 %26
-OpStore %31 %28
-%33 = OpAccessChain %30 %13 %25 %32
-%34 = OpAtomicIAdd %5 %33 %35 %25 %27
-%37 = OpAccessChain %30 %9 %25 %36
-OpStore %37 %34
-OpImageWrite %18 %26 %41
-%44 = OpAccessChain %30 %9 %25 %43
-OpStore %44 %42
+OpBranch %23
+%23 = OpLabel
+%15 = OpAccessChain %14 %13 %16
+%17 = OpLoad %5 %15
+%19 = OpGroupNonUniformShuffle %5 %20 %17 %18
+%22 = OpAccessChain %21 %9 %16 %17
+OpStore %22 %19
 OpReturn
 OpFunctionEnd
 #endif

--- a/shaders/nvapi/bringup.nvapi.ssbo.rgen
+++ b/shaders/nvapi/bringup.nvapi.ssbo.rgen
@@ -13,8 +13,8 @@ void main()
 	uint thr = DispatchRaysIndex().x;
 	Blah[thr] = NvShfl(thr, 9);
 
-	// Test UAV reference shenanigans.
-	Blah[100] = NvInterlockedAddFp16x2(BAB, 64, 9);
-	Blah[101] = NvInterlockedAddFp16x2(RWTex, thr, 10);
+	// Test UAV reference shenanigans (currently disabled).
+	// Blah[100] = NvInterlockedAddFp16x2(BAB, 64, 9);
+	// Blah[101] = NvInterlockedAddFp16x2(RWTex, thr, 10);
 }
 

--- a/shaders/nvapi/shuffle.nvapi.ssbo.comp
+++ b/shaders/nvapi/shuffle.nvapi.ssbo.comp
@@ -12,8 +12,8 @@ void main(uint thr : SV_DispatchThreadID)
 {
 	Blah[thr] = NvShfl(thr, 9);
 
-	// Test UAV reference shenanigans.
-	Blah[100] = NvInterlockedAddFp16x2(BAB, 64, 9);
-	Blah[101] = NvInterlockedAddFp16x2(RWTex, thr, 10);
+	// Test UAV reference shenanigans (currently disabled).
+	// Blah[100] = NvInterlockedAddFp16x2(BAB, 64, 9);
+	// Blah[101] = NvInterlockedAddFp16x2(RWTex, thr, 10);
 }
 


### PR DESCRIPTION
The code for emitting fp16atomic opcode (https://github.com/HansKristian-Work/dxil-spirv/blob/master/opcodes/dxil/dxil_nvapi.cpp#L195) is currently (per comment) just a demo implementation for UAV reference plumbing. This opcode is not advertised in VKD3D-Proton/DXVK-NVAPI as being supported, but at least Cyberpunk still wants to use it when seeing SER (through NVAPI) being supported (this is not the default, it needs `DXVK_NVAPI_D3D12_NV_SHADER_EXTN=1`). Running into the demo implementation prevents Cyberpunk from starting (driver segfault), so disable this opcode for now as a stop-gap solution. 
Alternatively I could remove all fp16atomic code, but I'm hesitant to do this since I guess the current code already handles a lot of non-trivial things.

As for properly fixing this, my knowledge in this area is unfortunately way to limited to know what exactly is missing/wrong there. I do learned how to extract the sub opcode (add/min/max) and I know that Cyberpunk hits the `StorageClassUniformConstant` case.

(For completeness, Cyberpunk wants to use fp16atomic and fp32atomic when SER is available)

~Draft for now to first wait for feedback from  @Saancreed .~