### PR TITLE
Add support for vectorized bit-scan ops in SM6.9

### DIFF
--- a/opcodes/dxil/dxil_arithmetic.cpp
+++ b/opcodes/dxil/dxil_arithmetic.cpp
@@ -1320,7 +1320,10 @@ bool emit_bit_count_instruction(Converter::Impl &impl, const llvm::CallInst *ins
 {
 	// Vulkan only allows 32-bit types here for whatever reason ...
 	auto &builder = impl.builder();
-	auto int_width = instruction->getOperand(1)->getType()->getIntegerBitWidth();
+	auto *operand_type = instruction->getOperand(1)->getType();
+	bool is_vector = operand_type->getTypeID() == llvm::Type::TypeID::VectorTyID;
+	unsigned num_elements = is_vector ? operand_type->getVectorNumElements() : 1;
+	auto int_width = operand_type->getScalarType()->getIntegerBitWidth();
 
 	if (int_width == 32)
 	{
@@ -1331,7 +1334,11 @@ bool emit_bit_count_instruction(Converter::Impl &impl, const llvm::CallInst *ins
 	}
 	else if (int_width == 16)
 	{
-		auto *conv_op = impl.allocate(spv::OpUConvert, builder.makeUintType(32));
+		spv::Id conv_type = builder.makeUintType(32);
+		if (is_vector)
+			conv_type = builder.makeVectorType(conv_type, num_elements);
+
+		auto *conv_op = impl.allocate(spv::OpUConvert, conv_type);
 		conv_op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 		impl.add(conv_op);
 
@@ -1343,30 +1350,56 @@ bool emit_bit_count_instruction(Converter::Impl &impl, const llvm::CallInst *ins
 	else if (int_width == 64)
 	{
 		spv::Id uint_type = builder.makeUintType(32);
-		spv::Id uvec2_type = builder.makeVectorType(uint_type, 2);
+		spv::Id uvec_type = builder.makeVectorType(uint_type, 2 * num_elements);
 
-		auto *conv_op = impl.allocate(spv::OpBitcast, uvec2_type);
+		auto *conv_op = impl.allocate(spv::OpBitcast, uvec_type);
 		conv_op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 		impl.add(conv_op);
 
-		auto *count_op = impl.allocate(spv::OpBitCount, uvec2_type);
+		auto *count_op = impl.allocate(spv::OpBitCount, uvec_type);
 		count_op->add_id(conv_op->id);
 		impl.add(count_op);
 
-		auto *ext0 = impl.allocate(spv::OpCompositeExtract, uint_type);
-		ext0->add_id(count_op->id);
-		ext0->add_literal(0);
-		impl.add(ext0);
+		if (!is_vector)
+		{
+			auto *ext0 = impl.allocate(spv::OpCompositeExtract, uint_type);
+			ext0->add_id(count_op->id);
+			ext0->add_literal(0);
+			impl.add(ext0);
 
-		auto *ext1 = impl.allocate(spv::OpCompositeExtract, uint_type);
-		ext1->add_id(count_op->id);
-		ext1->add_literal(1);
-		impl.add(ext1);
+			auto *ext1 = impl.allocate(spv::OpCompositeExtract, uint_type);
+			ext1->add_id(count_op->id);
+			ext1->add_literal(1);
+			impl.add(ext1);
 
-		auto *add_op = impl.allocate(spv::OpIAdd, instruction);
-		add_op->add_id(ext0->id);
-		add_op->add_id(ext1->id);
-		impl.add(add_op);
+			auto *add_op = impl.allocate(spv::OpIAdd, instruction);
+			add_op->add_id(ext0->id);
+			add_op->add_id(ext1->id);
+			impl.add(add_op);
+		}
+		else
+		{
+			spv::Id result_type = builder.makeVectorType(uint_type, num_elements);
+
+			auto *lo = impl.allocate(spv::OpVectorShuffle, result_type);
+			auto *hi = impl.allocate(spv::OpVectorShuffle, result_type);
+			lo->add_id(count_op->id);
+			lo->add_id(count_op->id);
+			hi->add_id(count_op->id);
+			hi->add_id(count_op->id);
+			for (unsigned i = 0; i < num_elements; i++)
+			{
+				lo->add_literal(2 * i);
+				hi->add_literal(2 * i + 1);
+			}
+			impl.add(lo);
+			impl.add(hi);
+
+			auto *add_op = impl.allocate(spv::OpIAdd, instruction);
+			add_op->add_id(lo->id);
+			add_op->add_id(hi->id);
+			impl.add(add_op);
+		}
 		return true;
 	}
 

--- a/opcodes/dxil/dxil_arithmetic.cpp
+++ b/opcodes/dxil/dxil_arithmetic.cpp
@@ -1253,7 +1253,10 @@ bool emit_msad_instruction(Converter::Impl &impl, const llvm::CallInst *instruct
 bool emit_bit_reverse_instruction(Converter::Impl &impl, const llvm::CallInst *instruction)
 {
 	auto &builder = impl.builder();
-	auto int_width = instruction->getType()->getIntegerBitWidth();
+	auto *result_type_llvm = instruction->getType();
+	unsigned num_elements =
+	    result_type_llvm->getTypeID() == llvm::Type::TypeID::VectorTyID ? result_type_llvm->getVectorNumElements() : 1;
+	auto int_width = result_type_llvm->getScalarType()->getIntegerBitWidth();
 
 	if (int_width == 32)
 	{
@@ -1264,46 +1267,69 @@ bool emit_bit_reverse_instruction(Converter::Impl &impl, const llvm::CallInst *i
 	}
 	else if (int_width == 16)
 	{
+		bool is_vector = num_elements > 1;
+
 		spv::Id uint_type = builder.makeUintType(32);
 		spv::Id u16_type = builder.makeUintType(16);
-		spv::Id u16vec2_type = builder.makeVectorType(u16_type, 2);
+		spv::Id u16vec_type = builder.makeVectorType(u16_type, 2 * num_elements);
 
-		auto *conv_op = impl.allocate(spv::OpUConvert, uint_type);
+		spv::Id conv_type = uint_type;
+		if (is_vector)
+			conv_type = builder.makeVectorType(uint_type, num_elements);
+
+		auto *conv_op = impl.allocate(spv::OpUConvert, conv_type);
 		conv_op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 		impl.add(conv_op);
 
-		auto *reverse_op = impl.allocate(spv::OpBitReverse, uint_type);
+		auto *reverse_op = impl.allocate(spv::OpBitReverse, conv_type);
 		reverse_op->add_id(conv_op->id);
 		impl.add(reverse_op);
 
-		auto *cast_op = impl.allocate(spv::OpBitcast, u16vec2_type);
+		auto *cast_op = impl.allocate(spv::OpBitcast, u16vec_type);
 		cast_op->add_id(reverse_op->id);
 		impl.add(cast_op);
 
-		auto *ext1 = impl.allocate(spv::OpCompositeExtract, instruction);
-		ext1->add_id(cast_op->id);
-		ext1->add_literal(1);
-		impl.add(ext1);
+		if (!is_vector)
+		{
+			auto *ext1 = impl.allocate(spv::OpCompositeExtract, instruction);
+			ext1->add_id(cast_op->id);
+			ext1->add_literal(1);
+			impl.add(ext1);
+		}
+		else
+		{
+			auto *shuf_op = impl.allocate(spv::OpVectorShuffle, instruction);
+			shuf_op->add_id(cast_op->id);
+			shuf_op->add_id(cast_op->id);
+			for (unsigned i = 0; i < num_elements; i++)
+			{
+				shuf_op->add_literal(2 * i + 1);
+			}
+			impl.add(shuf_op);
+		}
 		return true;
 	}
 	else if (int_width == 64)
 	{
 		spv::Id uint_type = builder.makeUintType(32);
-		spv::Id uvec2_type = builder.makeVectorType(uint_type, 2);
+		spv::Id uvec_type = builder.makeVectorType(uint_type, 2 * num_elements);
 
-		auto *conv_op = impl.allocate(spv::OpBitcast, uvec2_type);
+		auto *conv_op = impl.allocate(spv::OpBitcast, uvec_type);
 		conv_op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
 		impl.add(conv_op);
 
-		auto *reverse_op = impl.allocate(spv::OpBitReverse, uvec2_type);
+		auto *reverse_op = impl.allocate(spv::OpBitReverse, uvec_type);
 		reverse_op->add_id(conv_op->id);
 		impl.add(reverse_op);
 
-		auto *shuf_op = impl.allocate(spv::OpVectorShuffle, uvec2_type);
+		auto *shuf_op = impl.allocate(spv::OpVectorShuffle, uvec_type);
 		shuf_op->add_id(reverse_op->id);
 		shuf_op->add_id(reverse_op->id);
-		shuf_op->add_literal(1);
-		shuf_op->add_literal(0);
+		for (unsigned i = 0; i < num_elements; i++)
+		{
+			shuf_op->add_literal(2 * i + 1);
+			shuf_op->add_literal(2 * i);
+		}
 		impl.add(shuf_op);
 
 		auto *cast_op = impl.allocate(spv::OpBitcast, instruction);

--- a/opcodes/dxil/dxil_arithmetic.cpp
+++ b/opcodes/dxil/dxil_arithmetic.cpp
@@ -136,11 +136,19 @@ spv::Id emit_native_bitscan(GLSLstd450 opcode, Converter::Impl &impl,
 
 	Operation *op;
 
+	auto *value_type = value->getType();
+	bool is_vector = value_type->getTypeID() == llvm::Type::TypeID::VectorTyID;
+	unsigned num_elements = is_vector ? value_type->getVectorNumElements() : 1;
+
 	// Vulkan currently does not allow 16/64-bit for these ... :(
-	if (value->getType()->getIntegerBitWidth() == 16)
+	if (value_type->getScalarType()->getIntegerBitWidth() == 16)
 	{
-		auto *extend = impl.allocate(
-		    opcode == GLSLstd450FindSMsb ? spv::OpSConvert : spv::OpUConvert, builder.makeUintType(32));
+		spv::Id result_type = builder.makeUintType(32);
+
+		if (is_vector)
+			result_type = builder.makeVectorType(result_type, num_elements);
+
+		auto *extend = impl.allocate(opcode == GLSLstd450FindSMsb ? spv::OpSConvert : spv::OpUConvert, result_type);
 
 		extend->add_id(impl.get_id_for_value(value));
 		impl.add(extend);
@@ -148,85 +156,163 @@ spv::Id emit_native_bitscan(GLSLstd450 opcode, Converter::Impl &impl,
 		if (instruction)
 			op = impl.allocate(spv::OpExtInst, instruction);
 		else
-			op = impl.allocate(spv::OpExtInst, builder.makeUintType(32));
+			op = impl.allocate(spv::OpExtInst, result_type);
 
 		op->add_id(impl.glsl_std450_ext);
 		op->add_literal(opcode);
 		op->add_id(extend->id);
 	}
-	else if (value->getType()->getIntegerBitWidth() == 64)
+	else if (value_type->getScalarType()->getIntegerBitWidth() == 64)
 	{
 		spv::Id uint_type = builder.makeUintType(32);
-		spv::Id uvec2_type = builder.makeVectorType(uint_type, 2);
+		spv::Id uvec_type = builder.makeVectorType(uint_type, 2 * num_elements);
 
-		auto *bitcast = impl.allocate(spv::OpBitcast, uvec2_type);
+		auto *bitcast = impl.allocate(spv::OpBitcast, uvec_type);
 		bitcast->add_id(impl.get_id_for_value(value));
 		impl.add(bitcast);
 
+		spv::Id result_type = uint_type;
+		if (is_vector)
+			result_type = builder.makeVectorType(uint_type, num_elements);
+
 		if (opcode == GLSLstd450FindSMsb)
 		{
-			auto *ext = impl.allocate(spv::OpCompositeExtract, uint_type);
-			ext->add_id(bitcast->id);
-			ext->add_literal(1);
-			impl.add(ext);
+			if (!is_vector)
+			{
+				auto *ext = impl.allocate(spv::OpCompositeExtract, uint_type);
+				ext->add_id(bitcast->id);
+				ext->add_literal(1);
+				impl.add(ext);
 
-			spv::Id int_type = builder.makeIntType(32);
-			auto *shifted = impl.allocate(spv::OpShiftRightArithmetic, int_type);
-			shifted->add_id(ext->id);
-			shifted->add_id(builder.makeIntConstant(31));
-			impl.add(shifted);
+				spv::Id int_type = builder.makeIntType(32);
+				auto *shifted = impl.allocate(spv::OpShiftRightArithmetic, int_type);
+				shifted->add_id(ext->id);
+				shifted->add_id(builder.makeIntConstant(31));
+				impl.add(shifted);
 
-			const spv::Id elems[] = { shifted->id, shifted->id };
+				const spv::Id elems[] = { shifted->id, shifted->id };
 
-			auto *xored = impl.allocate(spv::OpBitwiseXor, uvec2_type);
-			xored->add_id(bitcast->id);
-			xored->add_id(impl.build_vector(int_type, elems, 2));
-			impl.add(xored);
+				auto *xored = impl.allocate(spv::OpBitwiseXor, uvec_type);
+				xored->add_id(bitcast->id);
+				xored->add_id(impl.build_vector(int_type, elems, 2));
+				impl.add(xored);
 
-			bitcast = xored;
+				bitcast = xored;
+			}
+			else
+			{
+				auto *hi = impl.allocate(spv::OpVectorShuffle, result_type);
+				hi->add_id(bitcast->id);
+				hi->add_id(bitcast->id);
+				for (unsigned i = 0; i < num_elements; i++)
+				{
+					hi->add_literal(2 * i + 1);
+				}
+				impl.add(hi);
+
+				spv::Id int_type = builder.makeIntType(32);
+
+				auto *shifted = impl.allocate(spv::OpShiftRightArithmetic, builder.makeVectorType(int_type, num_elements));
+				shifted->add_id(hi->id);
+				shifted->add_id(impl.build_splat_constant_vector(int_type, builder.makeIntConstant(31), num_elements));
+				impl.add(shifted);
+
+				auto *dup = impl.allocate(spv::OpVectorShuffle, builder.makeVectorType(int_type, 2 * num_elements));
+				dup->add_id(shifted->id);
+				dup->add_id(shifted->id);
+				for (unsigned i = 0; i < num_elements; i++)
+				{
+					dup->add_literal(i);
+					dup->add_literal(i);
+				}
+				impl.add(dup);
+
+				auto *xored = impl.allocate(spv::OpBitwiseXor, uvec_type);
+				xored->add_id(bitcast->id);
+				xored->add_id(dup->id);
+				impl.add(xored);
+
+				bitcast = xored;
+			}
+
 			opcode = GLSLstd450FindUMsb;
 		}
 
-		auto *ilsb = impl.allocate(spv::OpExtInst, uvec2_type);
+		auto *ilsb = impl.allocate(spv::OpExtInst, uvec_type);
 		ilsb->add_id(impl.glsl_std450_ext);
 		ilsb->add_literal(opcode);
 		ilsb->add_id(bitcast->id);
 		impl.add(ilsb);
 
-		spv::Id scalars[2];
-		for (int i = 0; i < 2; i++)
+		spv::Id lo_id, hi_id;
+
+		if (!is_vector)
 		{
-			auto *ext = impl.allocate(spv::OpCompositeExtract, uint_type);
-			ext->add_id(ilsb->id);
-			ext->add_literal(i);
-			impl.add(ext);
-			scalars[i] = ext->id;
+			spv::Id scalars[2];
+			for (int i = 0; i < 2; i++)
+			{
+				auto *ext = impl.allocate(spv::OpCompositeExtract, uint_type);
+				ext->add_id(ilsb->id);
+				ext->add_literal(i);
+				impl.add(ext);
+				scalars[i] = ext->id;
+			}
+			lo_id = scalars[0];
+			hi_id = scalars[1];
+		}
+		else
+		{
+			auto *lo = impl.allocate(spv::OpVectorShuffle, result_type);
+			auto *hi = impl.allocate(spv::OpVectorShuffle, result_type);
+			lo->add_id(ilsb->id);
+			lo->add_id(ilsb->id);
+			hi->add_id(ilsb->id);
+			hi->add_id(ilsb->id);
+			for (unsigned i = 0; i < num_elements; i++)
+			{
+				lo->add_literal(2 * i);
+				hi->add_literal(2 * i + 1);
+			}
+			impl.add(lo);
+			impl.add(hi);
+			lo_id = lo->id;
+			hi_id = hi->id;
 		}
 
-		auto *or32 = impl.allocate(spv::OpBitwiseOr, uint_type);
-		or32->add_id(scalars[1]);
-		or32->add_id(builder.makeUintConstant(32));
+		auto *or32 = impl.allocate(spv::OpBitwiseOr, result_type);
+		or32->add_id(hi_id);
+		{
+			spv::Id const32 = builder.makeUintConstant(32);
+			if (is_vector)
+				const32 = impl.build_splat_constant_vector(uint_type, const32, num_elements);
+			or32->add_id(const32);
+		}
 		impl.add(or32);
-		scalars[1] = or32->id;
+		hi_id = or32->id;
 
 		auto merge_op = opcode == GLSLstd450FindILsb ? GLSLstd450UMin : GLSLstd450SMax;
 
 		if (instruction)
 			op = impl.allocate(spv::OpExtInst, instruction);
 		else
-			op = impl.allocate(spv::OpExtInst, uint_type);
+			op = impl.allocate(spv::OpExtInst, result_type);
 
 		op->add_id(impl.glsl_std450_ext);
 		op->add_literal(merge_op);
-		op->add_id(scalars[0]);
-		op->add_id(scalars[1]);
+		op->add_id(lo_id);
+		op->add_id(hi_id);
 	}
 	else
 	{
 		if (instruction)
 			op = impl.allocate(spv::OpExtInst, instruction);
 		else
-			op = impl.allocate(spv::OpExtInst, builder.makeUintType(32));
+		{
+			spv::Id result_type = builder.makeUintType(32);
+			if (is_vector)
+				result_type = builder.makeVectorType(result_type, num_elements);
+			op = impl.allocate(spv::OpExtInst, result_type);
+		}
 
 		op->add_id(impl.glsl_std450_ext);
 		op->add_literal(opcode);
@@ -251,23 +337,39 @@ bool emit_find_high_bit_instruction(GLSLstd450 opcode, Converter::Impl &impl, co
 	auto *value = instruction->getOperand(1);
 	spv::Id msb_id = emit_native_bitscan(opcode, impl, nullptr, value);
 
-	Operation *eq_neg1_op = impl.allocate(spv::OpIEqual, builder.makeBoolType());
+	auto *value_type = value->getType();
+	bool is_vector = value_type->getTypeID() == llvm::Type::TypeID::VectorTyID;
+	unsigned num_elements = is_vector ? value_type->getVectorNumElements() : 1;
+
+	spv::Id bool_type = builder.makeBoolType();
+	if (is_vector)
+		bool_type = builder.makeVectorType(bool_type, num_elements);
+
+	Operation *eq_neg1_op = impl.allocate(spv::OpIEqual, bool_type);
 	{
-		eq_neg1_op->add_ids({ msb_id, builder.makeUintConstant(~0u) });
+		spv::Id neg1_const = builder.makeUintConstant(~0u);
+		if (is_vector)
+			neg1_const = impl.build_splat_constant_vector(builder.makeUintType(32), neg1_const, num_elements);
+		eq_neg1_op->add_ids({ msb_id, neg1_const });
 		impl.add(eq_neg1_op);
 	}
 
 	Operation *msb_sub_op = impl.allocate(spv::OpISub, impl.get_type_id(instruction->getType()));
 	{
-		msb_sub_op->add_ids({
-		    builder.makeUintConstant(value->getType()->getIntegerBitWidth() - 1),
-		    msb_id
-		});
+		spv::Id width_minus_1 = builder.makeUintConstant(value_type->getScalarType()->getIntegerBitWidth() - 1);
+		if (is_vector)
+			width_minus_1 = impl.build_splat_constant_vector(builder.makeUintType(32), width_minus_1, num_elements);
+		msb_sub_op->add_ids({ width_minus_1, msb_id });
 		impl.add(msb_sub_op);
 	}
 
 	Operation *op = impl.allocate(spv::OpSelect, instruction);
-	op->add_ids({ eq_neg1_op->id, builder.makeUintConstant(~0u), msb_sub_op->id });
+	{
+		spv::Id neg1_const = builder.makeUintConstant(~0u);
+		if (is_vector)
+			neg1_const = impl.build_splat_constant_vector(builder.makeUintType(32), neg1_const, num_elements);
+		op->add_ids({ eq_neg1_op->id, neg1_const, msb_sub_op->id });
+	}
 	impl.add(op);
 	return true;
 }

--- a/reference/shaders/dxil-builtin/bfrev-vector.sm69.ssbo.comp
+++ b/reference/shaders/dxil-builtin/bfrev-vector.sm69.ssbo.comp
@@ -1,0 +1,131 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, std430) buffer SSBO
+{
+    uvec4 _m0[];
+} _10;
+
+layout(set = 0, binding = 1, std430) buffer _14_16
+{
+    u16vec2 _m0[];
+} _16;
+
+layout(set = 0, binding = 2, std430) buffer _20_22
+{
+    u64vec2 _m0[];
+} _22;
+
+void main()
+{
+    _10._m0[0u] = uvec4(bitfieldReverse(_10._m0[0u]));
+    _16._m0[0u] = u16vec2((bitfieldReverse(uvec2(_16._m0[0u]))).yw);
+    _22._m0[0u] = u64vec2(bitfieldReverse((_22._m0[0u])).yxwz);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 60
+; Schema: 0
+OpCapability Shader
+OpCapability Int64
+OpCapability Int16
+OpCapability StorageBuffer16BitAccess
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main" %10 %16 %22
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %8 "SSBO"
+OpName %14 "SSBO"
+OpName %20 "SSBO"
+OpDecorate %7 ArrayStride 16
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %8 Block
+OpDecorate %10 DescriptorSet 0
+OpDecorate %10 Binding 0
+OpDecorate %13 ArrayStride 4
+OpMemberDecorate %14 0 Offset 0
+OpDecorate %14 Block
+OpDecorate %16 DescriptorSet 0
+OpDecorate %16 Binding 1
+OpDecorate %19 ArrayStride 16
+OpMemberDecorate %20 0 Offset 0
+OpDecorate %20 Block
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 2
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeVector %5 4
+%7 = OpTypeRuntimeArray %6
+%8 = OpTypeStruct %7
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpVariable %9 StorageBuffer
+%11 = OpTypeInt 16 0
+%12 = OpTypeVector %11 2
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypeStruct %13
+%15 = OpTypePointer StorageBuffer %14
+%16 = OpVariable %15 StorageBuffer
+%17 = OpTypeInt 64 0
+%18 = OpTypeVector %17 2
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypeStruct %19
+%21 = OpTypePointer StorageBuffer %20
+%22 = OpVariable %21 StorageBuffer
+%23 = OpConstant %5 0
+%24 = OpTypePointer StorageBuffer %6
+%34 = OpTypePointer StorageBuffer %12
+%37 = OpTypeVector %11 4
+%38 = OpTypeVector %5 2
+%47 = OpTypePointer StorageBuffer %18
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %58
+%58 = OpLabel
+%25 = OpAccessChain %24 %10 %23 %23
+%26 = OpLoad %6 %25
+%27 = OpBitReverse %6 %26
+%28 = OpCompositeExtract %5 %27 0
+%29 = OpCompositeExtract %5 %27 1
+%30 = OpCompositeExtract %5 %27 2
+%31 = OpCompositeExtract %5 %27 3
+%32 = OpCompositeConstruct %6 %28 %29 %30 %31
+%33 = OpAccessChain %24 %10 %23 %23
+OpStore %33 %32
+%35 = OpAccessChain %34 %16 %23 %23
+%36 = OpLoad %12 %35
+%39 = OpUConvert %38 %36
+%40 = OpBitReverse %38 %39
+%41 = OpBitcast %37 %40
+%42 = OpVectorShuffle %12 %41 %41 1 3
+%43 = OpCompositeExtract %11 %42 0
+%44 = OpCompositeExtract %11 %42 1
+%45 = OpCompositeConstruct %12 %43 %44
+%46 = OpAccessChain %34 %16 %23 %23
+OpStore %46 %45
+%48 = OpAccessChain %47 %22 %23 %23
+%49 = OpLoad %18 %48
+%50 = OpBitcast %6 %49
+%51 = OpBitReverse %6 %50
+%52 = OpVectorShuffle %6 %51 %51 1 0 3 2
+%53 = OpBitcast %18 %52
+%54 = OpCompositeExtract %17 %53 0
+%55 = OpCompositeExtract %17 %53 1
+%56 = OpCompositeConstruct %18 %54 %55
+%57 = OpAccessChain %47 %22 %23 %23
+OpStore %57 %56
+OpReturn
+OpFunctionEnd
+#endif

--- a/reference/shaders/dxil-builtin/countbits-vector.sm69.ssbo.comp
+++ b/reference/shaders/dxil-builtin/countbits-vector.sm69.ssbo.comp
@@ -1,0 +1,154 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+uvec4 _34;
+
+layout(set = 0, binding = 0, std430) readonly buffer SSBO
+{
+    uvec4 _m0[];
+} _10;
+
+layout(set = 0, binding = 1, std430) readonly buffer _14_16
+{
+    u16vec2 _m0[];
+} _16;
+
+layout(set = 0, binding = 2, std430) readonly buffer _20_22
+{
+    u64vec2 _m0[];
+} _22;
+
+layout(set = 0, binding = 3, std430) writeonly buffer _25_27
+{
+    uvec2 _m0[];
+} _27;
+
+void main()
+{
+    _27._m0[0u] = uvec2(uvec4(bitCount(_10._m0[0u])).xy);
+    _27._m0[1u] = uvec2(uvec2(bitCount(uvec2(_16._m0[0u]))));
+    uvec4 _54 = uvec4(bitCount((_22._m0[0u])));
+    _27._m0[2u] = uvec2(_54.xz + _54.yw);
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 65
+; Schema: 0
+OpCapability Shader
+OpCapability Int64
+OpCapability Int16
+OpCapability StorageBuffer16BitAccess
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main" %10 %16 %22 %27
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %8 "SSBO"
+OpName %14 "SSBO"
+OpName %20 "SSBO"
+OpName %25 "SSBO"
+OpDecorate %7 ArrayStride 16
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %8 Block
+OpDecorate %10 DescriptorSet 0
+OpDecorate %10 Binding 0
+OpDecorate %10 NonWritable
+OpDecorate %13 ArrayStride 4
+OpMemberDecorate %14 0 Offset 0
+OpDecorate %14 Block
+OpDecorate %16 DescriptorSet 0
+OpDecorate %16 Binding 1
+OpDecorate %16 NonWritable
+OpDecorate %19 ArrayStride 16
+OpMemberDecorate %20 0 Offset 0
+OpDecorate %20 Block
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 2
+OpDecorate %22 NonWritable
+OpDecorate %24 ArrayStride 8
+OpMemberDecorate %25 0 Offset 0
+OpDecorate %25 Block
+OpDecorate %27 DescriptorSet 0
+OpDecorate %27 Binding 3
+OpDecorate %27 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeVector %5 4
+%7 = OpTypeRuntimeArray %6
+%8 = OpTypeStruct %7
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpVariable %9 StorageBuffer
+%11 = OpTypeInt 16 0
+%12 = OpTypeVector %11 2
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypeStruct %13
+%15 = OpTypePointer StorageBuffer %14
+%16 = OpVariable %15 StorageBuffer
+%17 = OpTypeInt 64 0
+%18 = OpTypeVector %17 2
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypeStruct %19
+%21 = OpTypePointer StorageBuffer %20
+%22 = OpVariable %21 StorageBuffer
+%23 = OpTypeVector %5 2
+%24 = OpTypeRuntimeArray %23
+%25 = OpTypeStruct %24
+%26 = OpTypePointer StorageBuffer %25
+%27 = OpVariable %26 StorageBuffer
+%28 = OpConstant %5 0
+%29 = OpTypePointer StorageBuffer %6
+%38 = OpTypePointer StorageBuffer %23
+%40 = OpTypePointer StorageBuffer %12
+%45 = OpConstant %5 1
+%50 = OpTypePointer StorageBuffer %18
+%58 = OpConstant %5 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%34 = OpUndef %6
+OpBranch %63
+%63 = OpLabel
+%30 = OpAccessChain %29 %10 %28 %28
+%31 = OpLoad %6 %30
+%32 = OpBitCount %6 %31
+%33 = OpVectorShuffle %23 %32 %34 0 1
+%35 = OpCompositeExtract %5 %33 0
+%36 = OpCompositeExtract %5 %33 1
+%37 = OpCompositeConstruct %23 %35 %36
+%39 = OpAccessChain %38 %27 %28 %28
+OpStore %39 %37
+%41 = OpAccessChain %40 %16 %28 %28
+%42 = OpLoad %12 %41
+%43 = OpUConvert %23 %42
+%44 = OpBitCount %23 %43
+%46 = OpCompositeExtract %5 %44 0
+%47 = OpCompositeExtract %5 %44 1
+%48 = OpCompositeConstruct %23 %46 %47
+%49 = OpAccessChain %38 %27 %28 %45
+OpStore %49 %48
+%51 = OpAccessChain %50 %22 %28 %28
+%52 = OpLoad %18 %51
+%53 = OpBitcast %6 %52
+%54 = OpBitCount %6 %53
+%55 = OpVectorShuffle %23 %54 %54 0 2
+%56 = OpVectorShuffle %23 %54 %54 1 3
+%57 = OpIAdd %23 %55 %56
+%59 = OpCompositeExtract %5 %57 0
+%60 = OpCompositeExtract %5 %57 1
+%61 = OpCompositeConstruct %23 %59 %60
+%62 = OpAccessChain %38 %27 %28 %58
+OpStore %62 %61
+OpReturn
+OpFunctionEnd
+#endif

--- a/reference/shaders/dxil-builtin/firstbithi-vector.sm69.ssbo.comp
+++ b/reference/shaders/dxil-builtin/firstbithi-vector.sm69.ssbo.comp
@@ -1,0 +1,204 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+uint _44;
+uint _45;
+uint _49;
+uint _50;
+uvec4 _53;
+
+layout(set = 0, binding = 0, std430) readonly buffer SSBO
+{
+    uvec4 _m0[];
+} _10;
+
+layout(set = 0, binding = 1, std430) readonly buffer _14_16
+{
+    u16vec2 _m0[];
+} _16;
+
+layout(set = 0, binding = 2, std430) readonly buffer _20_22
+{
+    u64vec2 _m0[];
+} _22;
+
+layout(set = 0, binding = 3, std430) writeonly buffer _25_27
+{
+    uvec2 _m0[];
+} _27;
+
+void main()
+{
+    uvec4 _33 = uvec4(findMSB(_10._m0[0u]));
+    uvec4 _42 = mix(uvec4(31u) - _33, uvec4(4294967295u), equal(_33, uvec4(4294967295u)));
+    _27._m0[0u] = uvec2(mix(uvec4(31u, 31u, 0u, 0u) - _42, uvec4(4294967295u, 4294967295u, 0u, 0u), equal(_42, uvec4(4294967295u))).xy);
+    uvec2 _63 = uvec2(findMSB(uvec2(_16._m0[0u])));
+    uvec2 _70 = mix(uvec2(15u) - _63, uvec2(4294967295u), equal(_63, uvec2(4294967295u)));
+    _27._m0[1u] = uvec2(mix(uvec2(15u) - _70, uvec2(4294967295u), equal(_70, uvec2(4294967295u))));
+    uvec4 _83 = uvec4(findMSB((_22._m0[0u])));
+    uvec2 _89 = uvec2(max(ivec2(_83.xz), ivec2(_83.yw | uvec2(32u))));
+    uvec2 _94 = mix(uvec2(63u) - _89, uvec2(4294967295u), equal(_89, uvec2(4294967295u)));
+    _27._m0[2u] = uvec2(mix(uvec2(63u) - _94, uvec2(4294967295u), equal(_94, uvec2(4294967295u))));
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 105
+; Schema: 0
+OpCapability Shader
+OpCapability Int64
+OpCapability Int16
+OpCapability StorageBuffer16BitAccess
+%32 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main" %10 %16 %22 %27
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %8 "SSBO"
+OpName %14 "SSBO"
+OpName %20 "SSBO"
+OpName %25 "SSBO"
+OpDecorate %7 ArrayStride 16
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %8 Block
+OpDecorate %10 DescriptorSet 0
+OpDecorate %10 Binding 0
+OpDecorate %10 NonWritable
+OpDecorate %13 ArrayStride 4
+OpMemberDecorate %14 0 Offset 0
+OpDecorate %14 Block
+OpDecorate %16 DescriptorSet 0
+OpDecorate %16 Binding 1
+OpDecorate %16 NonWritable
+OpDecorate %19 ArrayStride 16
+OpMemberDecorate %20 0 Offset 0
+OpDecorate %20 Block
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 2
+OpDecorate %22 NonWritable
+OpDecorate %24 ArrayStride 8
+OpMemberDecorate %25 0 Offset 0
+OpDecorate %25 Block
+OpDecorate %27 DescriptorSet 0
+OpDecorate %27 Binding 3
+OpDecorate %27 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeVector %5 4
+%7 = OpTypeRuntimeArray %6
+%8 = OpTypeStruct %7
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpVariable %9 StorageBuffer
+%11 = OpTypeInt 16 0
+%12 = OpTypeVector %11 2
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypeStruct %13
+%15 = OpTypePointer StorageBuffer %14
+%16 = OpVariable %15 StorageBuffer
+%17 = OpTypeInt 64 0
+%18 = OpTypeVector %17 2
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypeStruct %19
+%21 = OpTypePointer StorageBuffer %20
+%22 = OpVariable %21 StorageBuffer
+%23 = OpTypeVector %5 2
+%24 = OpTypeRuntimeArray %23
+%25 = OpTypeStruct %24
+%26 = OpTypePointer StorageBuffer %25
+%27 = OpVariable %26 StorageBuffer
+%28 = OpConstant %5 0
+%29 = OpTypePointer StorageBuffer %6
+%34 = OpTypeBool
+%35 = OpTypeVector %34 4
+%37 = OpConstant %5 4294967295
+%38 = OpConstantComposite %6 %37 %37 %37 %37
+%40 = OpConstant %5 31
+%41 = OpConstantComposite %6 %40 %40 %40 %40
+%44 = OpUndef %5
+%45 = OpUndef %5
+%46 = OpConstantComposite %6 %40 %40 %44 %45
+%49 = OpUndef %5
+%50 = OpUndef %5
+%51 = OpConstantComposite %6 %37 %37 %49 %50
+%57 = OpTypePointer StorageBuffer %23
+%59 = OpTypePointer StorageBuffer %12
+%64 = OpTypeVector %34 2
+%66 = OpConstantComposite %23 %37 %37
+%68 = OpConstant %5 15
+%69 = OpConstantComposite %23 %68 %68
+%74 = OpConstant %5 1
+%79 = OpTypePointer StorageBuffer %18
+%87 = OpConstant %5 32
+%88 = OpConstantComposite %23 %87 %87
+%92 = OpConstant %5 63
+%93 = OpConstantComposite %23 %92 %92
+%98 = OpConstant %5 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%53 = OpUndef %6
+OpBranch %103
+%103 = OpLabel
+%30 = OpAccessChain %29 %10 %28 %28
+%31 = OpLoad %6 %30
+%33 = OpExtInst %6 %32 FindUMsb %31
+%36 = OpIEqual %35 %33 %38
+%39 = OpISub %6 %41 %33
+%42 = OpSelect %6 %36 %38 %39
+%43 = OpISub %6 %46 %42
+%47 = OpIEqual %35 %42 %38
+%48 = OpSelect %6 %47 %51 %43
+%52 = OpVectorShuffle %23 %48 %53 0 1
+%54 = OpCompositeExtract %5 %52 0
+%55 = OpCompositeExtract %5 %52 1
+%56 = OpCompositeConstruct %23 %54 %55
+%58 = OpAccessChain %57 %27 %28 %28
+OpStore %58 %56
+%60 = OpAccessChain %59 %16 %28 %28
+%61 = OpLoad %12 %60
+%62 = OpUConvert %23 %61
+%63 = OpExtInst %23 %32 FindUMsb %62
+%65 = OpIEqual %64 %63 %66
+%67 = OpISub %23 %69 %63
+%70 = OpSelect %23 %65 %66 %67
+%71 = OpISub %23 %69 %70
+%72 = OpIEqual %64 %70 %66
+%73 = OpSelect %23 %72 %66 %71
+%75 = OpCompositeExtract %5 %73 0
+%76 = OpCompositeExtract %5 %73 1
+%77 = OpCompositeConstruct %23 %75 %76
+%78 = OpAccessChain %57 %27 %28 %74
+OpStore %78 %77
+%80 = OpAccessChain %79 %22 %28 %28
+%81 = OpLoad %18 %80
+%82 = OpBitcast %6 %81
+%83 = OpExtInst %6 %32 FindUMsb %82
+%84 = OpVectorShuffle %23 %83 %83 0 2
+%85 = OpVectorShuffle %23 %83 %83 1 3
+%86 = OpBitwiseOr %23 %85 %88
+%89 = OpExtInst %23 %32 SMax %84 %86
+%90 = OpIEqual %64 %89 %66
+%91 = OpISub %23 %93 %89
+%94 = OpSelect %23 %90 %66 %91
+%95 = OpISub %23 %93 %94
+%96 = OpIEqual %64 %94 %66
+%97 = OpSelect %23 %96 %66 %95
+%99 = OpCompositeExtract %5 %97 0
+%100 = OpCompositeExtract %5 %97 1
+%101 = OpCompositeConstruct %23 %99 %100
+%102 = OpAccessChain %57 %27 %28 %98
+OpStore %102 %101
+OpReturn
+OpFunctionEnd
+#endif

--- a/reference/shaders/dxil-builtin/firstbitlo-vector.sm69.ssbo.comp
+++ b/reference/shaders/dxil-builtin/firstbitlo-vector.sm69.ssbo.comp
@@ -1,0 +1,158 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+uvec4 _35;
+
+layout(set = 0, binding = 0, std430) readonly buffer SSBO
+{
+    uvec4 _m0[];
+} _10;
+
+layout(set = 0, binding = 1, std430) readonly buffer _14_16
+{
+    u16vec2 _m0[];
+} _16;
+
+layout(set = 0, binding = 2, std430) readonly buffer _20_22
+{
+    u64vec2 _m0[];
+} _22;
+
+layout(set = 0, binding = 3, std430) writeonly buffer _25_27
+{
+    uvec2 _m0[];
+} _27;
+
+void main()
+{
+    _27._m0[0u] = uvec2(uvec4(findLSB(_10._m0[0u])).xy);
+    _27._m0[1u] = uvec2(uvec2(findLSB(uvec2(_16._m0[0u]))));
+    uvec4 _55 = uvec4(findLSB((_22._m0[0u])));
+    _27._m0[2u] = uvec2(min(_55.xz, (_55.yw | uvec2(32u))));
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 69
+; Schema: 0
+OpCapability Shader
+OpCapability Int64
+OpCapability Int16
+OpCapability StorageBuffer16BitAccess
+%32 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main" %10 %16 %22 %27
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %8 "SSBO"
+OpName %14 "SSBO"
+OpName %20 "SSBO"
+OpName %25 "SSBO"
+OpDecorate %7 ArrayStride 16
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %8 Block
+OpDecorate %10 DescriptorSet 0
+OpDecorate %10 Binding 0
+OpDecorate %10 NonWritable
+OpDecorate %13 ArrayStride 4
+OpMemberDecorate %14 0 Offset 0
+OpDecorate %14 Block
+OpDecorate %16 DescriptorSet 0
+OpDecorate %16 Binding 1
+OpDecorate %16 NonWritable
+OpDecorate %19 ArrayStride 16
+OpMemberDecorate %20 0 Offset 0
+OpDecorate %20 Block
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 2
+OpDecorate %22 NonWritable
+OpDecorate %24 ArrayStride 8
+OpMemberDecorate %25 0 Offset 0
+OpDecorate %25 Block
+OpDecorate %27 DescriptorSet 0
+OpDecorate %27 Binding 3
+OpDecorate %27 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeVector %5 4
+%7 = OpTypeRuntimeArray %6
+%8 = OpTypeStruct %7
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpVariable %9 StorageBuffer
+%11 = OpTypeInt 16 0
+%12 = OpTypeVector %11 2
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypeStruct %13
+%15 = OpTypePointer StorageBuffer %14
+%16 = OpVariable %15 StorageBuffer
+%17 = OpTypeInt 64 0
+%18 = OpTypeVector %17 2
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypeStruct %19
+%21 = OpTypePointer StorageBuffer %20
+%22 = OpVariable %21 StorageBuffer
+%23 = OpTypeVector %5 2
+%24 = OpTypeRuntimeArray %23
+%25 = OpTypeStruct %24
+%26 = OpTypePointer StorageBuffer %25
+%27 = OpVariable %26 StorageBuffer
+%28 = OpConstant %5 0
+%29 = OpTypePointer StorageBuffer %6
+%39 = OpTypePointer StorageBuffer %23
+%41 = OpTypePointer StorageBuffer %12
+%46 = OpConstant %5 1
+%51 = OpTypePointer StorageBuffer %18
+%59 = OpConstant %5 32
+%60 = OpConstantComposite %23 %59 %59
+%62 = OpConstant %5 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%35 = OpUndef %6
+OpBranch %67
+%67 = OpLabel
+%30 = OpAccessChain %29 %10 %28 %28
+%31 = OpLoad %6 %30
+%33 = OpExtInst %6 %32 FindILsb %31
+%34 = OpVectorShuffle %23 %33 %35 0 1
+%36 = OpCompositeExtract %5 %34 0
+%37 = OpCompositeExtract %5 %34 1
+%38 = OpCompositeConstruct %23 %36 %37
+%40 = OpAccessChain %39 %27 %28 %28
+OpStore %40 %38
+%42 = OpAccessChain %41 %16 %28 %28
+%43 = OpLoad %12 %42
+%44 = OpUConvert %23 %43
+%45 = OpExtInst %23 %32 FindILsb %44
+%47 = OpCompositeExtract %5 %45 0
+%48 = OpCompositeExtract %5 %45 1
+%49 = OpCompositeConstruct %23 %47 %48
+%50 = OpAccessChain %39 %27 %28 %46
+OpStore %50 %49
+%52 = OpAccessChain %51 %22 %28 %28
+%53 = OpLoad %18 %52
+%54 = OpBitcast %6 %53
+%55 = OpExtInst %6 %32 FindILsb %54
+%56 = OpVectorShuffle %23 %55 %55 0 2
+%57 = OpVectorShuffle %23 %55 %55 1 3
+%58 = OpBitwiseOr %23 %57 %60
+%61 = OpExtInst %23 %32 UMin %56 %58
+%63 = OpCompositeExtract %5 %61 0
+%64 = OpCompositeExtract %5 %61 1
+%65 = OpCompositeConstruct %23 %63 %64
+%66 = OpAccessChain %39 %27 %28 %62
+OpStore %66 %65
+OpReturn
+OpFunctionEnd
+#endif

--- a/reference/shaders/dxil-builtin/firstbitshi-vector.sm69.ssbo.comp
+++ b/reference/shaders/dxil-builtin/firstbitshi-vector.sm69.ssbo.comp
@@ -1,0 +1,214 @@
+#version 460
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_16bit_storage : require
+#if defined(GL_ARB_gpu_shader_int64)
+#extension GL_ARB_gpu_shader_int64 : require
+#else
+#error No extension available for 64-bit integers.
+#endif
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+uint _44;
+uint _45;
+uint _49;
+uint _50;
+uvec4 _53;
+
+layout(set = 0, binding = 0, std430) readonly buffer SSBO
+{
+    uvec4 _m0[];
+} _10;
+
+layout(set = 0, binding = 1, std430) readonly buffer _14_16
+{
+    u16vec2 _m0[];
+} _16;
+
+layout(set = 0, binding = 2, std430) readonly buffer _20_22
+{
+    u64vec2 _m0[];
+} _22;
+
+layout(set = 0, binding = 3, std430) writeonly buffer _25_27
+{
+    uvec2 _m0[];
+} _27;
+
+void main()
+{
+    uvec4 _33 = uvec4(findMSB(ivec4(_10._m0[0u])));
+    uvec4 _42 = mix(uvec4(31u) - _33, uvec4(4294967295u), equal(_33, uvec4(4294967295u)));
+    _27._m0[0u] = uvec2(mix(uvec4(31u, 31u, 0u, 0u) - _42, uvec4(4294967295u, 4294967295u, 0u, 0u), equal(_42, uvec4(4294967295u))).xy);
+    uvec2 _63 = uvec2(findMSB(ivec2(uvec2(i16vec2(_16._m0[0u])))));
+    uvec2 _70 = mix(uvec2(15u) - _63, uvec2(4294967295u), equal(_63, uvec2(4294967295u)));
+    _27._m0[1u] = uvec2(mix(uvec2(15u) - _70, uvec2(4294967295u), equal(_70, uvec2(4294967295u))));
+    uvec4 _82 = (_22._m0[0u]);
+    uvec4 _92 = uvec4(findMSB(_82 ^ uvec4((ivec2(_82.yw) >> ivec2(31)).xxyy)));
+    uvec2 _98 = uvec2(max(ivec2(_92.xz), ivec2(_92.yw | uvec2(32u))));
+    uvec2 _103 = mix(uvec2(63u) - _98, uvec2(4294967295u), equal(_98, uvec2(4294967295u)));
+    _27._m0[2u] = uvec2(mix(uvec2(63u) - _103, uvec2(4294967295u), equal(_103, uvec2(4294967295u))));
+}
+
+
+#if 0
+// SPIR-V disassembly
+; SPIR-V
+; Version: 1.6
+; Generator: Unknown(30017); 21022
+; Bound: 114
+; Schema: 0
+OpCapability Shader
+OpCapability Int64
+OpCapability Int16
+OpCapability StorageBuffer16BitAccess
+%32 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main" %10 %16 %22 %27
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %3 "main"
+OpName %8 "SSBO"
+OpName %14 "SSBO"
+OpName %20 "SSBO"
+OpName %25 "SSBO"
+OpDecorate %7 ArrayStride 16
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %8 Block
+OpDecorate %10 DescriptorSet 0
+OpDecorate %10 Binding 0
+OpDecorate %10 NonWritable
+OpDecorate %13 ArrayStride 4
+OpMemberDecorate %14 0 Offset 0
+OpDecorate %14 Block
+OpDecorate %16 DescriptorSet 0
+OpDecorate %16 Binding 1
+OpDecorate %16 NonWritable
+OpDecorate %19 ArrayStride 16
+OpMemberDecorate %20 0 Offset 0
+OpDecorate %20 Block
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 2
+OpDecorate %22 NonWritable
+OpDecorate %24 ArrayStride 8
+OpMemberDecorate %25 0 Offset 0
+OpDecorate %25 Block
+OpDecorate %27 DescriptorSet 0
+OpDecorate %27 Binding 3
+OpDecorate %27 NonReadable
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%5 = OpTypeInt 32 0
+%6 = OpTypeVector %5 4
+%7 = OpTypeRuntimeArray %6
+%8 = OpTypeStruct %7
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpVariable %9 StorageBuffer
+%11 = OpTypeInt 16 0
+%12 = OpTypeVector %11 2
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypeStruct %13
+%15 = OpTypePointer StorageBuffer %14
+%16 = OpVariable %15 StorageBuffer
+%17 = OpTypeInt 64 0
+%18 = OpTypeVector %17 2
+%19 = OpTypeRuntimeArray %18
+%20 = OpTypeStruct %19
+%21 = OpTypePointer StorageBuffer %20
+%22 = OpVariable %21 StorageBuffer
+%23 = OpTypeVector %5 2
+%24 = OpTypeRuntimeArray %23
+%25 = OpTypeStruct %24
+%26 = OpTypePointer StorageBuffer %25
+%27 = OpVariable %26 StorageBuffer
+%28 = OpConstant %5 0
+%29 = OpTypePointer StorageBuffer %6
+%34 = OpTypeBool
+%35 = OpTypeVector %34 4
+%37 = OpConstant %5 4294967295
+%38 = OpConstantComposite %6 %37 %37 %37 %37
+%40 = OpConstant %5 31
+%41 = OpConstantComposite %6 %40 %40 %40 %40
+%44 = OpUndef %5
+%45 = OpUndef %5
+%46 = OpConstantComposite %6 %40 %40 %44 %45
+%49 = OpUndef %5
+%50 = OpUndef %5
+%51 = OpConstantComposite %6 %37 %37 %49 %50
+%57 = OpTypePointer StorageBuffer %23
+%59 = OpTypePointer StorageBuffer %12
+%64 = OpTypeVector %34 2
+%66 = OpConstantComposite %23 %37 %37
+%68 = OpConstant %5 15
+%69 = OpConstantComposite %23 %68 %68
+%74 = OpConstant %5 1
+%79 = OpTypePointer StorageBuffer %18
+%84 = OpTypeInt 32 1
+%85 = OpTypeVector %84 2
+%87 = OpConstant %84 31
+%88 = OpConstantComposite %85 %87 %87
+%89 = OpTypeVector %84 4
+%96 = OpConstant %5 32
+%97 = OpConstantComposite %23 %96 %96
+%101 = OpConstant %5 63
+%102 = OpConstantComposite %23 %101 %101
+%107 = OpConstant %5 2
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+%53 = OpUndef %6
+OpBranch %112
+%112 = OpLabel
+%30 = OpAccessChain %29 %10 %28 %28
+%31 = OpLoad %6 %30
+%33 = OpExtInst %6 %32 FindSMsb %31
+%36 = OpIEqual %35 %33 %38
+%39 = OpISub %6 %41 %33
+%42 = OpSelect %6 %36 %38 %39
+%43 = OpISub %6 %46 %42
+%47 = OpIEqual %35 %42 %38
+%48 = OpSelect %6 %47 %51 %43
+%52 = OpVectorShuffle %23 %48 %53 0 1
+%54 = OpCompositeExtract %5 %52 0
+%55 = OpCompositeExtract %5 %52 1
+%56 = OpCompositeConstruct %23 %54 %55
+%58 = OpAccessChain %57 %27 %28 %28
+OpStore %58 %56
+%60 = OpAccessChain %59 %16 %28 %28
+%61 = OpLoad %12 %60
+%62 = OpSConvert %23 %61
+%63 = OpExtInst %23 %32 FindSMsb %62
+%65 = OpIEqual %64 %63 %66
+%67 = OpISub %23 %69 %63
+%70 = OpSelect %23 %65 %66 %67
+%71 = OpISub %23 %69 %70
+%72 = OpIEqual %64 %70 %66
+%73 = OpSelect %23 %72 %66 %71
+%75 = OpCompositeExtract %5 %73 0
+%76 = OpCompositeExtract %5 %73 1
+%77 = OpCompositeConstruct %23 %75 %76
+%78 = OpAccessChain %57 %27 %28 %74
+OpStore %78 %77
+%80 = OpAccessChain %79 %22 %28 %28
+%81 = OpLoad %18 %80
+%82 = OpBitcast %6 %81
+%83 = OpVectorShuffle %23 %82 %82 1 3
+%86 = OpShiftRightArithmetic %85 %83 %88
+%90 = OpVectorShuffle %89 %86 %86 0 0 1 1
+%91 = OpBitwiseXor %6 %82 %90
+%92 = OpExtInst %6 %32 FindUMsb %91
+%93 = OpVectorShuffle %23 %92 %92 0 2
+%94 = OpVectorShuffle %23 %92 %92 1 3
+%95 = OpBitwiseOr %23 %94 %97
+%98 = OpExtInst %23 %32 SMax %93 %95
+%99 = OpIEqual %64 %98 %66
+%100 = OpISub %23 %102 %98
+%103 = OpSelect %23 %99 %66 %100
+%104 = OpISub %23 %102 %103
+%105 = OpIEqual %64 %103 %66
+%106 = OpSelect %23 %105 %66 %104
+%108 = OpCompositeExtract %5 %106 0
+%109 = OpCompositeExtract %5 %106 1
+%110 = OpCompositeConstruct %23 %108 %109
+%111 = OpAccessChain %57 %27 %28 %107
+OpStore %111 %110
+OpReturn
+OpFunctionEnd
+#endif

--- a/shaders/dxil-builtin/bfrev-vector.sm69.ssbo.comp
+++ b/shaders/dxil-builtin/bfrev-vector.sm69.ssbo.comp
@@ -1,0 +1,11 @@
+RWStructuredBuffer<vector<uint, 4> > U32;
+RWStructuredBuffer<vector<uint16_t, 2> > U16;
+RWStructuredBuffer<vector<uint64_t, 2> > U64;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+	U32[0] = reversebits(U32[0]);
+	U16[0] = reversebits(U16[0]);
+	U64[0] = reversebits(U64[0]);
+}

--- a/shaders/dxil-builtin/countbits-vector.sm69.ssbo.comp
+++ b/shaders/dxil-builtin/countbits-vector.sm69.ssbo.comp
@@ -1,0 +1,12 @@
+RWStructuredBuffer<vector<uint, 4> > U32;
+RWStructuredBuffer<vector<uint16_t, 2> > U16;
+RWStructuredBuffer<vector<uint64_t, 2> > U64;
+RWStructuredBuffer<vector<uint, 2> > result;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+	result[0] = countbits(U32[0]);
+	result[1] = countbits(U16[0]);
+	result[2] = countbits(U64[0]);
+}

--- a/shaders/dxil-builtin/firstbithi-vector.sm69.ssbo.comp
+++ b/shaders/dxil-builtin/firstbithi-vector.sm69.ssbo.comp
@@ -1,0 +1,12 @@
+RWStructuredBuffer<vector<uint, 4> > U32;
+RWStructuredBuffer<vector<uint16_t, 2> > U16;
+RWStructuredBuffer<vector<uint64_t, 2> > U64;
+RWStructuredBuffer<vector<uint, 2> > result;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+	result[0] = firstbithigh(U32[0]);
+	result[1] = firstbithigh(U16[0]);
+	result[2] = firstbithigh(U64[0]);
+}

--- a/shaders/dxil-builtin/firstbitlo-vector.sm69.ssbo.comp
+++ b/shaders/dxil-builtin/firstbitlo-vector.sm69.ssbo.comp
@@ -1,0 +1,12 @@
+RWStructuredBuffer<vector<uint, 4> > U32;
+RWStructuredBuffer<vector<uint16_t, 2> > U16;
+RWStructuredBuffer<vector<uint64_t, 2> > U64;
+RWStructuredBuffer<vector<uint, 2> > result;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+	result[0] = firstbitlow(U32[0]);
+	result[1] = firstbitlow(U16[0]);
+	result[2] = firstbitlow(U64[0]);
+}

--- a/shaders/dxil-builtin/firstbitshi-vector.sm69.ssbo.comp
+++ b/shaders/dxil-builtin/firstbitshi-vector.sm69.ssbo.comp
@@ -1,0 +1,12 @@
+RWStructuredBuffer<vector<int, 4> > I32;
+RWStructuredBuffer<vector<int16_t, 2> > I16;
+RWStructuredBuffer<vector<int64_t, 2> > I64;
+RWStructuredBuffer<vector<uint, 2> > result;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+	result[0] = firstbithigh(I32[0]);
+	result[1] = firstbithigh(I16[0]);
+	result[2] = firstbithigh(I64[0]);
+}


### PR DESCRIPTION
Add support for vectorized bit-scan ops in SM6.9:
- Countbits 
- Bfrev
- FirstBitLo
- FirstBitHi
- FirstBitSHi
