### PR TITLE
Explicitly include thread in scratch_pool.hpp.

### DIFF
--- a/scratch_pool.hpp
+++ b/scratch_pool.hpp
@@ -26,6 +26,7 @@
 #define DXIL_SPV_SCRATCH_POOL_H_
 
 #include "thread_local_allocator.hpp"
+#include <exception>
 
 namespace dxil_spv
 {


### PR DESCRIPTION
Fixes compilation with libc++ 23, which no longer includes it implicitly.