### PR TITLE
Guard against integer division by zero

### DIFF
--- a/bc/module_dxbc_ir.cpp
+++ b/bc/module_dxbc_ir.cpp
@@ -3988,6 +3988,7 @@ Module *parseDXBCBinary(LLVMContext &context, const void* data, size_t size)
 	options.arithmeticOptions.lowerDot = true;
 	options.arithmeticOptions.lowerSinCos = false;
 	options.arithmeticOptions.lowerMsad = true;
+	options.arithmeticOptions.lowerUdiv = false;
 	options.arithmeticOptions.lowerF32toF16 = true;
 	options.arithmeticOptions.lowerConvertFtoI = false;
 	options.arithmeticOptions.lowerGsVertexCountIn = true;

--- a/opcodes/dxil/dxil_arithmetic.cpp
+++ b/opcodes/dxil/dxil_arithmetic.cpp
@@ -496,20 +496,26 @@ bool emit_dxbc_udiv_instruction(Converter::Impl &impl, const llvm::CallInst *ins
 	spv::Id id0 = impl.get_id_for_value(instruction->getOperand(1));
 	spv::Id id1 = impl.get_id_for_value(instruction->getOperand(2));
 
+	auto *is_zero_divider = impl.allocate(spv::OpIEqual, builder.makeBoolType());
+	is_zero_divider->add_id(id1);
+	is_zero_divider->add_id(builder.makeUintConstant(0));
+	impl.add(is_zero_divider);
+
+	auto *divisor_select = impl.allocate(spv::OpSelect, builder.makeUintType(32));
+	divisor_select->add_id(is_zero_divider->id);
+	divisor_select->add_id(builder.makeUintConstant(UINT32_MAX));
+	divisor_select->add_id(id1);
+	impl.add(divisor_select);
+
 	auto *div_op = impl.allocate(spv::OpUDiv, builder.makeUintType(32));
 	div_op->add_id(id0);
-	div_op->add_id(id1);
+	div_op->add_id(divisor_select->id);
 	impl.add(div_op);
 
 	auto *mod_op = impl.allocate(spv::OpUMod, builder.makeUintType(32));
 	mod_op->add_id(id0);
 	mod_op->add_id(id1);
 	impl.add(mod_op);
-
-	auto *is_zero_divider = impl.allocate(spv::OpIEqual, builder.makeBoolType());
-	is_zero_divider->add_id(id1);
-	is_zero_divider->add_id(builder.makeUintConstant(0));
-	impl.add(is_zero_divider);
 
 	auto *quot_select = impl.allocate(spv::OpSelect, builder.makeUintType(32));
 	quot_select->add_id(is_zero_divider->id);

--- a/opcodes/opcodes_llvm_builtins.cpp
+++ b/opcodes/opcodes_llvm_builtins.cpp
@@ -344,6 +344,109 @@ static llvm::Value *get_bitwise_not_from_xor(llvm::Value *a, llvm::Value *b)
 }
 
 template <typename InstructionType>
+static spv::Id emit_integer_division_instruction(Converter::Impl &impl, const InstructionType *instruction, spv::Op opcode)
+{
+	auto &builder = impl.builder();
+
+	// UDiv and UMod have special behaviour regarding division by 0: At the HLSL
+	// and LLVM IR level, division by 0 is undefined behaviour and compilers may
+	// optimize assuming that the divisor is non-zero. Any UDiv or URem in the
+	// IR itself however behaves like DXBC when 0 is encountered, i.e. the result
+	// is -1.
+	//
+	// In SPIR-V, UDiv and UMod by zero also constitute undefined behaviour, and
+	// at least Nvidia drivers will optimize. Any solution that ensures the
+	// divisor cannot be zero works, but since we have no easy way to insert control
+	// flow here, simply set the divisor to -1.
+	//
+	// This does explicitly *not* apply to the signed variants.
+	//
+	// See: https://github.com/microsoft/DirectXShaderCompiler/issues/3150
+	auto divisor = instruction->getOperand(1);
+
+	// No need to add any extra code for instructions that have a constant
+	// divisor that isn't zero
+	bool is_constant_divisor = llvm::isa<llvm::ConstantInt>(divisor) &&
+		instruction->getType()->getTypeID() != llvm::Type::TypeID::VectorTyID;
+
+	if (is_constant_divisor && llvm::cast<llvm::ConstantInt>(divisor)->getUniqueInteger().getZExtValue())
+	{
+		auto op = impl.allocate(opcode, instruction);
+		op->add_id(impl.get_id_for_value(instruction->getOperand(0)));
+		op->add_id(impl.get_id_for_value(instruction->getOperand(1)));
+		impl.add(op);
+		return op->id;
+	}
+
+	auto scalar_type = instruction->getType()->getScalarType();
+
+	spv::Id const_0;
+	spv::Id const_neg1;
+
+	switch (physical_integer_bit_width(scalar_type->getIntegerBitWidth()))
+	{
+	case 16:
+		const_0 = builder.makeUint16Constant(0u);
+		const_neg1 = builder.makeUint16Constant(0xffffu);
+		break;
+
+	case 32:
+		const_0 = builder.makeUintConstant(0u);
+		const_neg1 = builder.makeUintConstant(0xffffffffu);
+		break;
+
+	case 64:
+		const_0 = builder.makeUint64Constant(0ull);
+		const_neg1 = builder.makeUint64Constant(0xffffffffffffffffull);
+		break;
+
+	default:
+		return 0;
+	}
+
+	// Any constant divisor would be 0 here
+	if (is_constant_divisor)
+		return const_neg1;
+
+	spv::Id cond_type = builder.makeBoolType();
+
+	if (instruction->getType()->getTypeID() == llvm::Type::TypeID::VectorTyID)
+	{
+		auto vector_size = instruction->getType()->getVectorNumElements();
+		cond_type = builder.makeVectorType(cond_type, vector_size);
+
+		const_0 = impl.build_splat_constant_vector(impl.get_type_id(scalar_type),
+																								const_0, vector_size);
+		const_neg1 = impl.build_splat_constant_vector(impl.get_type_id(scalar_type),
+																									const_neg1, vector_size);
+	}
+
+	spv::Id id0 = impl.get_id_for_value(instruction->getOperand(0));
+	spv::Id id1 = impl.get_id_for_value(instruction->getOperand(1));
+
+	auto *is_nonzero = impl.allocate(spv::OpINotEqual, cond_type);
+	is_nonzero->add_id(id1);
+	is_nonzero->add_id(const_0);
+	impl.add(is_nonzero);
+
+	auto type_id = impl.get_type_id(instruction->getType());
+
+	auto *divisor_select = impl.allocate(spv::OpSelect, type_id);
+	divisor_select->add_ids({ is_nonzero->id, id1, const_neg1 });
+	impl.add(divisor_select);
+
+	auto op = impl.allocate(opcode, type_id);
+	op->add_ids({ id0, divisor_select->id });
+	impl.add(op);
+
+	auto result_select = impl.allocate(spv::OpSelect, instruction);
+	result_select->add_ids({ is_nonzero->id, op->id, const_neg1 });
+	impl.add(result_select);
+
+	return result_select->id;
+}
+
+template <typename InstructionType>
 static spv::Id emit_binary_instruction_impl(Converter::Impl &impl, const InstructionType *instruction)
 {
 	bool signed_input = false;
@@ -420,9 +523,7 @@ static spv::Id emit_binary_instruction_impl(Converter::Impl &impl, const Instruc
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::UDiv:
-		opcode = spv::OpUDiv;
-		is_width_sensitive = true;
-		break;
+		return emit_integer_division_instruction(impl, instruction, spv::OpUDiv);
 
 	case llvm::BinaryOperator::BinaryOps::Shl:
 		opcode = spv::OpShiftLeftLogical;
@@ -452,10 +553,7 @@ static spv::Id emit_binary_instruction_impl(Converter::Impl &impl, const Instruc
 		break;
 
 	case llvm::BinaryOperator::BinaryOps::URem:
-		// Is this correct? There is no URem.
-		opcode = spv::OpUMod;
-		is_width_sensitive = true;
-		break;
+		return emit_integer_division_instruction(impl, instruction, spv::OpUMod);
 
 	case llvm::BinaryOperator::BinaryOps::Xor:
 		// Logical not in LLVM IR is encoded as XOR i1 against true.

--- a/reference/shaders/control-flow/wave-size-dependent-loop-unroll.comp
+++ b/reference/shaders/control-flow/wave-size-dependent-loop-unroll.comp
@@ -8,12 +8,13 @@ shared float _13[256];
 
 void main()
 {
-    uint _24 = 256u / gl_SubgroupSize;
-    bool _26 = _24 == 0u;
-    bool _27;
-    if (_26)
+    bool _26 = gl_SubgroupSize != 0u;
+    uint _29 = _26 ? (256u / (_26 ? gl_SubgroupSize : 4294967295u)) : 4294967295u;
+    bool _30 = _29 == 0u;
+    bool _31;
+    if (_30)
     {
-        _27 = true;
+        _31 = true;
     }
     else
     {
@@ -34,75 +35,75 @@ void main()
         _13[14u] = 14.0;
         _13[15u] = 15.0;
         bool frontier_phi_1_9_ladder;
-        if (_24 > 4u)
+        if (_29 > 4u)
         {
             _13[16u] = 16.0;
             _13[17u] = 17.0;
             _13[18u] = 18.0;
             _13[19u] = 19.0;
             bool frontier_phi_1_9_ladder_10_ladder;
-            if (_24 > 5u)
+            if (_29 > 5u)
             {
                 _13[20u] = 20.0;
                 _13[21u] = 21.0;
                 _13[22u] = 22.0;
                 _13[23u] = 23.0;
                 bool frontier_phi_1_9_ladder_10_ladder_11_ladder;
-                if (_24 > 6u)
+                if (_29 > 6u)
                 {
                     _13[24u] = 24.0;
                     _13[25u] = 25.0;
                     _13[26u] = 26.0;
                     _13[27u] = 27.0;
                     bool frontier_phi_1_9_ladder_10_ladder_11_ladder_12_ladder;
-                    if (_24 > 7u)
+                    if (_29 > 7u)
                     {
                         _13[28u] = 28.0;
                         _13[29u] = 29.0;
                         _13[30u] = 30.0;
                         _13[31u] = 31.0;
-                        frontier_phi_1_9_ladder_10_ladder_11_ladder_12_ladder = _26;
+                        frontier_phi_1_9_ladder_10_ladder_11_ladder_12_ladder = _30;
                     }
                     else
                     {
-                        frontier_phi_1_9_ladder_10_ladder_11_ladder_12_ladder = _26;
+                        frontier_phi_1_9_ladder_10_ladder_11_ladder_12_ladder = _30;
                     }
                     frontier_phi_1_9_ladder_10_ladder_11_ladder = frontier_phi_1_9_ladder_10_ladder_11_ladder_12_ladder;
                 }
                 else
                 {
-                    frontier_phi_1_9_ladder_10_ladder_11_ladder = _26;
+                    frontier_phi_1_9_ladder_10_ladder_11_ladder = _30;
                 }
                 frontier_phi_1_9_ladder_10_ladder = frontier_phi_1_9_ladder_10_ladder_11_ladder;
             }
             else
             {
-                frontier_phi_1_9_ladder_10_ladder = _26;
+                frontier_phi_1_9_ladder_10_ladder = _30;
             }
             frontier_phi_1_9_ladder = frontier_phi_1_9_ladder_10_ladder;
         }
         else
         {
-            frontier_phi_1_9_ladder = _26;
+            frontier_phi_1_9_ladder = _30;
         }
-        _27 = frontier_phi_1_9_ladder;
+        _31 = frontier_phi_1_9_ladder;
     }
     barrier();
-    if (!_27)
+    if (!_31)
     {
-        uint _56;
-        _56 = 0u;
+        uint _60;
+        _60 = 0u;
         for (;;)
         {
-            uint _74 = gl_GlobalInvocationID.x * 4u;
-            imageStore(_8, int(_74), uvec4(floatBitsToUint(_13[0u + (_56 * 4u)])));
-            imageStore(_8, int(_74 + 1u), uvec4(floatBitsToUint(_13[1u + (_56 * 4u)])));
-            imageStore(_8, int(_74 + 2u), uvec4(floatBitsToUint(_13[2u + (_56 * 4u)])));
-            imageStore(_8, int(_74 + 3u), uvec4(floatBitsToUint(_13[3u + (_56 * 4u)])));
-            uint _57 = _56 + 1u;
-            if (_57 < _24)
+            uint _78 = gl_GlobalInvocationID.x * 4u;
+            imageStore(_8, int(_78), uvec4(floatBitsToUint(_13[0u + (_60 * 4u)])));
+            imageStore(_8, int(_78 + 1u), uvec4(floatBitsToUint(_13[1u + (_60 * 4u)])));
+            imageStore(_8, int(_78 + 2u), uvec4(floatBitsToUint(_13[2u + (_60 * 4u)])));
+            imageStore(_8, int(_78 + 3u), uvec4(floatBitsToUint(_13[3u + (_60 * 4u)])));
+            uint _61 = _60 + 1u;
+            if (_61 < _29)
             {
-                _56 = _57;
+                _60 = _61;
             }
             else
             {
@@ -118,7 +119,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 189
+; Bound: 193
 ; Schema: 0
 OpCapability Shader
 OpCapability ImageBuffer
@@ -127,10 +128,10 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "main" %17 %22
 OpExecutionMode %3 LocalSize 64 1 1
 OpName %3 "main"
-OpName %166 "frontier_phi_1.9.ladder.10.ladder.11.ladder.12.ladder"
-OpName %167 "frontier_phi_1.9.ladder.10.ladder.11.ladder"
-OpName %168 "frontier_phi_1.9.ladder.10.ladder"
-OpName %169 "frontier_phi_1.9.ladder"
+OpName %170 "frontier_phi_1.9.ladder.10.ladder.11.ladder.12.ladder"
+OpName %171 "frontier_phi_1.9.ladder.10.ladder.11.ladder"
+OpName %172 "frontier_phi_1.9.ladder.10.ladder"
+OpName %173 "frontier_phi_1.9.ladder"
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %8 NonReadable
@@ -153,238 +154,242 @@ OpDecorate %22 BuiltIn SubgroupSize
 %18 = OpTypePointer Input %5
 %20 = OpConstant %5 0
 %22 = OpVariable %18 Input
+%24 = OpConstant %5 4294967295
 %25 = OpTypeBool
-%28 = OpConstantTrue %25
-%29 = OpConstant %5 2
-%30 = OpConstant %5 264
-%31 = OpTypePointer Workgroup %10
-%33 = OpConstant %10 0
-%35 = OpConstant %5 1
-%36 = OpConstant %10 1
-%38 = OpConstant %10 2
-%40 = OpConstant %5 3
-%41 = OpConstant %10 3
-%44 = OpConstant %5 4
-%45 = OpConstant %10 4
-%47 = OpConstant %5 5
-%48 = OpConstant %10 5
-%50 = OpConstant %5 6
-%51 = OpConstant %10 6
-%53 = OpConstant %5 7
-%54 = OpConstant %10 7
-%79 = OpTypeVector %5 4
-%89 = OpConstant %5 8
-%90 = OpConstant %10 8
-%92 = OpConstant %5 9
-%93 = OpConstant %10 9
-%95 = OpConstant %5 10
-%96 = OpConstant %10 10
-%98 = OpConstant %5 11
-%99 = OpConstant %10 11
-%102 = OpConstant %5 12
-%103 = OpConstant %10 12
-%105 = OpConstant %5 13
-%106 = OpConstant %10 13
-%108 = OpConstant %5 14
-%109 = OpConstant %10 14
-%111 = OpConstant %5 15
-%112 = OpConstant %10 15
-%115 = OpConstant %5 16
-%116 = OpConstant %10 16
-%118 = OpConstant %5 17
-%119 = OpConstant %10 17
-%121 = OpConstant %5 18
-%122 = OpConstant %10 18
-%124 = OpConstant %5 19
-%125 = OpConstant %10 19
-%128 = OpConstant %5 20
-%129 = OpConstant %10 20
-%131 = OpConstant %5 21
-%132 = OpConstant %10 21
-%134 = OpConstant %5 22
-%135 = OpConstant %10 22
-%137 = OpConstant %5 23
-%138 = OpConstant %10 23
-%141 = OpConstant %5 24
-%142 = OpConstant %10 24
-%144 = OpConstant %5 25
-%145 = OpConstant %10 25
-%147 = OpConstant %5 26
-%148 = OpConstant %10 26
-%150 = OpConstant %5 27
-%151 = OpConstant %10 27
-%154 = OpConstant %5 28
-%155 = OpConstant %10 28
-%157 = OpConstant %5 29
-%158 = OpConstant %10 29
-%160 = OpConstant %5 30
-%161 = OpConstant %10 30
-%163 = OpConstant %5 31
-%164 = OpConstant %10 31
+%32 = OpConstantTrue %25
+%33 = OpConstant %5 2
+%34 = OpConstant %5 264
+%35 = OpTypePointer Workgroup %10
+%37 = OpConstant %10 0
+%39 = OpConstant %5 1
+%40 = OpConstant %10 1
+%42 = OpConstant %10 2
+%44 = OpConstant %5 3
+%45 = OpConstant %10 3
+%48 = OpConstant %5 4
+%49 = OpConstant %10 4
+%51 = OpConstant %5 5
+%52 = OpConstant %10 5
+%54 = OpConstant %5 6
+%55 = OpConstant %10 6
+%57 = OpConstant %5 7
+%58 = OpConstant %10 7
+%83 = OpTypeVector %5 4
+%93 = OpConstant %5 8
+%94 = OpConstant %10 8
+%96 = OpConstant %5 9
+%97 = OpConstant %10 9
+%99 = OpConstant %5 10
+%100 = OpConstant %10 10
+%102 = OpConstant %5 11
+%103 = OpConstant %10 11
+%106 = OpConstant %5 12
+%107 = OpConstant %10 12
+%109 = OpConstant %5 13
+%110 = OpConstant %10 13
+%112 = OpConstant %5 14
+%113 = OpConstant %10 14
+%115 = OpConstant %5 15
+%116 = OpConstant %10 15
+%119 = OpConstant %5 16
+%120 = OpConstant %10 16
+%122 = OpConstant %5 17
+%123 = OpConstant %10 17
+%125 = OpConstant %5 18
+%126 = OpConstant %10 18
+%128 = OpConstant %5 19
+%129 = OpConstant %10 19
+%132 = OpConstant %5 20
+%133 = OpConstant %10 20
+%135 = OpConstant %5 21
+%136 = OpConstant %10 21
+%138 = OpConstant %5 22
+%139 = OpConstant %10 22
+%141 = OpConstant %5 23
+%142 = OpConstant %10 23
+%145 = OpConstant %5 24
+%146 = OpConstant %10 24
+%148 = OpConstant %5 25
+%149 = OpConstant %10 25
+%151 = OpConstant %5 26
+%152 = OpConstant %10 26
+%154 = OpConstant %5 27
+%155 = OpConstant %10 27
+%158 = OpConstant %5 28
+%159 = OpConstant %10 28
+%161 = OpConstant %5 29
+%162 = OpConstant %10 29
+%164 = OpConstant %5 30
+%165 = OpConstant %10 30
+%167 = OpConstant %5 31
+%168 = OpConstant %10 31
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %170
-%170 = OpLabel
+OpBranch %174
+%174 = OpLabel
 %14 = OpLoad %6 %8
 %19 = OpAccessChain %18 %17 %20
 %21 = OpLoad %5 %19
 %23 = OpLoad %5 %22
-%24 = OpUDiv %5 %9 %23
-%26 = OpIEqual %25 %24 %20
-OpSelectionMerge %183 None
-OpBranchConditional %26 %183 %171
-%171 = OpLabel
-%32 = OpAccessChain %31 %13 %20
-OpStore %32 %33
-%34 = OpAccessChain %31 %13 %35
-OpStore %34 %36
-%37 = OpAccessChain %31 %13 %29
-OpStore %37 %38
-%39 = OpAccessChain %31 %13 %40
-OpStore %39 %41
-%42 = OpUGreaterThan %25 %24 %35
-OpBranch %172
-%172 = OpLabel
-%43 = OpAccessChain %31 %13 %44
-OpStore %43 %45
-%46 = OpAccessChain %31 %13 %47
-OpStore %46 %48
-%49 = OpAccessChain %31 %13 %50
-OpStore %49 %51
-%52 = OpAccessChain %31 %13 %53
-OpStore %52 %54
-%55 = OpUGreaterThan %25 %24 %29
-OpBranch %173
-%173 = OpLabel
-%88 = OpAccessChain %31 %13 %89
-OpStore %88 %90
-%91 = OpAccessChain %31 %13 %92
-OpStore %91 %93
-%94 = OpAccessChain %31 %13 %95
-OpStore %94 %96
-%97 = OpAccessChain %31 %13 %98
-OpStore %97 %99
-%100 = OpUGreaterThan %25 %24 %40
-OpBranch %174
-%174 = OpLabel
-%101 = OpAccessChain %31 %13 %102
-OpStore %101 %103
-%104 = OpAccessChain %31 %13 %105
-OpStore %104 %106
-%107 = OpAccessChain %31 %13 %108
-OpStore %107 %109
-%110 = OpAccessChain %31 %13 %111
-OpStore %110 %112
-%113 = OpUGreaterThan %25 %24 %44
-OpSelectionMerge %182 None
-OpBranchConditional %113 %175 %182
+%26 = OpINotEqual %25 %23 %20
+%27 = OpSelect %5 %26 %23 %24
+%28 = OpUDiv %5 %9 %27
+%29 = OpSelect %5 %26 %28 %24
+%30 = OpIEqual %25 %29 %20
+OpSelectionMerge %187 None
+OpBranchConditional %30 %187 %175
 %175 = OpLabel
-%114 = OpAccessChain %31 %13 %115
-OpStore %114 %116
-%117 = OpAccessChain %31 %13 %118
-OpStore %117 %119
-%120 = OpAccessChain %31 %13 %121
-OpStore %120 %122
-%123 = OpAccessChain %31 %13 %124
-OpStore %123 %125
-%126 = OpUGreaterThan %25 %24 %47
-OpSelectionMerge %181 None
-OpBranchConditional %126 %176 %181
+%36 = OpAccessChain %35 %13 %20
+OpStore %36 %37
+%38 = OpAccessChain %35 %13 %39
+OpStore %38 %40
+%41 = OpAccessChain %35 %13 %33
+OpStore %41 %42
+%43 = OpAccessChain %35 %13 %44
+OpStore %43 %45
+%46 = OpUGreaterThan %25 %29 %39
+OpBranch %176
 %176 = OpLabel
-%127 = OpAccessChain %31 %13 %128
-OpStore %127 %129
-%130 = OpAccessChain %31 %13 %131
-OpStore %130 %132
-%133 = OpAccessChain %31 %13 %134
-OpStore %133 %135
-%136 = OpAccessChain %31 %13 %137
-OpStore %136 %138
-%139 = OpUGreaterThan %25 %24 %50
-OpSelectionMerge %180 None
-OpBranchConditional %139 %177 %180
+%47 = OpAccessChain %35 %13 %48
+OpStore %47 %49
+%50 = OpAccessChain %35 %13 %51
+OpStore %50 %52
+%53 = OpAccessChain %35 %13 %54
+OpStore %53 %55
+%56 = OpAccessChain %35 %13 %57
+OpStore %56 %58
+%59 = OpUGreaterThan %25 %29 %33
+OpBranch %177
 %177 = OpLabel
-%140 = OpAccessChain %31 %13 %141
-OpStore %140 %142
-%143 = OpAccessChain %31 %13 %144
-OpStore %143 %145
-%146 = OpAccessChain %31 %13 %147
-OpStore %146 %148
-%149 = OpAccessChain %31 %13 %150
-OpStore %149 %151
-%152 = OpUGreaterThan %25 %24 %53
-OpSelectionMerge %179 None
-OpBranchConditional %152 %178 %179
+%92 = OpAccessChain %35 %13 %93
+OpStore %92 %94
+%95 = OpAccessChain %35 %13 %96
+OpStore %95 %97
+%98 = OpAccessChain %35 %13 %99
+OpStore %98 %100
+%101 = OpAccessChain %35 %13 %102
+OpStore %101 %103
+%104 = OpUGreaterThan %25 %29 %44
+OpBranch %178
 %178 = OpLabel
-%153 = OpAccessChain %31 %13 %154
-OpStore %153 %155
-%156 = OpAccessChain %31 %13 %157
-OpStore %156 %158
-%159 = OpAccessChain %31 %13 %160
-OpStore %159 %161
-%162 = OpAccessChain %31 %13 %163
-OpStore %162 %164
-%165 = OpUGreaterThan %25 %24 %89
-OpBranch %179
+%105 = OpAccessChain %35 %13 %106
+OpStore %105 %107
+%108 = OpAccessChain %35 %13 %109
+OpStore %108 %110
+%111 = OpAccessChain %35 %13 %112
+OpStore %111 %113
+%114 = OpAccessChain %35 %13 %115
+OpStore %114 %116
+%117 = OpUGreaterThan %25 %29 %48
+OpSelectionMerge %186 None
+OpBranchConditional %117 %179 %186
 %179 = OpLabel
-%166 = OpPhi %25 %26 %178 %26 %177
-OpBranch %180
+%118 = OpAccessChain %35 %13 %119
+OpStore %118 %120
+%121 = OpAccessChain %35 %13 %122
+OpStore %121 %123
+%124 = OpAccessChain %35 %13 %125
+OpStore %124 %126
+%127 = OpAccessChain %35 %13 %128
+OpStore %127 %129
+%130 = OpUGreaterThan %25 %29 %51
+OpSelectionMerge %185 None
+OpBranchConditional %130 %180 %185
 %180 = OpLabel
-%167 = OpPhi %25 %26 %176 %166 %179
-OpBranch %181
+%131 = OpAccessChain %35 %13 %132
+OpStore %131 %133
+%134 = OpAccessChain %35 %13 %135
+OpStore %134 %136
+%137 = OpAccessChain %35 %13 %138
+OpStore %137 %139
+%140 = OpAccessChain %35 %13 %141
+OpStore %140 %142
+%143 = OpUGreaterThan %25 %29 %54
+OpSelectionMerge %184 None
+OpBranchConditional %143 %181 %184
 %181 = OpLabel
-%168 = OpPhi %25 %26 %175 %167 %180
-OpBranch %182
+%144 = OpAccessChain %35 %13 %145
+OpStore %144 %146
+%147 = OpAccessChain %35 %13 %148
+OpStore %147 %149
+%150 = OpAccessChain %35 %13 %151
+OpStore %150 %152
+%153 = OpAccessChain %35 %13 %154
+OpStore %153 %155
+%156 = OpUGreaterThan %25 %29 %57
+OpSelectionMerge %183 None
+OpBranchConditional %156 %182 %183
 %182 = OpLabel
-%169 = OpPhi %25 %26 %174 %168 %181
+%157 = OpAccessChain %35 %13 %158
+OpStore %157 %159
+%160 = OpAccessChain %35 %13 %161
+OpStore %160 %162
+%163 = OpAccessChain %35 %13 %164
+OpStore %163 %165
+%166 = OpAccessChain %35 %13 %167
+OpStore %166 %168
+%169 = OpUGreaterThan %25 %29 %93
 OpBranch %183
 %183 = OpLabel
-%27 = OpPhi %25 %28 %170 %169 %182
-OpControlBarrier %29 %29 %30
-OpSelectionMerge %187 None
-OpBranchConditional %27 %187 %184
+%170 = OpPhi %25 %30 %182 %30 %181
+OpBranch %184
 %184 = OpLabel
+%171 = OpPhi %25 %30 %180 %170 %183
 OpBranch %185
 %185 = OpLabel
-%56 = OpPhi %5 %20 %184 %57 %185
-%58 = OpIMul %5 %56 %44
-%59 = OpIAdd %5 %20 %58
-%60 = OpAccessChain %31 %13 %59
-%61 = OpLoad %10 %60
-%62 = OpIMul %5 %56 %44
-%63 = OpIAdd %5 %35 %62
-%64 = OpAccessChain %31 %13 %63
-%65 = OpLoad %10 %64
-%66 = OpIMul %5 %56 %44
-%67 = OpIAdd %5 %29 %66
-%68 = OpAccessChain %31 %13 %67
-%69 = OpLoad %10 %68
-%70 = OpIMul %5 %56 %44
-%71 = OpIAdd %5 %40 %70
-%72 = OpAccessChain %31 %13 %71
-%73 = OpLoad %10 %72
-%74 = OpIMul %5 %21 %44
-%75 = OpBitcast %5 %61
-%76 = OpBitcast %5 %65
-%77 = OpBitcast %5 %69
-%78 = OpBitcast %5 %73
-%80 = OpCompositeConstruct %79 %75 %75 %75 %75
-OpImageWrite %14 %74 %80
-%81 = OpCompositeConstruct %79 %76 %76 %76 %76
-%82 = OpIAdd %5 %74 %35
-OpImageWrite %14 %82 %81
-%83 = OpCompositeConstruct %79 %77 %77 %77 %77
-%84 = OpIAdd %5 %74 %29
-OpImageWrite %14 %84 %83
-%85 = OpCompositeConstruct %79 %78 %78 %78 %78
-%86 = OpIAdd %5 %74 %40
-OpImageWrite %14 %86 %85
-%57 = OpIAdd %5 %56 %35
-%87 = OpULessThan %25 %57 %24
-OpLoopMerge %186 %185 None
-OpBranchConditional %87 %185 %186
+%172 = OpPhi %25 %30 %179 %171 %184
+OpBranch %186
 %186 = OpLabel
+%173 = OpPhi %25 %30 %178 %172 %185
 OpBranch %187
 %187 = OpLabel
+%31 = OpPhi %25 %32 %174 %173 %186
+OpControlBarrier %33 %33 %34
+OpSelectionMerge %191 None
+OpBranchConditional %31 %191 %188
+%188 = OpLabel
+OpBranch %189
+%189 = OpLabel
+%60 = OpPhi %5 %20 %188 %61 %189
+%62 = OpIMul %5 %60 %48
+%63 = OpIAdd %5 %20 %62
+%64 = OpAccessChain %35 %13 %63
+%65 = OpLoad %10 %64
+%66 = OpIMul %5 %60 %48
+%67 = OpIAdd %5 %39 %66
+%68 = OpAccessChain %35 %13 %67
+%69 = OpLoad %10 %68
+%70 = OpIMul %5 %60 %48
+%71 = OpIAdd %5 %33 %70
+%72 = OpAccessChain %35 %13 %71
+%73 = OpLoad %10 %72
+%74 = OpIMul %5 %60 %48
+%75 = OpIAdd %5 %44 %74
+%76 = OpAccessChain %35 %13 %75
+%77 = OpLoad %10 %76
+%78 = OpIMul %5 %21 %48
+%79 = OpBitcast %5 %65
+%80 = OpBitcast %5 %69
+%81 = OpBitcast %5 %73
+%82 = OpBitcast %5 %77
+%84 = OpCompositeConstruct %83 %79 %79 %79 %79
+OpImageWrite %14 %78 %84
+%85 = OpCompositeConstruct %83 %80 %80 %80 %80
+%86 = OpIAdd %5 %78 %39
+OpImageWrite %14 %86 %85
+%87 = OpCompositeConstruct %83 %81 %81 %81 %81
+%88 = OpIAdd %5 %78 %33
+OpImageWrite %14 %88 %87
+%89 = OpCompositeConstruct %83 %82 %82 %82 %82
+%90 = OpIAdd %5 %78 %44
+OpImageWrite %14 %90 %89
+%61 = OpIAdd %5 %60 %39
+%91 = OpULessThan %25 %61 %29
+OpLoopMerge %190 %189 None
+OpBranchConditional %91 %189 %190
+%190 = OpLabel
+OpBranch %191
+%191 = OpLabel
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/dxil-builtin/vector-uint-arithmetic.sm69.frag
+++ b/reference/shaders/dxil-builtin/vector-uint-arithmetic.sm69.frag
@@ -1,7 +1,7 @@
 #version 460
 
 uvec4 _18;
-vec4 _75;
+vec4 _83;
 
 layout(location = 0) flat in uvec4 A;
 layout(location = 1) flat in uvec4 B;
@@ -25,19 +25,20 @@ void main()
     _45.y = A.y;
     _45.z = A.z;
     _45.w = A.w;
-    vec4 _65 = vec4((_45 * _33) + _17);
-    float _66 = _65.x;
-    float _73 = inversesqrt(dot(vec4(_66, _65.yzw), vec4(_66, _65.yzw)));
-    vec4 _74;
-    _74.x = _73;
-    _74.y = _73;
-    _74.z = _73;
-    _74.w = _73;
-    uvec4 _82 = min(uvec4(sqrt(vec4(_45 + (_33 / _17)))), uvec4(cos(_74 * _65)));
-    SV_Target.x = _82.x;
-    SV_Target.y = _82.y;
-    SV_Target.z = _82.z;
-    SV_Target.w = _82.w;
+    bvec4 _60 = notEqual(_17, uvec4(0u));
+    vec4 _73 = vec4((_45 * _33) + _17);
+    float _74 = _73.x;
+    float _81 = inversesqrt(dot(vec4(_74, _73.yzw), vec4(_74, _73.yzw)));
+    vec4 _82;
+    _82.x = _81;
+    _82.y = _81;
+    _82.z = _81;
+    _82.w = _81;
+    uvec4 _90 = min(uvec4(sqrt(vec4(_45 + mix(uvec4(4294967295u), _33 / mix(uvec4(4294967295u), _17, _60), _60)))), uvec4(cos(_82 * _73)));
+    SV_Target.x = _90.x;
+    SV_Target.y = _90.y;
+    SV_Target.z = _90.z;
+    SV_Target.w = _90.w;
 }
 
 
@@ -46,10 +47,10 @@ void main()
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 94
+; Bound: 102
 ; Schema: 0
 OpCapability Shader
-%62 = OpExtInstImport "GLSL.std.450"
+%70 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %3 "main" %8 %9 %10 %12
 OpExecutionMode %3 OriginUpperLeft
@@ -80,15 +81,20 @@ OpDecorate %12 Location 0
 %20 = OpConstant %5 1
 %24 = OpConstant %5 2
 %28 = OpConstant %5 3
-%59 = OpTypeFloat 32
-%60 = OpTypeVector %59 4
-%84 = OpTypePointer Output %5
+%55 = OpConstant %5 4294967295
+%56 = OpTypeBool
+%57 = OpTypeVector %56 4
+%58 = OpConstantComposite %6 %15 %15 %15 %15
+%59 = OpConstantComposite %6 %55 %55 %55 %55
+%67 = OpTypeFloat 32
+%68 = OpTypeVector %67 4
+%92 = OpTypePointer Output %5
 %3 = OpFunction %1 None %2
 %4 = OpLabel
 %18 = OpUndef %6
-%75 = OpUndef %60
-OpBranch %92
-%92 = OpLabel
+%83 = OpUndef %68
+OpBranch %100
+%100 = OpLabel
 %14 = OpAccessChain %13 %10 %15
 %16 = OpLoad %5 %14
 %17 = OpCompositeInsert %6 %16 %18 0
@@ -125,42 +131,45 @@ OpBranch %92
 %52 = OpAccessChain %13 %8 %28
 %53 = OpLoad %5 %52
 %54 = OpCompositeInsert %6 %53 %51 3
-%55 = OpUDiv %6 %42 %30
-%56 = OpIAdd %6 %54 %55
-%57 = OpIMul %6 %54 %42
-%58 = OpIAdd %6 %57 %30
-%61 = OpConvertUToF %60 %56
-%63 = OpExtInst %60 %62 Sqrt %61
-%64 = OpConvertFToU %6 %63
-%65 = OpConvertUToF %60 %58
-%66 = OpCompositeExtract %59 %65 0
-%67 = OpCompositeExtract %59 %65 1
-%68 = OpCompositeExtract %59 %65 2
-%69 = OpCompositeExtract %59 %65 3
-%71 = OpCompositeConstruct %60 %66 %67 %68 %69
-%72 = OpCompositeConstruct %60 %66 %67 %68 %69
-%70 = OpDot %59 %71 %72
-%73 = OpExtInst %59 %62 InverseSqrt %70
-%74 = OpCompositeInsert %60 %73 %75 0
-%76 = OpCompositeInsert %60 %73 %74 1
-%77 = OpCompositeInsert %60 %73 %76 2
-%78 = OpCompositeInsert %60 %73 %77 3
-%79 = OpFMul %60 %78 %65
-%80 = OpExtInst %60 %62 Cos %79
-%81 = OpConvertFToU %6 %80
-%82 = OpExtInst %6 %62 UMin %64 %81
-%83 = OpCompositeExtract %5 %82 0
-%85 = OpAccessChain %84 %12 %15
-OpStore %85 %83
-%86 = OpCompositeExtract %5 %82 1
-%87 = OpAccessChain %84 %12 %20
-OpStore %87 %86
-%88 = OpCompositeExtract %5 %82 2
-%89 = OpAccessChain %84 %12 %24
-OpStore %89 %88
-%90 = OpCompositeExtract %5 %82 3
-%91 = OpAccessChain %84 %12 %28
-OpStore %91 %90
+%60 = OpINotEqual %57 %30 %58
+%61 = OpSelect %6 %60 %30 %59
+%62 = OpUDiv %6 %42 %61
+%63 = OpSelect %6 %60 %62 %59
+%64 = OpIAdd %6 %54 %63
+%65 = OpIMul %6 %54 %42
+%66 = OpIAdd %6 %65 %30
+%69 = OpConvertUToF %68 %64
+%71 = OpExtInst %68 %70 Sqrt %69
+%72 = OpConvertFToU %6 %71
+%73 = OpConvertUToF %68 %66
+%74 = OpCompositeExtract %67 %73 0
+%75 = OpCompositeExtract %67 %73 1
+%76 = OpCompositeExtract %67 %73 2
+%77 = OpCompositeExtract %67 %73 3
+%79 = OpCompositeConstruct %68 %74 %75 %76 %77
+%80 = OpCompositeConstruct %68 %74 %75 %76 %77
+%78 = OpDot %67 %79 %80
+%81 = OpExtInst %67 %70 InverseSqrt %78
+%82 = OpCompositeInsert %68 %81 %83 0
+%84 = OpCompositeInsert %68 %81 %82 1
+%85 = OpCompositeInsert %68 %81 %84 2
+%86 = OpCompositeInsert %68 %81 %85 3
+%87 = OpFMul %68 %86 %73
+%88 = OpExtInst %68 %70 Cos %87
+%89 = OpConvertFToU %6 %88
+%90 = OpExtInst %6 %70 UMin %72 %89
+%91 = OpCompositeExtract %5 %90 0
+%93 = OpAccessChain %92 %12 %15
+OpStore %93 %91
+%94 = OpCompositeExtract %5 %90 1
+%95 = OpAccessChain %92 %12 %20
+OpStore %95 %94
+%96 = OpCompositeExtract %5 %90 2
+%97 = OpAccessChain %92 %12 %24
+OpStore %97 %96
+%98 = OpCompositeExtract %5 %90 3
+%99 = OpAccessChain %92 %12 %28
+OpStore %99 %98
 OpReturn
 OpFunctionEnd
 #endif

--- a/reference/shaders/llvm-builtin/vector-conversions-width.sm69.ssbo.comp
+++ b/reference/shaders/llvm-builtin/vector-conversions-width.sm69.ssbo.comp
@@ -31,7 +31,8 @@ void main()
     uint _33 = ByteAddressMask(gl_GlobalInvocationID.x, 16u);
     uint _41 = ByteAddressMask(gl_GlobalInvocationID.x + 1u, 16u);
     vec4 _53 = uintBitsToFloat(_10._m0[ByteAddressMask(gl_GlobalInvocationID.x + 2u, 16u)]);
-    _14._m0[ByteAddressMask(gl_GlobalInvocationID.x, 16u)] = uvec4(uvec4(u16vec4(_10._m0[_33]) / u16vec4(1us, 2us, 3us, 4us)) + _10._m0[_33]);
+    bvec4 _72 = notEqual(u16vec4(1us, 2us, 3us, 4us), u16vec4(0));
+    _14._m0[ByteAddressMask(gl_GlobalInvocationID.x, 16u)] = uvec4(uvec4(mix(u16vec4(65535), u16vec4(_10._m0[_33]) / mix(u16vec4(65535), u16vec4(1us, 2us, 3us, 4us), _72), _72)) + _10._m0[_33]);
     _14._m0[ByteAddressMask(gl_GlobalInvocationID.x + 16u, 16u)] = uvec4(uvec4(i16vec4(u16vec4(i16vec4(u16vec4(_10._m0[_41])) / i16vec4(u16vec4(1us, 2us, 3us, 4us))))) + _10._m0[_41]);
     _14._m0[ByteAddressMask(gl_GlobalInvocationID.x + 64u, 16u)] = uvec4(floatBitsToUint(vec4(f16vec4(_53) / f16vec4(float16_t(1.0), float16_t(2.0), float16_t(3.0), float16_t(4.0))) + _53));
 }
@@ -42,7 +43,7 @@ void main()
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Unknown(30017); 21022
-; Bound: 111
+; Bound: 120
 ; Schema: 0
 OpCapability Shader
 OpCapability Float16
@@ -104,23 +105,29 @@ OpDecorate %17 BuiltIn GlobalInvocationId
 %55 = OpTypeVector %54 4
 %58 = OpTypeFloat 16
 %59 = OpTypeVector %58 4
-%62 = OpConstant %54 1
-%63 = OpConstant %54 2
-%64 = OpConstant %54 3
-%65 = OpConstant %54 4
-%66 = OpConstantComposite %55 %62 %63 %64 %65
-%69 = OpConstant %58 0x1p+0
-%70 = OpConstant %58 0x1p+1
-%71 = OpConstant %58 0x1.8p+1
-%72 = OpConstant %58 0x1p+2
-%73 = OpConstantComposite %59 %69 %70 %71 %72
-%88 = OpConstant %5 256
-%98 = OpConstant %5 1024
-%100 = OpConstant %5 64
+%61 = OpConstant %54 0
+%62 = OpConstant %54 65535
+%63 = OpTypeBool
+%64 = OpTypeVector %63 4
+%65 = OpConstantComposite %55 %61 %61 %61 %61
+%66 = OpConstantComposite %55 %62 %62 %62 %62
+%67 = OpConstant %54 1
+%68 = OpConstant %54 2
+%69 = OpConstant %54 3
+%70 = OpConstant %54 4
+%71 = OpConstantComposite %55 %67 %68 %69 %70
+%78 = OpConstant %58 0x1p+0
+%79 = OpConstant %58 0x1p+1
+%80 = OpConstant %58 0x1.8p+1
+%81 = OpConstant %58 0x1p+2
+%82 = OpConstantComposite %59 %78 %79 %80 %81
+%97 = OpConstant %5 256
+%107 = OpConstant %5 1024
+%109 = OpConstant %5 64
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %109
-%109 = OpLabel
+OpBranch %118
+%118 = OpLabel
 %19 = OpAccessChain %18 %17 %20
 %21 = OpLoad %5 %19
 %22 = OpShiftLeftLogical %5 %21 %23
@@ -141,44 +148,47 @@ OpBranch %109
 %56 = OpUConvert %55 %37
 %57 = OpUConvert %55 %43
 %60 = OpFConvert %59 %53
-%61 = OpUDiv %55 %56 %66
-%67 = OpSDiv %55 %57 %66
-%68 = OpFDiv %59 %60 %73
-%74 = OpUConvert %6 %61
-%75 = OpIAdd %6 %74 %37
-%76 = OpSConvert %6 %67
-%77 = OpIAdd %6 %76 %43
-%78 = OpFConvert %52 %68
-%79 = OpFAdd %52 %78 %53
-%80 = OpFunctionCall %5 %27 %21 %34
-%81 = OpCompositeExtract %5 %75 0
-%82 = OpCompositeExtract %5 %75 1
-%83 = OpCompositeExtract %5 %75 2
-%84 = OpCompositeExtract %5 %75 3
-%85 = OpCompositeConstruct %6 %81 %82 %83 %84
-%86 = OpAccessChain %35 %14 %20 %80
-OpStore %86 %85
-%87 = OpIAdd %5 %22 %88
-%89 = OpIAdd %5 %21 %34
-%90 = OpFunctionCall %5 %27 %89 %34
-%91 = OpCompositeExtract %5 %77 0
-%92 = OpCompositeExtract %5 %77 1
-%93 = OpCompositeExtract %5 %77 2
-%94 = OpCompositeExtract %5 %77 3
-%95 = OpCompositeConstruct %6 %91 %92 %93 %94
-%96 = OpAccessChain %35 %14 %20 %90
-OpStore %96 %95
-%97 = OpIAdd %5 %22 %98
-%99 = OpIAdd %5 %21 %100
-%101 = OpFunctionCall %5 %27 %99 %34
-%102 = OpBitcast %6 %79
-%103 = OpCompositeExtract %5 %102 0
-%104 = OpCompositeExtract %5 %102 1
-%105 = OpCompositeExtract %5 %102 2
-%106 = OpCompositeExtract %5 %102 3
-%107 = OpCompositeConstruct %6 %103 %104 %105 %106
-%108 = OpAccessChain %35 %14 %20 %101
-OpStore %108 %107
+%72 = OpINotEqual %64 %71 %65
+%73 = OpSelect %55 %72 %71 %66
+%74 = OpUDiv %55 %56 %73
+%75 = OpSelect %55 %72 %74 %66
+%76 = OpSDiv %55 %57 %71
+%77 = OpFDiv %59 %60 %82
+%83 = OpUConvert %6 %75
+%84 = OpIAdd %6 %83 %37
+%85 = OpSConvert %6 %76
+%86 = OpIAdd %6 %85 %43
+%87 = OpFConvert %52 %77
+%88 = OpFAdd %52 %87 %53
+%89 = OpFunctionCall %5 %27 %21 %34
+%90 = OpCompositeExtract %5 %84 0
+%91 = OpCompositeExtract %5 %84 1
+%92 = OpCompositeExtract %5 %84 2
+%93 = OpCompositeExtract %5 %84 3
+%94 = OpCompositeConstruct %6 %90 %91 %92 %93
+%95 = OpAccessChain %35 %14 %20 %89
+OpStore %95 %94
+%96 = OpIAdd %5 %22 %97
+%98 = OpIAdd %5 %21 %34
+%99 = OpFunctionCall %5 %27 %98 %34
+%100 = OpCompositeExtract %5 %86 0
+%101 = OpCompositeExtract %5 %86 1
+%102 = OpCompositeExtract %5 %86 2
+%103 = OpCompositeExtract %5 %86 3
+%104 = OpCompositeConstruct %6 %100 %101 %102 %103
+%105 = OpAccessChain %35 %14 %20 %99
+OpStore %105 %104
+%106 = OpIAdd %5 %22 %107
+%108 = OpIAdd %5 %21 %109
+%110 = OpFunctionCall %5 %27 %108 %34
+%111 = OpBitcast %6 %88
+%112 = OpCompositeExtract %5 %111 0
+%113 = OpCompositeExtract %5 %111 1
+%114 = OpCompositeExtract %5 %111 2
+%115 = OpCompositeExtract %5 %111 3
+%116 = OpCompositeConstruct %6 %112 %113 %114 %115
+%117 = OpAccessChain %35 %14 %20 %110
+OpStore %117 %116
 OpReturn
 OpFunctionEnd
 %27 = OpFunction %5 None %24

--- a/reference/shaders/resources/buffer-64bit.ssbo.bindless.ssbo-align.comp
+++ b/reference/shaders/resources/buffer-64bit.ssbo.bindless.ssbo-align.comp
@@ -87,42 +87,45 @@ void main()
     _29[registers._m4]._m0[_169] = _124 * _104;
     _29[registers._m4]._m0[_169 + 1u] = _125 * _105;
     _29[registers._m4]._m0[_169 + 2u] = _126 * _106;
-    uint _181 = (gl_GlobalInvocationID.x * 24u) + 9u;
-    uint _186 = (_181 < _58.y) ? (_181 + _58.x) : 536870908u;
-    _29[registers._m4]._m0[_186] = _104 / _124;
-    _29[registers._m4]._m0[_186 + 1u] = _105 / _125;
-    _29[registers._m4]._m0[_186 + 2u] = _106 / _126;
-    uint64_t _192 = _124 & 63ul;
-    uint64_t _194 = _125 & 63ul;
-    uint64_t _195 = _126 & 63ul;
-    uint _202 = (gl_GlobalInvocationID.x * 24u) + 12u;
-    uint _207 = (_202 < _58.y) ? (_202 + _58.x) : 536870908u;
-    _29[registers._m4]._m0[_207] = _104 << _192;
-    _29[registers._m4]._m0[_207 + 1u] = _105 << _194;
-    _29[registers._m4]._m0[_207 + 2u] = _106 << _195;
-    uint _220 = (gl_GlobalInvocationID.x * 24u) + 15u;
-    uint _225 = (_220 < _58.y) ? (_220 + _58.x) : 536870908u;
-    _29[registers._m4]._m0[_225] = _104 >> _192;
-    _29[registers._m4]._m0[_225 + 1u] = _105 >> _194;
-    _29[registers._m4]._m0[_225 + 2u] = _106 >> _195;
-    uint _237 = (gl_GlobalInvocationID.x * 24u) + 18u;
-    uint _242 = (_237 < _58.y) ? (_237 + _58.x) : 536870908u;
-    _29[registers._m4]._m0[_242] = uint64_t(int64_t(_104) >> int64_t(_192));
-    _29[registers._m4]._m0[_242 + 1u] = uint64_t(int64_t(_105) >> int64_t(_194));
-    _29[registers._m4]._m0[_242 + 2u] = uint64_t(int64_t(_106) >> int64_t(_195));
-    uint _255 = (gl_GlobalInvocationID.x * 24u) + 21u;
-    uint _260 = (_255 < _58.y) ? (_255 + _58.x) : 536870908u;
-    _29[registers._m4]._m0[_260] = _124 & _104;
-    _29[registers._m4]._m0[_260 + 1u] = _125 & _105;
-    _29[registers._m4]._m0[_260 + 2u] = _126 & _106;
-    uint _277 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
-    uint _283 = (_277 < _67.y) ? (_277 + _67.x) : 536870908u;
-    u64vec2 _290 = u64vec2(_24[_63]._m0[_283], _24[_63]._m0[_283 + 1u]);
-    uint _293 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
-    uint _298 = (_293 < _49.y) ? (_293 + _49.x) : 536870908u;
-    _34[_41]._m0[_298] = _290.x;
-    _34[_41]._m0[_298 + 1u] = _290.y;
-    _34[_41]._m0[_298 + 2u] = _106;
+    bool _177 = _124 != 0ul;
+    bool _181 = _125 != 0ul;
+    bool _185 = _126 != 0ul;
+    uint _192 = (gl_GlobalInvocationID.x * 24u) + 9u;
+    uint _197 = (_192 < _58.y) ? (_192 + _58.x) : 536870908u;
+    _29[registers._m4]._m0[_197] = _177 ? (_104 / (_177 ? _124 : 18446744073709551615ul)) : 18446744073709551615ul;
+    _29[registers._m4]._m0[_197 + 1u] = _181 ? (_105 / (_181 ? _125 : 18446744073709551615ul)) : 18446744073709551615ul;
+    _29[registers._m4]._m0[_197 + 2u] = _185 ? (_106 / (_185 ? _126 : 18446744073709551615ul)) : 18446744073709551615ul;
+    uint64_t _203 = _124 & 63ul;
+    uint64_t _205 = _125 & 63ul;
+    uint64_t _206 = _126 & 63ul;
+    uint _213 = (gl_GlobalInvocationID.x * 24u) + 12u;
+    uint _218 = (_213 < _58.y) ? (_213 + _58.x) : 536870908u;
+    _29[registers._m4]._m0[_218] = _104 << _203;
+    _29[registers._m4]._m0[_218 + 1u] = _105 << _205;
+    _29[registers._m4]._m0[_218 + 2u] = _106 << _206;
+    uint _231 = (gl_GlobalInvocationID.x * 24u) + 15u;
+    uint _236 = (_231 < _58.y) ? (_231 + _58.x) : 536870908u;
+    _29[registers._m4]._m0[_236] = _104 >> _203;
+    _29[registers._m4]._m0[_236 + 1u] = _105 >> _205;
+    _29[registers._m4]._m0[_236 + 2u] = _106 >> _206;
+    uint _248 = (gl_GlobalInvocationID.x * 24u) + 18u;
+    uint _253 = (_248 < _58.y) ? (_248 + _58.x) : 536870908u;
+    _29[registers._m4]._m0[_253] = uint64_t(int64_t(_104) >> int64_t(_203));
+    _29[registers._m4]._m0[_253 + 1u] = uint64_t(int64_t(_105) >> int64_t(_205));
+    _29[registers._m4]._m0[_253 + 2u] = uint64_t(int64_t(_106) >> int64_t(_206));
+    uint _266 = (gl_GlobalInvocationID.x * 24u) + 21u;
+    uint _271 = (_266 < _58.y) ? (_266 + _58.x) : 536870908u;
+    _29[registers._m4]._m0[_271] = _124 & _104;
+    _29[registers._m4]._m0[_271 + 1u] = _125 & _105;
+    _29[registers._m4]._m0[_271 + 2u] = _126 & _106;
+    uint _288 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
+    uint _294 = (_288 < _67.y) ? (_288 + _67.x) : 536870908u;
+    u64vec2 _301 = u64vec2(_24[_63]._m0[_294], _24[_63]._m0[_294 + 1u]);
+    uint _304 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
+    uint _309 = (_304 < _49.y) ? (_304 + _49.x) : 536870908u;
+    _34[_41]._m0[_309] = _301.x;
+    _34[_41]._m0[_309 + 1u] = _301.y;
+    _34[_41]._m0[_309 + 2u] = _106;
 }
 
 
@@ -131,7 +134,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 306
+; Bound: 317
 ; Schema: 0
 OpCapability Shader
 OpCapability Int64
@@ -151,9 +154,9 @@ OpName %16 "SSBO"
 OpName %21 "SSBO"
 OpName %26 "SSBO"
 OpName %31 "SSBO"
-OpName %271 "ByteAddressMask"
-OpName %269 "index"
-OpName %270 "stride"
+OpName %282 "ByteAddressMask"
+OpName %280 "index"
+OpName %281 "stride"
 OpDecorate %6 Block
 OpMemberDecorate %6 0 Offset 0
 OpMemberDecorate %6 1 Offset 4
@@ -251,22 +254,24 @@ OpDecorate %78 BuiltIn GlobalInvocationId
 %100 = OpConstant %5 2
 %102 = OpTypeVector %14 3
 %132 = OpConstant %5 24
-%180 = OpConstant %5 9
-%193 = OpConstant %14 63
-%201 = OpConstant %5 12
-%217 = OpConstant %5 5
-%219 = OpConstant %5 15
-%236 = OpConstant %5 18
-%252 = OpConstant %5 7
-%254 = OpConstant %5 21
-%268 = OpTypeFunction %5 %5 %5
-%274 = OpConstant %5 4294967295
-%278 = OpConstant %5 8
-%289 = OpTypeVector %14 2
+%175 = OpConstant %14 0
+%176 = OpConstant %14 18446744073709551615
+%191 = OpConstant %5 9
+%204 = OpConstant %14 63
+%212 = OpConstant %5 12
+%228 = OpConstant %5 5
+%230 = OpConstant %5 15
+%247 = OpConstant %5 18
+%263 = OpConstant %5 7
+%265 = OpConstant %5 21
+%279 = OpTypeFunction %5 %5 %5
+%285 = OpConstant %5 4294967295
+%289 = OpConstant %5 8
+%300 = OpTypeVector %14 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %304
-%304 = OpLabel
+OpBranch %315
+%315 = OpLabel
 %38 = OpAccessChain %37 %8 %39
 %40 = OpLoad %5 %38
 %41 = OpIAdd %5 %40 %42
@@ -394,142 +399,151 @@ OpStore %171 %160
 %174 = OpIAdd %5 %169 %100
 %173 = OpAccessChain %92 %52 %47 %174
 OpStore %173 %161
-%175 = OpUDiv %14 %104 %124
-%176 = OpUDiv %14 %105 %125
-%177 = OpUDiv %14 %106 %126
-%178 = OpBitwiseOr %5 %130 %44
-%179 = OpIMul %5 %81 %132
-%181 = OpIAdd %5 %179 %180
-%182 = OpCompositeExtract %5 %58 0
-%183 = OpCompositeExtract %5 %58 1
-%184 = OpIAdd %5 %181 %182
-%185 = OpULessThan %88 %181 %183
-%186 = OpSelect %5 %185 %184 %91
-%187 = OpAccessChain %92 %52 %47 %186
-OpStore %187 %175
-%189 = OpIAdd %5 %186 %42
-%188 = OpAccessChain %92 %52 %47 %189
-OpStore %188 %176
-%191 = OpIAdd %5 %186 %100
-%190 = OpAccessChain %92 %52 %47 %191
-OpStore %190 %177
-%192 = OpBitwiseAnd %14 %124 %193
-%194 = OpBitwiseAnd %14 %125 %193
-%195 = OpBitwiseAnd %14 %126 %193
-%196 = OpShiftLeftLogical %14 %104 %192
-%197 = OpShiftLeftLogical %14 %105 %194
-%198 = OpShiftLeftLogical %14 %106 %195
-%199 = OpBitwiseOr %5 %130 %39
-%200 = OpIMul %5 %81 %132
-%202 = OpIAdd %5 %200 %201
-%203 = OpCompositeExtract %5 %58 0
-%204 = OpCompositeExtract %5 %58 1
-%205 = OpIAdd %5 %202 %203
-%206 = OpULessThan %88 %202 %204
-%207 = OpSelect %5 %206 %205 %91
-%208 = OpAccessChain %92 %52 %47 %207
-OpStore %208 %196
-%210 = OpIAdd %5 %207 %42
-%209 = OpAccessChain %92 %52 %47 %210
-OpStore %209 %197
-%212 = OpIAdd %5 %207 %100
-%211 = OpAccessChain %92 %52 %47 %212
-OpStore %211 %198
-%213 = OpShiftRightLogical %14 %104 %192
-%214 = OpShiftRightLogical %14 %105 %194
-%215 = OpShiftRightLogical %14 %106 %195
-%216 = OpBitwiseOr %5 %130 %217
-%218 = OpIMul %5 %81 %132
-%220 = OpIAdd %5 %218 %219
-%221 = OpCompositeExtract %5 %58 0
-%222 = OpCompositeExtract %5 %58 1
-%223 = OpIAdd %5 %220 %221
-%224 = OpULessThan %88 %220 %222
-%225 = OpSelect %5 %224 %223 %91
-%226 = OpAccessChain %92 %52 %47 %225
-OpStore %226 %213
-%228 = OpIAdd %5 %225 %42
-%227 = OpAccessChain %92 %52 %47 %228
-OpStore %227 %214
-%230 = OpIAdd %5 %225 %100
-%229 = OpAccessChain %92 %52 %47 %230
-OpStore %229 %215
-%231 = OpShiftRightArithmetic %14 %104 %192
-%232 = OpShiftRightArithmetic %14 %105 %194
-%233 = OpShiftRightArithmetic %14 %106 %195
-%234 = OpBitwiseOr %5 %130 %84
-%235 = OpIMul %5 %81 %132
-%237 = OpIAdd %5 %235 %236
-%238 = OpCompositeExtract %5 %58 0
-%239 = OpCompositeExtract %5 %58 1
-%240 = OpIAdd %5 %237 %238
-%241 = OpULessThan %88 %237 %239
-%242 = OpSelect %5 %241 %240 %91
-%243 = OpAccessChain %92 %52 %47 %242
-OpStore %243 %231
-%245 = OpIAdd %5 %242 %42
-%244 = OpAccessChain %92 %52 %47 %245
-OpStore %244 %232
-%247 = OpIAdd %5 %242 %100
-%246 = OpAccessChain %92 %52 %47 %247
-OpStore %246 %233
-%248 = OpBitwiseAnd %14 %124 %104
-%249 = OpBitwiseAnd %14 %125 %105
-%250 = OpBitwiseAnd %14 %126 %106
-%251 = OpBitwiseOr %5 %130 %252
-%253 = OpIMul %5 %81 %132
-%255 = OpIAdd %5 %253 %254
-%256 = OpCompositeExtract %5 %58 0
-%257 = OpCompositeExtract %5 %58 1
-%258 = OpIAdd %5 %255 %256
-%259 = OpULessThan %88 %255 %257
-%260 = OpSelect %5 %259 %258 %91
-%261 = OpAccessChain %92 %52 %47 %260
-OpStore %261 %248
-%263 = OpIAdd %5 %260 %42
-%262 = OpAccessChain %92 %52 %47 %263
-OpStore %262 %249
-%265 = OpIAdd %5 %260 %100
-%264 = OpAccessChain %92 %52 %47 %265
-OpStore %264 %250
-%266 = OpIMul %5 %81 %132
-%267 = OpIMul %5 %81 %44
-%277 = OpFunctionCall %5 %271 %267 %278
-%279 = OpCompositeExtract %5 %67 0
-%280 = OpCompositeExtract %5 %67 1
-%281 = OpIAdd %5 %277 %279
-%282 = OpULessThan %88 %277 %280
-%283 = OpSelect %5 %282 %281 %91
-%284 = OpAccessChain %92 %60 %47 %283
-%285 = OpLoad %14 %284
-%287 = OpIAdd %5 %283 %42
-%286 = OpAccessChain %92 %60 %47 %287
-%288 = OpLoad %14 %286
-%290 = OpCompositeConstruct %289 %285 %288
-%291 = OpCompositeExtract %14 %290 0
-%292 = OpCompositeExtract %14 %290 1
-%293 = OpFunctionCall %5 %271 %81 %278
-%294 = OpCompositeExtract %5 %49 0
-%295 = OpCompositeExtract %5 %49 1
-%296 = OpIAdd %5 %293 %294
-%297 = OpULessThan %88 %293 %295
-%298 = OpSelect %5 %297 %296 %91
-%299 = OpAccessChain %92 %36 %47 %298
-OpStore %299 %291
-%301 = OpIAdd %5 %298 %42
-%300 = OpAccessChain %92 %36 %47 %301
-OpStore %300 %292
-%303 = OpIAdd %5 %298 %100
-%302 = OpAccessChain %92 %36 %47 %303
-OpStore %302 %106
+%177 = OpINotEqual %88 %124 %175
+%178 = OpSelect %14 %177 %124 %176
+%179 = OpUDiv %14 %104 %178
+%180 = OpSelect %14 %177 %179 %176
+%181 = OpINotEqual %88 %125 %175
+%182 = OpSelect %14 %181 %125 %176
+%183 = OpUDiv %14 %105 %182
+%184 = OpSelect %14 %181 %183 %176
+%185 = OpINotEqual %88 %126 %175
+%186 = OpSelect %14 %185 %126 %176
+%187 = OpUDiv %14 %106 %186
+%188 = OpSelect %14 %185 %187 %176
+%189 = OpBitwiseOr %5 %130 %44
+%190 = OpIMul %5 %81 %132
+%192 = OpIAdd %5 %190 %191
+%193 = OpCompositeExtract %5 %58 0
+%194 = OpCompositeExtract %5 %58 1
+%195 = OpIAdd %5 %192 %193
+%196 = OpULessThan %88 %192 %194
+%197 = OpSelect %5 %196 %195 %91
+%198 = OpAccessChain %92 %52 %47 %197
+OpStore %198 %180
+%200 = OpIAdd %5 %197 %42
+%199 = OpAccessChain %92 %52 %47 %200
+OpStore %199 %184
+%202 = OpIAdd %5 %197 %100
+%201 = OpAccessChain %92 %52 %47 %202
+OpStore %201 %188
+%203 = OpBitwiseAnd %14 %124 %204
+%205 = OpBitwiseAnd %14 %125 %204
+%206 = OpBitwiseAnd %14 %126 %204
+%207 = OpShiftLeftLogical %14 %104 %203
+%208 = OpShiftLeftLogical %14 %105 %205
+%209 = OpShiftLeftLogical %14 %106 %206
+%210 = OpBitwiseOr %5 %130 %39
+%211 = OpIMul %5 %81 %132
+%213 = OpIAdd %5 %211 %212
+%214 = OpCompositeExtract %5 %58 0
+%215 = OpCompositeExtract %5 %58 1
+%216 = OpIAdd %5 %213 %214
+%217 = OpULessThan %88 %213 %215
+%218 = OpSelect %5 %217 %216 %91
+%219 = OpAccessChain %92 %52 %47 %218
+OpStore %219 %207
+%221 = OpIAdd %5 %218 %42
+%220 = OpAccessChain %92 %52 %47 %221
+OpStore %220 %208
+%223 = OpIAdd %5 %218 %100
+%222 = OpAccessChain %92 %52 %47 %223
+OpStore %222 %209
+%224 = OpShiftRightLogical %14 %104 %203
+%225 = OpShiftRightLogical %14 %105 %205
+%226 = OpShiftRightLogical %14 %106 %206
+%227 = OpBitwiseOr %5 %130 %228
+%229 = OpIMul %5 %81 %132
+%231 = OpIAdd %5 %229 %230
+%232 = OpCompositeExtract %5 %58 0
+%233 = OpCompositeExtract %5 %58 1
+%234 = OpIAdd %5 %231 %232
+%235 = OpULessThan %88 %231 %233
+%236 = OpSelect %5 %235 %234 %91
+%237 = OpAccessChain %92 %52 %47 %236
+OpStore %237 %224
+%239 = OpIAdd %5 %236 %42
+%238 = OpAccessChain %92 %52 %47 %239
+OpStore %238 %225
+%241 = OpIAdd %5 %236 %100
+%240 = OpAccessChain %92 %52 %47 %241
+OpStore %240 %226
+%242 = OpShiftRightArithmetic %14 %104 %203
+%243 = OpShiftRightArithmetic %14 %105 %205
+%244 = OpShiftRightArithmetic %14 %106 %206
+%245 = OpBitwiseOr %5 %130 %84
+%246 = OpIMul %5 %81 %132
+%248 = OpIAdd %5 %246 %247
+%249 = OpCompositeExtract %5 %58 0
+%250 = OpCompositeExtract %5 %58 1
+%251 = OpIAdd %5 %248 %249
+%252 = OpULessThan %88 %248 %250
+%253 = OpSelect %5 %252 %251 %91
+%254 = OpAccessChain %92 %52 %47 %253
+OpStore %254 %242
+%256 = OpIAdd %5 %253 %42
+%255 = OpAccessChain %92 %52 %47 %256
+OpStore %255 %243
+%258 = OpIAdd %5 %253 %100
+%257 = OpAccessChain %92 %52 %47 %258
+OpStore %257 %244
+%259 = OpBitwiseAnd %14 %124 %104
+%260 = OpBitwiseAnd %14 %125 %105
+%261 = OpBitwiseAnd %14 %126 %106
+%262 = OpBitwiseOr %5 %130 %263
+%264 = OpIMul %5 %81 %132
+%266 = OpIAdd %5 %264 %265
+%267 = OpCompositeExtract %5 %58 0
+%268 = OpCompositeExtract %5 %58 1
+%269 = OpIAdd %5 %266 %267
+%270 = OpULessThan %88 %266 %268
+%271 = OpSelect %5 %270 %269 %91
+%272 = OpAccessChain %92 %52 %47 %271
+OpStore %272 %259
+%274 = OpIAdd %5 %271 %42
+%273 = OpAccessChain %92 %52 %47 %274
+OpStore %273 %260
+%276 = OpIAdd %5 %271 %100
+%275 = OpAccessChain %92 %52 %47 %276
+OpStore %275 %261
+%277 = OpIMul %5 %81 %132
+%278 = OpIMul %5 %81 %44
+%288 = OpFunctionCall %5 %282 %278 %289
+%290 = OpCompositeExtract %5 %67 0
+%291 = OpCompositeExtract %5 %67 1
+%292 = OpIAdd %5 %288 %290
+%293 = OpULessThan %88 %288 %291
+%294 = OpSelect %5 %293 %292 %91
+%295 = OpAccessChain %92 %60 %47 %294
+%296 = OpLoad %14 %295
+%298 = OpIAdd %5 %294 %42
+%297 = OpAccessChain %92 %60 %47 %298
+%299 = OpLoad %14 %297
+%301 = OpCompositeConstruct %300 %296 %299
+%302 = OpCompositeExtract %14 %301 0
+%303 = OpCompositeExtract %14 %301 1
+%304 = OpFunctionCall %5 %282 %81 %289
+%305 = OpCompositeExtract %5 %49 0
+%306 = OpCompositeExtract %5 %49 1
+%307 = OpIAdd %5 %304 %305
+%308 = OpULessThan %88 %304 %306
+%309 = OpSelect %5 %308 %307 %91
+%310 = OpAccessChain %92 %36 %47 %309
+OpStore %310 %302
+%312 = OpIAdd %5 %309 %42
+%311 = OpAccessChain %92 %36 %47 %312
+OpStore %311 %303
+%314 = OpIAdd %5 %309 %100
+%313 = OpAccessChain %92 %36 %47 %314
+OpStore %313 %106
 OpReturn
 OpFunctionEnd
-%271 = OpFunction %5 None %268
-%269 = OpFunctionParameter %5
-%270 = OpFunctionParameter %5
-%272 = OpLabel
-%273 = OpUDiv %5 %274 %270
-%275 = OpBitwiseAnd %5 %269 %273
-OpReturnValue %275
+%282 = OpFunction %5 None %279
+%280 = OpFunctionParameter %5
+%281 = OpFunctionParameter %5
+%283 = OpLabel
+%284 = OpUDiv %5 %285 %281
+%286 = OpBitwiseAnd %5 %280 %284
+OpReturnValue %286
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/buffer-64bit.ssbo.comp
+++ b/reference/shaders/resources/buffer-64bit.ssbo.comp
@@ -40,20 +40,23 @@ void main()
     _19._m0[gl_GlobalInvocationID.x * 8u] = u64vec3(_11._m0[_43].x + _11._m0[_33].x, _11._m0[_43].y + _11._m0[_33].y, _11._m0[_43].z + _11._m0[_33].z);
     _19._m0[(gl_GlobalInvocationID.x * 8u) + 1u] = u64vec3(_11._m0[_33].x - _11._m0[_43].x, _11._m0[_33].y - _11._m0[_43].y, _11._m0[_33].z - _11._m0[_43].z);
     _19._m0[(gl_GlobalInvocationID.x * 8u) + 2u] = u64vec3(_11._m0[_43].x * _11._m0[_33].x, _11._m0[_43].y * _11._m0[_33].y, _11._m0[_43].z * _11._m0[_33].z);
-    _19._m0[(gl_GlobalInvocationID.x * 8u) + 3u] = u64vec3(_11._m0[_33].x / _11._m0[_43].x, _11._m0[_33].y / _11._m0[_43].y, _11._m0[_33].z / _11._m0[_43].z);
-    uint64_t _82 = _11._m0[_43].x & 63ul;
-    uint64_t _84 = _11._m0[_43].y & 63ul;
-    uint64_t _85 = _11._m0[_43].z & 63ul;
-    _19._m0[(gl_GlobalInvocationID.x * 8u) + 4u] = u64vec3(_11._m0[_33].x << _82, _11._m0[_33].y << _84, _11._m0[_33].z << _85);
-    _19._m0[(gl_GlobalInvocationID.x * 8u) + 5u] = u64vec3(_11._m0[_33].x >> _82, _11._m0[_33].y >> _84, _11._m0[_33].z >> _85);
-    _19._m0[(gl_GlobalInvocationID.x * 8u) + 6u] = u64vec3(uint64_t(int64_t(_11._m0[_33].x) >> int64_t(_82)), uint64_t(int64_t(_11._m0[_33].y) >> int64_t(_84)), uint64_t(int64_t(_11._m0[_33].z) >> int64_t(_85)));
+    bool _77 = _11._m0[_43].x != 0ul;
+    bool _81 = _11._m0[_43].y != 0ul;
+    bool _85 = _11._m0[_43].z != 0ul;
+    _19._m0[(gl_GlobalInvocationID.x * 8u) + 3u] = u64vec3(_77 ? (_11._m0[_33].x / (_77 ? _11._m0[_43].x : 18446744073709551615ul)) : 18446744073709551615ul, _81 ? (_11._m0[_33].y / (_81 ? _11._m0[_43].y : 18446744073709551615ul)) : 18446744073709551615ul, _85 ? (_11._m0[_33].z / (_85 ? _11._m0[_43].z : 18446744073709551615ul)) : 18446744073709551615ul);
+    uint64_t _94 = _11._m0[_43].x & 63ul;
+    uint64_t _96 = _11._m0[_43].y & 63ul;
+    uint64_t _97 = _11._m0[_43].z & 63ul;
+    _19._m0[(gl_GlobalInvocationID.x * 8u) + 4u] = u64vec3(_11._m0[_33].x << _94, _11._m0[_33].y << _96, _11._m0[_33].z << _97);
+    _19._m0[(gl_GlobalInvocationID.x * 8u) + 5u] = u64vec3(_11._m0[_33].x >> _94, _11._m0[_33].y >> _96, _11._m0[_33].z >> _97);
+    _19._m0[(gl_GlobalInvocationID.x * 8u) + 6u] = u64vec3(uint64_t(int64_t(_11._m0[_33].x) >> int64_t(_94)), uint64_t(int64_t(_11._m0[_33].y) >> int64_t(_96)), uint64_t(int64_t(_11._m0[_33].z) >> int64_t(_97)));
     _19._m0[(gl_GlobalInvocationID.x * 8u) + 7u] = u64vec3(_11._m0[_43].x & _11._m0[_33].x, _11._m0[_43].y & _11._m0[_33].y, _11._m0[_43].z & _11._m0[_33].z);
-    uint _134 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
-    u64vec2 _142 = u64vec2(_15._m0[_134], _15._m0[_134 + 1u]);
-    uint _145 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
-    _23._m0[_145] = _142.x;
-    _23._m0[_145 + 1u] = _142.y;
-    _23._m0[_145 + 2u] = _11._m0[_33].z;
+    uint _146 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
+    u64vec2 _154 = u64vec2(_15._m0[_146], _15._m0[_146 + 1u]);
+    uint _157 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
+    _23._m0[_157] = _154.x;
+    _23._m0[_157 + 1u] = _154.y;
+    _23._m0[_157 + 2u] = _11._m0[_33].z;
 }
 
 
@@ -62,7 +65,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 153
+; Bound: 165
 ; Schema: 0
 OpCapability Shader
 OpCapability Int64
@@ -74,9 +77,9 @@ OpName %9 "SSBO"
 OpName %13 "SSBO"
 OpName %17 "SSBO"
 OpName %21 "SSBO"
-OpName %128 "ByteAddressMask"
-OpName %126 "index"
-OpName %127 "stride"
+OpName %140 "ByteAddressMask"
+OpName %138 "index"
+OpName %139 "stride"
 OpDecorate %8 ArrayStride 24
 OpMemberDecorate %9 0 Offset 0
 OpDecorate %9 Block
@@ -135,20 +138,23 @@ OpDecorate %26 BuiltIn GlobalInvocationId
 %35 = OpTypePointer StorageBuffer %7
 %53 = OpConstant %5 3
 %55 = OpConstant %5 8
-%83 = OpConstant %6 63
-%90 = OpConstant %5 4
-%99 = OpConstant %5 5
-%108 = OpConstant %5 6
-%117 = OpConstant %5 7
-%123 = OpConstant %5 24
-%125 = OpTypeFunction %5 %5 %5
-%131 = OpConstant %5 4294967295
-%135 = OpTypePointer StorageBuffer %6
-%141 = OpTypeVector %6 2
+%74 = OpConstant %6 0
+%75 = OpConstant %6 18446744073709551615
+%76 = OpTypeBool
+%95 = OpConstant %6 63
+%102 = OpConstant %5 4
+%111 = OpConstant %5 5
+%120 = OpConstant %5 6
+%129 = OpConstant %5 7
+%135 = OpConstant %5 24
+%137 = OpTypeFunction %5 %5 %5
+%143 = OpConstant %5 4294967295
+%147 = OpTypePointer StorageBuffer %6
+%153 = OpTypeVector %6 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %151
-%151 = OpLabel
+OpBranch %163
+%163 = OpLabel
 %28 = OpAccessChain %27 %26 %29
 %30 = OpLoad %5 %28
 %31 = OpShiftLeftLogical %5 %30 %32
@@ -192,82 +198,91 @@ OpStore %65 %64
 %72 = OpCompositeConstruct %7 %66 %67 %68
 %73 = OpAccessChain %35 %19 %29 %71
 OpStore %73 %72
-%74 = OpUDiv %6 %38 %46
-%75 = OpUDiv %6 %39 %47
-%76 = OpUDiv %6 %40 %48
-%77 = OpBitwiseOr %5 %52 %53
-%78 = OpIMul %5 %30 %55
-%79 = OpIAdd %5 %78 %53
-%80 = OpCompositeConstruct %7 %74 %75 %76
-%81 = OpAccessChain %35 %19 %29 %79
-OpStore %81 %80
-%82 = OpBitwiseAnd %6 %46 %83
-%84 = OpBitwiseAnd %6 %47 %83
-%85 = OpBitwiseAnd %6 %48 %83
-%86 = OpShiftLeftLogical %6 %38 %82
-%87 = OpShiftLeftLogical %6 %39 %84
-%88 = OpShiftLeftLogical %6 %40 %85
-%89 = OpBitwiseOr %5 %52 %90
-%91 = OpIMul %5 %30 %55
-%92 = OpIAdd %5 %91 %90
-%93 = OpCompositeConstruct %7 %86 %87 %88
-%94 = OpAccessChain %35 %19 %29 %92
-OpStore %94 %93
-%95 = OpShiftRightLogical %6 %38 %82
-%96 = OpShiftRightLogical %6 %39 %84
-%97 = OpShiftRightLogical %6 %40 %85
-%98 = OpBitwiseOr %5 %52 %99
-%100 = OpIMul %5 %30 %55
-%101 = OpIAdd %5 %100 %99
-%102 = OpCompositeConstruct %7 %95 %96 %97
-%103 = OpAccessChain %35 %19 %29 %101
-OpStore %103 %102
-%104 = OpShiftRightArithmetic %6 %38 %82
-%105 = OpShiftRightArithmetic %6 %39 %84
-%106 = OpShiftRightArithmetic %6 %40 %85
-%107 = OpBitwiseOr %5 %52 %108
-%109 = OpIMul %5 %30 %55
-%110 = OpIAdd %5 %109 %108
-%111 = OpCompositeConstruct %7 %104 %105 %106
-%112 = OpAccessChain %35 %19 %29 %110
-OpStore %112 %111
-%113 = OpBitwiseAnd %6 %46 %38
-%114 = OpBitwiseAnd %6 %47 %39
-%115 = OpBitwiseAnd %6 %48 %40
-%116 = OpBitwiseOr %5 %52 %117
-%118 = OpIMul %5 %30 %55
-%119 = OpIAdd %5 %118 %117
-%120 = OpCompositeConstruct %7 %113 %114 %115
-%121 = OpAccessChain %35 %19 %29 %119
-OpStore %121 %120
-%122 = OpIMul %5 %30 %123
-%124 = OpIMul %5 %30 %53
-%134 = OpFunctionCall %5 %128 %124 %55
-%136 = OpAccessChain %135 %15 %29 %134
-%137 = OpLoad %6 %136
-%139 = OpIAdd %5 %134 %32
-%138 = OpAccessChain %135 %15 %29 %139
-%140 = OpLoad %6 %138
-%142 = OpCompositeConstruct %141 %137 %140
-%143 = OpCompositeExtract %6 %142 0
-%144 = OpCompositeExtract %6 %142 1
-%145 = OpFunctionCall %5 %128 %30 %55
-%146 = OpAccessChain %135 %23 %29 %145
-OpStore %146 %143
-%148 = OpIAdd %5 %145 %32
-%147 = OpAccessChain %135 %23 %29 %148
-OpStore %147 %144
-%150 = OpIAdd %5 %145 %34
-%149 = OpAccessChain %135 %23 %29 %150
-OpStore %149 %40
+%77 = OpINotEqual %76 %46 %74
+%78 = OpSelect %6 %77 %46 %75
+%79 = OpUDiv %6 %38 %78
+%80 = OpSelect %6 %77 %79 %75
+%81 = OpINotEqual %76 %47 %74
+%82 = OpSelect %6 %81 %47 %75
+%83 = OpUDiv %6 %39 %82
+%84 = OpSelect %6 %81 %83 %75
+%85 = OpINotEqual %76 %48 %74
+%86 = OpSelect %6 %85 %48 %75
+%87 = OpUDiv %6 %40 %86
+%88 = OpSelect %6 %85 %87 %75
+%89 = OpBitwiseOr %5 %52 %53
+%90 = OpIMul %5 %30 %55
+%91 = OpIAdd %5 %90 %53
+%92 = OpCompositeConstruct %7 %80 %84 %88
+%93 = OpAccessChain %35 %19 %29 %91
+OpStore %93 %92
+%94 = OpBitwiseAnd %6 %46 %95
+%96 = OpBitwiseAnd %6 %47 %95
+%97 = OpBitwiseAnd %6 %48 %95
+%98 = OpShiftLeftLogical %6 %38 %94
+%99 = OpShiftLeftLogical %6 %39 %96
+%100 = OpShiftLeftLogical %6 %40 %97
+%101 = OpBitwiseOr %5 %52 %102
+%103 = OpIMul %5 %30 %55
+%104 = OpIAdd %5 %103 %102
+%105 = OpCompositeConstruct %7 %98 %99 %100
+%106 = OpAccessChain %35 %19 %29 %104
+OpStore %106 %105
+%107 = OpShiftRightLogical %6 %38 %94
+%108 = OpShiftRightLogical %6 %39 %96
+%109 = OpShiftRightLogical %6 %40 %97
+%110 = OpBitwiseOr %5 %52 %111
+%112 = OpIMul %5 %30 %55
+%113 = OpIAdd %5 %112 %111
+%114 = OpCompositeConstruct %7 %107 %108 %109
+%115 = OpAccessChain %35 %19 %29 %113
+OpStore %115 %114
+%116 = OpShiftRightArithmetic %6 %38 %94
+%117 = OpShiftRightArithmetic %6 %39 %96
+%118 = OpShiftRightArithmetic %6 %40 %97
+%119 = OpBitwiseOr %5 %52 %120
+%121 = OpIMul %5 %30 %55
+%122 = OpIAdd %5 %121 %120
+%123 = OpCompositeConstruct %7 %116 %117 %118
+%124 = OpAccessChain %35 %19 %29 %122
+OpStore %124 %123
+%125 = OpBitwiseAnd %6 %46 %38
+%126 = OpBitwiseAnd %6 %47 %39
+%127 = OpBitwiseAnd %6 %48 %40
+%128 = OpBitwiseOr %5 %52 %129
+%130 = OpIMul %5 %30 %55
+%131 = OpIAdd %5 %130 %129
+%132 = OpCompositeConstruct %7 %125 %126 %127
+%133 = OpAccessChain %35 %19 %29 %131
+OpStore %133 %132
+%134 = OpIMul %5 %30 %135
+%136 = OpIMul %5 %30 %53
+%146 = OpFunctionCall %5 %140 %136 %55
+%148 = OpAccessChain %147 %15 %29 %146
+%149 = OpLoad %6 %148
+%151 = OpIAdd %5 %146 %32
+%150 = OpAccessChain %147 %15 %29 %151
+%152 = OpLoad %6 %150
+%154 = OpCompositeConstruct %153 %149 %152
+%155 = OpCompositeExtract %6 %154 0
+%156 = OpCompositeExtract %6 %154 1
+%157 = OpFunctionCall %5 %140 %30 %55
+%158 = OpAccessChain %147 %23 %29 %157
+OpStore %158 %155
+%160 = OpIAdd %5 %157 %32
+%159 = OpAccessChain %147 %23 %29 %160
+OpStore %159 %156
+%162 = OpIAdd %5 %157 %34
+%161 = OpAccessChain %147 %23 %29 %162
+OpStore %161 %40
 OpReturn
 OpFunctionEnd
-%128 = OpFunction %5 None %125
-%126 = OpFunctionParameter %5
-%127 = OpFunctionParameter %5
-%129 = OpLabel
-%130 = OpUDiv %5 %131 %127
-%132 = OpBitwiseAnd %5 %126 %130
-OpReturnValue %132
+%140 = OpFunction %5 None %137
+%138 = OpFunctionParameter %5
+%139 = OpFunctionParameter %5
+%141 = OpLabel
+%142 = OpUDiv %5 %143 %139
+%144 = OpBitwiseAnd %5 %138 %142
+OpReturnValue %144
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/sm66/buffer-64bit.ssbo.sm66.comp
+++ b/reference/shaders/resources/sm66/buffer-64bit.ssbo.sm66.comp
@@ -41,20 +41,23 @@ void main()
     _11[0u]._m0[gl_GlobalInvocationID.x * 8u] = u64vec3(_16[1u]._m0[_56].x + _16[1u]._m0[_47].x, _16[1u]._m0[_56].y + _16[1u]._m0[_47].y, _16[1u]._m0[_56].z + _16[1u]._m0[_47].z);
     _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 1u] = u64vec3(_16[1u]._m0[_47].x - _16[1u]._m0[_56].x, _16[1u]._m0[_47].y - _16[1u]._m0[_56].y, _16[1u]._m0[_47].z - _16[1u]._m0[_56].z);
     _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 2u] = u64vec3(_16[1u]._m0[_56].x * _16[1u]._m0[_47].x, _16[1u]._m0[_56].y * _16[1u]._m0[_47].y, _16[1u]._m0[_56].z * _16[1u]._m0[_47].z);
-    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 3u] = u64vec3(_16[1u]._m0[_47].x / _16[1u]._m0[_56].x, _16[1u]._m0[_47].y / _16[1u]._m0[_56].y, _16[1u]._m0[_47].z / _16[1u]._m0[_56].z);
-    uint64_t _94 = _16[1u]._m0[_56].x & 63ul;
-    uint64_t _96 = _16[1u]._m0[_56].y & 63ul;
-    uint64_t _97 = _16[1u]._m0[_56].z & 63ul;
-    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 4u] = u64vec3(_16[1u]._m0[_47].x << _94, _16[1u]._m0[_47].y << _96, _16[1u]._m0[_47].z << _97);
-    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 5u] = u64vec3(_16[1u]._m0[_47].x >> _94, _16[1u]._m0[_47].y >> _96, _16[1u]._m0[_47].z >> _97);
-    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 6u] = u64vec3(uint64_t(int64_t(_16[1u]._m0[_47].x) >> int64_t(_94)), uint64_t(int64_t(_16[1u]._m0[_47].y) >> int64_t(_96)), uint64_t(int64_t(_16[1u]._m0[_47].z) >> int64_t(_97)));
+    bool _89 = _16[1u]._m0[_56].x != 0ul;
+    bool _93 = _16[1u]._m0[_56].y != 0ul;
+    bool _97 = _16[1u]._m0[_56].z != 0ul;
+    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 3u] = u64vec3(_89 ? (_16[1u]._m0[_47].x / (_89 ? _16[1u]._m0[_56].x : 18446744073709551615ul)) : 18446744073709551615ul, _93 ? (_16[1u]._m0[_47].y / (_93 ? _16[1u]._m0[_56].y : 18446744073709551615ul)) : 18446744073709551615ul, _97 ? (_16[1u]._m0[_47].z / (_97 ? _16[1u]._m0[_56].z : 18446744073709551615ul)) : 18446744073709551615ul);
+    uint64_t _106 = _16[1u]._m0[_56].x & 63ul;
+    uint64_t _108 = _16[1u]._m0[_56].y & 63ul;
+    uint64_t _109 = _16[1u]._m0[_56].z & 63ul;
+    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 4u] = u64vec3(_16[1u]._m0[_47].x << _106, _16[1u]._m0[_47].y << _108, _16[1u]._m0[_47].z << _109);
+    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 5u] = u64vec3(_16[1u]._m0[_47].x >> _106, _16[1u]._m0[_47].y >> _108, _16[1u]._m0[_47].z >> _109);
+    _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 6u] = u64vec3(uint64_t(int64_t(_16[1u]._m0[_47].x) >> int64_t(_106)), uint64_t(int64_t(_16[1u]._m0[_47].y) >> int64_t(_108)), uint64_t(int64_t(_16[1u]._m0[_47].z) >> int64_t(_109)));
     _11[0u]._m0[(gl_GlobalInvocationID.x * 8u) + 7u] = u64vec3(_16[1u]._m0[_56].x & _16[1u]._m0[_47].x, _16[1u]._m0[_56].y & _16[1u]._m0[_47].y, _16[1u]._m0[_56].z & _16[1u]._m0[_47].z);
-    uint _146 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
-    u64vec2 _154 = u64vec2(_26[3u]._m0[_146], _26[3u]._m0[_146 + 1u]);
-    uint _157 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
-    _21[2u]._m0[_157] = _154.x;
-    _21[2u]._m0[_157 + 1u] = _154.y;
-    _21[2u]._m0[_157 + 2u] = _16[1u]._m0[_47].z;
+    uint _158 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
+    u64vec2 _166 = u64vec2(_26[3u]._m0[_158], _26[3u]._m0[_158 + 1u]);
+    uint _169 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
+    _21[2u]._m0[_169] = _166.x;
+    _21[2u]._m0[_169 + 1u] = _166.y;
+    _21[2u]._m0[_169 + 2u] = _16[1u]._m0[_47].z;
 }
 
 
@@ -63,7 +66,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 165
+; Bound: 177
 ; Schema: 0
 OpCapability Shader
 OpCapability Int64
@@ -77,9 +80,9 @@ OpName %8 "SSBO"
 OpName %13 "SSBO"
 OpName %18 "SSBO"
 OpName %23 "SSBO"
-OpName %140 "ByteAddressMask"
-OpName %138 "index"
-OpName %139 "stride"
+OpName %152 "ByteAddressMask"
+OpName %150 "index"
+OpName %151 "stride"
 OpDecorate %7 ArrayStride 24
 OpMemberDecorate %8 0 Offset 0
 OpDecorate %8 Block
@@ -144,20 +147,23 @@ OpDecorate %30 BuiltIn GlobalInvocationId
 %45 = OpConstant %27 3
 %48 = OpTypePointer StorageBuffer %6
 %67 = OpConstant %27 8
-%95 = OpConstant %5 63
-%102 = OpConstant %27 4
-%111 = OpConstant %27 5
-%120 = OpConstant %27 6
-%129 = OpConstant %27 7
-%135 = OpConstant %27 24
-%137 = OpTypeFunction %27 %27 %27
-%143 = OpConstant %27 4294967295
-%147 = OpTypePointer StorageBuffer %5
-%153 = OpTypeVector %5 2
+%86 = OpConstant %5 0
+%87 = OpConstant %5 18446744073709551615
+%88 = OpTypeBool
+%107 = OpConstant %5 63
+%114 = OpConstant %27 4
+%123 = OpConstant %27 5
+%132 = OpConstant %27 6
+%141 = OpConstant %27 7
+%147 = OpConstant %27 24
+%149 = OpTypeFunction %27 %27 %27
+%155 = OpConstant %27 4294967295
+%159 = OpTypePointer StorageBuffer %5
+%165 = OpTypeVector %5 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %163
-%163 = OpLabel
+OpBranch %175
+%175 = OpLabel
 %32 = OpAccessChain %31 %30 %33
 %34 = OpLoad %27 %32
 %36 = OpAccessChain %35 %11 %33
@@ -205,82 +211,91 @@ OpStore %77 %76
 %84 = OpCompositeConstruct %6 %78 %79 %80
 %85 = OpAccessChain %48 %36 %33 %83
 OpStore %85 %84
-%86 = OpUDiv %5 %51 %59
-%87 = OpUDiv %5 %52 %60
-%88 = OpUDiv %5 %53 %61
-%89 = OpBitwiseOr %27 %65 %45
-%90 = OpIMul %27 %34 %67
-%91 = OpIAdd %27 %90 %45
-%92 = OpCompositeConstruct %6 %86 %87 %88
-%93 = OpAccessChain %48 %36 %33 %91
-OpStore %93 %92
-%94 = OpBitwiseAnd %5 %59 %95
-%96 = OpBitwiseAnd %5 %60 %95
-%97 = OpBitwiseAnd %5 %61 %95
-%98 = OpShiftLeftLogical %5 %51 %94
-%99 = OpShiftLeftLogical %5 %52 %96
-%100 = OpShiftLeftLogical %5 %53 %97
-%101 = OpBitwiseOr %27 %65 %102
-%103 = OpIMul %27 %34 %67
-%104 = OpIAdd %27 %103 %102
-%105 = OpCompositeConstruct %6 %98 %99 %100
-%106 = OpAccessChain %48 %36 %33 %104
-OpStore %106 %105
-%107 = OpShiftRightLogical %5 %51 %94
-%108 = OpShiftRightLogical %5 %52 %96
-%109 = OpShiftRightLogical %5 %53 %97
-%110 = OpBitwiseOr %27 %65 %111
-%112 = OpIMul %27 %34 %67
-%113 = OpIAdd %27 %112 %111
-%114 = OpCompositeConstruct %6 %107 %108 %109
-%115 = OpAccessChain %48 %36 %33 %113
-OpStore %115 %114
-%116 = OpShiftRightArithmetic %5 %51 %94
-%117 = OpShiftRightArithmetic %5 %52 %96
-%118 = OpShiftRightArithmetic %5 %53 %97
-%119 = OpBitwiseOr %27 %65 %120
-%121 = OpIMul %27 %34 %67
-%122 = OpIAdd %27 %121 %120
-%123 = OpCompositeConstruct %6 %116 %117 %118
-%124 = OpAccessChain %48 %36 %33 %122
-OpStore %124 %123
-%125 = OpBitwiseAnd %5 %59 %51
-%126 = OpBitwiseAnd %5 %60 %52
-%127 = OpBitwiseAnd %5 %61 %53
-%128 = OpBitwiseOr %27 %65 %129
-%130 = OpIMul %27 %34 %67
-%131 = OpIAdd %27 %130 %129
-%132 = OpCompositeConstruct %6 %125 %126 %127
-%133 = OpAccessChain %48 %36 %33 %131
-OpStore %133 %132
-%134 = OpIMul %27 %34 %135
-%136 = OpIMul %27 %34 %45
-%146 = OpFunctionCall %27 %140 %136 %67
-%148 = OpAccessChain %147 %44 %33 %146
-%149 = OpLoad %5 %148
-%151 = OpIAdd %27 %146 %39
-%150 = OpAccessChain %147 %44 %33 %151
-%152 = OpLoad %5 %150
-%154 = OpCompositeConstruct %153 %149 %152
-%155 = OpCompositeExtract %5 %154 0
-%156 = OpCompositeExtract %5 %154 1
-%157 = OpFunctionCall %27 %140 %34 %67
-%158 = OpAccessChain %147 %41 %33 %157
-OpStore %158 %155
-%160 = OpIAdd %27 %157 %39
-%159 = OpAccessChain %147 %41 %33 %160
-OpStore %159 %156
-%162 = OpIAdd %27 %157 %42
-%161 = OpAccessChain %147 %41 %33 %162
-OpStore %161 %53
+%89 = OpINotEqual %88 %59 %86
+%90 = OpSelect %5 %89 %59 %87
+%91 = OpUDiv %5 %51 %90
+%92 = OpSelect %5 %89 %91 %87
+%93 = OpINotEqual %88 %60 %86
+%94 = OpSelect %5 %93 %60 %87
+%95 = OpUDiv %5 %52 %94
+%96 = OpSelect %5 %93 %95 %87
+%97 = OpINotEqual %88 %61 %86
+%98 = OpSelect %5 %97 %61 %87
+%99 = OpUDiv %5 %53 %98
+%100 = OpSelect %5 %97 %99 %87
+%101 = OpBitwiseOr %27 %65 %45
+%102 = OpIMul %27 %34 %67
+%103 = OpIAdd %27 %102 %45
+%104 = OpCompositeConstruct %6 %92 %96 %100
+%105 = OpAccessChain %48 %36 %33 %103
+OpStore %105 %104
+%106 = OpBitwiseAnd %5 %59 %107
+%108 = OpBitwiseAnd %5 %60 %107
+%109 = OpBitwiseAnd %5 %61 %107
+%110 = OpShiftLeftLogical %5 %51 %106
+%111 = OpShiftLeftLogical %5 %52 %108
+%112 = OpShiftLeftLogical %5 %53 %109
+%113 = OpBitwiseOr %27 %65 %114
+%115 = OpIMul %27 %34 %67
+%116 = OpIAdd %27 %115 %114
+%117 = OpCompositeConstruct %6 %110 %111 %112
+%118 = OpAccessChain %48 %36 %33 %116
+OpStore %118 %117
+%119 = OpShiftRightLogical %5 %51 %106
+%120 = OpShiftRightLogical %5 %52 %108
+%121 = OpShiftRightLogical %5 %53 %109
+%122 = OpBitwiseOr %27 %65 %123
+%124 = OpIMul %27 %34 %67
+%125 = OpIAdd %27 %124 %123
+%126 = OpCompositeConstruct %6 %119 %120 %121
+%127 = OpAccessChain %48 %36 %33 %125
+OpStore %127 %126
+%128 = OpShiftRightArithmetic %5 %51 %106
+%129 = OpShiftRightArithmetic %5 %52 %108
+%130 = OpShiftRightArithmetic %5 %53 %109
+%131 = OpBitwiseOr %27 %65 %132
+%133 = OpIMul %27 %34 %67
+%134 = OpIAdd %27 %133 %132
+%135 = OpCompositeConstruct %6 %128 %129 %130
+%136 = OpAccessChain %48 %36 %33 %134
+OpStore %136 %135
+%137 = OpBitwiseAnd %5 %59 %51
+%138 = OpBitwiseAnd %5 %60 %52
+%139 = OpBitwiseAnd %5 %61 %53
+%140 = OpBitwiseOr %27 %65 %141
+%142 = OpIMul %27 %34 %67
+%143 = OpIAdd %27 %142 %141
+%144 = OpCompositeConstruct %6 %137 %138 %139
+%145 = OpAccessChain %48 %36 %33 %143
+OpStore %145 %144
+%146 = OpIMul %27 %34 %147
+%148 = OpIMul %27 %34 %45
+%158 = OpFunctionCall %27 %152 %148 %67
+%160 = OpAccessChain %159 %44 %33 %158
+%161 = OpLoad %5 %160
+%163 = OpIAdd %27 %158 %39
+%162 = OpAccessChain %159 %44 %33 %163
+%164 = OpLoad %5 %162
+%166 = OpCompositeConstruct %165 %161 %164
+%167 = OpCompositeExtract %5 %166 0
+%168 = OpCompositeExtract %5 %166 1
+%169 = OpFunctionCall %27 %152 %34 %67
+%170 = OpAccessChain %159 %41 %33 %169
+OpStore %170 %167
+%172 = OpIAdd %27 %169 %39
+%171 = OpAccessChain %159 %41 %33 %172
+OpStore %171 %168
+%174 = OpIAdd %27 %169 %42
+%173 = OpAccessChain %159 %41 %33 %174
+OpStore %173 %53
 OpReturn
 OpFunctionEnd
-%140 = OpFunction %27 None %137
-%138 = OpFunctionParameter %27
-%139 = OpFunctionParameter %27
-%141 = OpLabel
-%142 = OpUDiv %27 %143 %139
-%144 = OpBitwiseAnd %27 %138 %142
-OpReturnValue %144
+%152 = OpFunction %27 None %149
+%150 = OpFunctionParameter %27
+%151 = OpFunctionParameter %27
+%153 = OpLabel
+%154 = OpUDiv %27 %155 %151
+%156 = OpBitwiseAnd %27 %150 %154
+OpReturnValue %156
 OpFunctionEnd
 #endif

--- a/reference/shaders/resources/sm66/buffer-64bit.ssbo.ssbo-align.sm66.comp
+++ b/reference/shaders/resources/sm66/buffer-64bit.ssbo.ssbo-align.sm66.comp
@@ -72,42 +72,45 @@ void main()
     _16[0u]._m0[_154] = _109 * _89;
     _16[0u]._m0[_154 + 1u] = _110 * _90;
     _16[0u]._m0[_154 + 2u] = _111 * _91;
-    uint _166 = (gl_GlobalInvocationID.x * 24u) + 9u;
-    uint _171 = (_166 < _46.y) ? (_166 + _46.x) : 536870908u;
-    _16[0u]._m0[_171] = _89 / _109;
-    _16[0u]._m0[_171 + 1u] = _90 / _110;
-    _16[0u]._m0[_171 + 2u] = _91 / _111;
-    uint64_t _177 = _109 & 63ul;
-    uint64_t _179 = _110 & 63ul;
-    uint64_t _180 = _111 & 63ul;
-    uint _188 = (gl_GlobalInvocationID.x * 24u) + 12u;
-    uint _193 = (_188 < _46.y) ? (_188 + _46.x) : 536870908u;
-    _16[0u]._m0[_193] = _89 << _177;
-    _16[0u]._m0[_193 + 1u] = _90 << _179;
-    _16[0u]._m0[_193 + 2u] = _91 << _180;
-    uint _206 = (gl_GlobalInvocationID.x * 24u) + 15u;
-    uint _211 = (_206 < _46.y) ? (_206 + _46.x) : 536870908u;
-    _16[0u]._m0[_211] = _89 >> _177;
-    _16[0u]._m0[_211 + 1u] = _90 >> _179;
-    _16[0u]._m0[_211 + 2u] = _91 >> _180;
-    uint _223 = (gl_GlobalInvocationID.x * 24u) + 18u;
-    uint _228 = (_223 < _46.y) ? (_223 + _46.x) : 536870908u;
-    _16[0u]._m0[_228] = uint64_t(int64_t(_89) >> int64_t(_177));
-    _16[0u]._m0[_228 + 1u] = uint64_t(int64_t(_90) >> int64_t(_179));
-    _16[0u]._m0[_228 + 2u] = uint64_t(int64_t(_91) >> int64_t(_180));
-    uint _241 = (gl_GlobalInvocationID.x * 24u) + 21u;
-    uint _246 = (_241 < _46.y) ? (_241 + _46.x) : 536870908u;
-    _16[0u]._m0[_246] = _109 & _89;
-    _16[0u]._m0[_246 + 1u] = _110 & _90;
-    _16[0u]._m0[_246 + 2u] = _111 & _91;
-    uint _263 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
-    uint _269 = (_263 < _67.y) ? (_263 + _67.x) : 536870908u;
-    u64vec2 _276 = u64vec2(_31[3u]._m0[_269], _31[3u]._m0[_269 + 1u]);
-    uint _279 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
-    uint _284 = (_279 < _61.y) ? (_279 + _61.x) : 536870908u;
-    _26[2u]._m0[_284] = _276.x;
-    _26[2u]._m0[_284 + 1u] = _276.y;
-    _26[2u]._m0[_284 + 2u] = _91;
+    bool _162 = _109 != 0ul;
+    bool _166 = _110 != 0ul;
+    bool _170 = _111 != 0ul;
+    uint _177 = (gl_GlobalInvocationID.x * 24u) + 9u;
+    uint _182 = (_177 < _46.y) ? (_177 + _46.x) : 536870908u;
+    _16[0u]._m0[_182] = _162 ? (_89 / (_162 ? _109 : 18446744073709551615ul)) : 18446744073709551615ul;
+    _16[0u]._m0[_182 + 1u] = _166 ? (_90 / (_166 ? _110 : 18446744073709551615ul)) : 18446744073709551615ul;
+    _16[0u]._m0[_182 + 2u] = _170 ? (_91 / (_170 ? _111 : 18446744073709551615ul)) : 18446744073709551615ul;
+    uint64_t _188 = _109 & 63ul;
+    uint64_t _190 = _110 & 63ul;
+    uint64_t _191 = _111 & 63ul;
+    uint _199 = (gl_GlobalInvocationID.x * 24u) + 12u;
+    uint _204 = (_199 < _46.y) ? (_199 + _46.x) : 536870908u;
+    _16[0u]._m0[_204] = _89 << _188;
+    _16[0u]._m0[_204 + 1u] = _90 << _190;
+    _16[0u]._m0[_204 + 2u] = _91 << _191;
+    uint _217 = (gl_GlobalInvocationID.x * 24u) + 15u;
+    uint _222 = (_217 < _46.y) ? (_217 + _46.x) : 536870908u;
+    _16[0u]._m0[_222] = _89 >> _188;
+    _16[0u]._m0[_222 + 1u] = _90 >> _190;
+    _16[0u]._m0[_222 + 2u] = _91 >> _191;
+    uint _234 = (gl_GlobalInvocationID.x * 24u) + 18u;
+    uint _239 = (_234 < _46.y) ? (_234 + _46.x) : 536870908u;
+    _16[0u]._m0[_239] = uint64_t(int64_t(_89) >> int64_t(_188));
+    _16[0u]._m0[_239 + 1u] = uint64_t(int64_t(_90) >> int64_t(_190));
+    _16[0u]._m0[_239 + 2u] = uint64_t(int64_t(_91) >> int64_t(_191));
+    uint _252 = (gl_GlobalInvocationID.x * 24u) + 21u;
+    uint _257 = (_252 < _46.y) ? (_252 + _46.x) : 536870908u;
+    _16[0u]._m0[_257] = _109 & _89;
+    _16[0u]._m0[_257 + 1u] = _110 & _90;
+    _16[0u]._m0[_257 + 2u] = _111 & _91;
+    uint _274 = ByteAddressMask(gl_GlobalInvocationID.x * 3u, 8u);
+    uint _280 = (_274 < _67.y) ? (_274 + _67.x) : 536870908u;
+    u64vec2 _287 = u64vec2(_31[3u]._m0[_280], _31[3u]._m0[_280 + 1u]);
+    uint _290 = ByteAddressMask(gl_GlobalInvocationID.x, 8u);
+    uint _295 = (_290 < _61.y) ? (_290 + _61.x) : 536870908u;
+    _26[2u]._m0[_295] = _287.x;
+    _26[2u]._m0[_295 + 1u] = _287.y;
+    _26[2u]._m0[_295 + 2u] = _91;
 }
 
 
@@ -116,7 +119,7 @@ void main()
 ; SPIR-V
 ; Version: 1.3
 ; Generator: Unknown(30017); 21022
-; Bound: 292
+; Bound: 303
 ; Schema: 0
 OpCapability Shader
 OpCapability Int64
@@ -132,9 +135,9 @@ OpName %13 "SSBO"
 OpName %18 "SSBO"
 OpName %23 "SSBO"
 OpName %28 "SSBO"
-OpName %257 "ByteAddressMask"
-OpName %255 "index"
-OpName %256 "stride"
+OpName %268 "ByteAddressMask"
+OpName %266 "index"
+OpName %267 "stride"
 OpDecorate %7 ArrayStride 8
 OpMemberDecorate %8 0 Offset 0
 OpDecorate %8 Block
@@ -216,23 +219,25 @@ OpDecorate %34 BuiltIn GlobalInvocationId
 %78 = OpTypePointer StorageBuffer %11
 %87 = OpTypeVector %11 3
 %117 = OpConstant %5 24
-%165 = OpConstant %5 9
-%178 = OpConstant %11 63
-%185 = OpConstant %5 4
-%187 = OpConstant %5 12
-%203 = OpConstant %5 5
-%205 = OpConstant %5 15
-%222 = OpConstant %5 18
-%238 = OpConstant %5 7
-%240 = OpConstant %5 21
-%254 = OpTypeFunction %5 %5 %5
-%260 = OpConstant %5 4294967295
-%264 = OpConstant %5 8
-%275 = OpTypeVector %11 2
+%160 = OpConstant %11 0
+%161 = OpConstant %11 18446744073709551615
+%176 = OpConstant %5 9
+%189 = OpConstant %11 63
+%196 = OpConstant %5 4
+%198 = OpConstant %5 12
+%214 = OpConstant %5 5
+%216 = OpConstant %5 15
+%233 = OpConstant %5 18
+%249 = OpConstant %5 7
+%251 = OpConstant %5 21
+%265 = OpTypeFunction %5 %5 %5
+%271 = OpConstant %5 4294967295
+%275 = OpConstant %5 8
+%286 = OpTypeVector %11 2
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-OpBranch %290
-%290 = OpLabel
+OpBranch %301
+%301 = OpLabel
 %36 = OpAccessChain %35 %34 %37
 %38 = OpLoad %5 %36
 %40 = OpAccessChain %39 %16 %37
@@ -350,142 +355,151 @@ OpStore %156 %145
 %159 = OpIAdd %5 %154 %57
 %158 = OpAccessChain %78 %40 %37 %159
 OpStore %158 %146
-%160 = OpUDiv %11 %89 %109
-%161 = OpUDiv %11 %90 %110
-%162 = OpUDiv %11 %91 %111
-%163 = OpBitwiseOr %5 %115 %42
-%164 = OpIMul %5 %38 %117
-%166 = OpIAdd %5 %164 %165
-%167 = OpCompositeExtract %5 %46 0
-%168 = OpCompositeExtract %5 %46 1
-%169 = OpIAdd %5 %166 %167
-%170 = OpULessThan %74 %166 %168
-%171 = OpSelect %5 %170 %169 %77
-%172 = OpAccessChain %78 %40 %37 %171
-OpStore %172 %160
-%174 = OpIAdd %5 %171 %50
-%173 = OpAccessChain %78 %40 %37 %174
-OpStore %173 %161
-%176 = OpIAdd %5 %171 %57
-%175 = OpAccessChain %78 %40 %37 %176
-OpStore %175 %162
-%177 = OpBitwiseAnd %11 %109 %178
-%179 = OpBitwiseAnd %11 %110 %178
-%180 = OpBitwiseAnd %11 %111 %178
-%181 = OpShiftLeftLogical %11 %89 %177
-%182 = OpShiftLeftLogical %11 %90 %179
-%183 = OpShiftLeftLogical %11 %91 %180
-%184 = OpBitwiseOr %5 %115 %185
-%186 = OpIMul %5 %38 %117
-%188 = OpIAdd %5 %186 %187
-%189 = OpCompositeExtract %5 %46 0
-%190 = OpCompositeExtract %5 %46 1
-%191 = OpIAdd %5 %188 %189
-%192 = OpULessThan %74 %188 %190
-%193 = OpSelect %5 %192 %191 %77
-%194 = OpAccessChain %78 %40 %37 %193
-OpStore %194 %181
-%196 = OpIAdd %5 %193 %50
-%195 = OpAccessChain %78 %40 %37 %196
-OpStore %195 %182
-%198 = OpIAdd %5 %193 %57
-%197 = OpAccessChain %78 %40 %37 %198
-OpStore %197 %183
-%199 = OpShiftRightLogical %11 %89 %177
-%200 = OpShiftRightLogical %11 %90 %179
-%201 = OpShiftRightLogical %11 %91 %180
-%202 = OpBitwiseOr %5 %115 %203
-%204 = OpIMul %5 %38 %117
-%206 = OpIAdd %5 %204 %205
-%207 = OpCompositeExtract %5 %46 0
-%208 = OpCompositeExtract %5 %46 1
-%209 = OpIAdd %5 %206 %207
-%210 = OpULessThan %74 %206 %208
-%211 = OpSelect %5 %210 %209 %77
-%212 = OpAccessChain %78 %40 %37 %211
-OpStore %212 %199
-%214 = OpIAdd %5 %211 %50
-%213 = OpAccessChain %78 %40 %37 %214
-OpStore %213 %200
-%216 = OpIAdd %5 %211 %57
-%215 = OpAccessChain %78 %40 %37 %216
-OpStore %215 %201
-%217 = OpShiftRightArithmetic %11 %89 %177
-%218 = OpShiftRightArithmetic %11 %90 %179
-%219 = OpShiftRightArithmetic %11 %91 %180
-%220 = OpBitwiseOr %5 %115 %70
-%221 = OpIMul %5 %38 %117
-%223 = OpIAdd %5 %221 %222
-%224 = OpCompositeExtract %5 %46 0
-%225 = OpCompositeExtract %5 %46 1
-%226 = OpIAdd %5 %223 %224
-%227 = OpULessThan %74 %223 %225
-%228 = OpSelect %5 %227 %226 %77
-%229 = OpAccessChain %78 %40 %37 %228
-OpStore %229 %217
-%231 = OpIAdd %5 %228 %50
-%230 = OpAccessChain %78 %40 %37 %231
-OpStore %230 %218
-%233 = OpIAdd %5 %228 %57
-%232 = OpAccessChain %78 %40 %37 %233
-OpStore %232 %219
-%234 = OpBitwiseAnd %11 %109 %89
-%235 = OpBitwiseAnd %11 %110 %90
-%236 = OpBitwiseAnd %11 %111 %91
-%237 = OpBitwiseOr %5 %115 %238
-%239 = OpIMul %5 %38 %117
-%241 = OpIAdd %5 %239 %240
-%242 = OpCompositeExtract %5 %46 0
-%243 = OpCompositeExtract %5 %46 1
-%244 = OpIAdd %5 %241 %242
-%245 = OpULessThan %74 %241 %243
-%246 = OpSelect %5 %245 %244 %77
-%247 = OpAccessChain %78 %40 %37 %246
-OpStore %247 %234
-%249 = OpIAdd %5 %246 %50
-%248 = OpAccessChain %78 %40 %37 %249
-OpStore %248 %235
-%251 = OpIAdd %5 %246 %57
-%250 = OpAccessChain %78 %40 %37 %251
-OpStore %250 %236
-%252 = OpIMul %5 %38 %117
-%253 = OpIMul %5 %38 %42
-%263 = OpFunctionCall %5 %257 %253 %264
-%265 = OpCompositeExtract %5 %67 0
-%266 = OpCompositeExtract %5 %67 1
-%267 = OpIAdd %5 %263 %265
-%268 = OpULessThan %74 %263 %266
-%269 = OpSelect %5 %268 %267 %77
-%270 = OpAccessChain %78 %63 %37 %269
-%271 = OpLoad %11 %270
-%273 = OpIAdd %5 %269 %50
-%272 = OpAccessChain %78 %63 %37 %273
-%274 = OpLoad %11 %272
-%276 = OpCompositeConstruct %275 %271 %274
-%277 = OpCompositeExtract %11 %276 0
-%278 = OpCompositeExtract %11 %276 1
-%279 = OpFunctionCall %5 %257 %38 %264
-%280 = OpCompositeExtract %5 %61 0
-%281 = OpCompositeExtract %5 %61 1
-%282 = OpIAdd %5 %279 %280
-%283 = OpULessThan %74 %279 %281
-%284 = OpSelect %5 %283 %282 %77
-%285 = OpAccessChain %78 %56 %37 %284
-OpStore %285 %277
-%287 = OpIAdd %5 %284 %50
-%286 = OpAccessChain %78 %56 %37 %287
-OpStore %286 %278
-%289 = OpIAdd %5 %284 %57
-%288 = OpAccessChain %78 %56 %37 %289
-OpStore %288 %91
+%162 = OpINotEqual %74 %109 %160
+%163 = OpSelect %11 %162 %109 %161
+%164 = OpUDiv %11 %89 %163
+%165 = OpSelect %11 %162 %164 %161
+%166 = OpINotEqual %74 %110 %160
+%167 = OpSelect %11 %166 %110 %161
+%168 = OpUDiv %11 %90 %167
+%169 = OpSelect %11 %166 %168 %161
+%170 = OpINotEqual %74 %111 %160
+%171 = OpSelect %11 %170 %111 %161
+%172 = OpUDiv %11 %91 %171
+%173 = OpSelect %11 %170 %172 %161
+%174 = OpBitwiseOr %5 %115 %42
+%175 = OpIMul %5 %38 %117
+%177 = OpIAdd %5 %175 %176
+%178 = OpCompositeExtract %5 %46 0
+%179 = OpCompositeExtract %5 %46 1
+%180 = OpIAdd %5 %177 %178
+%181 = OpULessThan %74 %177 %179
+%182 = OpSelect %5 %181 %180 %77
+%183 = OpAccessChain %78 %40 %37 %182
+OpStore %183 %165
+%185 = OpIAdd %5 %182 %50
+%184 = OpAccessChain %78 %40 %37 %185
+OpStore %184 %169
+%187 = OpIAdd %5 %182 %57
+%186 = OpAccessChain %78 %40 %37 %187
+OpStore %186 %173
+%188 = OpBitwiseAnd %11 %109 %189
+%190 = OpBitwiseAnd %11 %110 %189
+%191 = OpBitwiseAnd %11 %111 %189
+%192 = OpShiftLeftLogical %11 %89 %188
+%193 = OpShiftLeftLogical %11 %90 %190
+%194 = OpShiftLeftLogical %11 %91 %191
+%195 = OpBitwiseOr %5 %115 %196
+%197 = OpIMul %5 %38 %117
+%199 = OpIAdd %5 %197 %198
+%200 = OpCompositeExtract %5 %46 0
+%201 = OpCompositeExtract %5 %46 1
+%202 = OpIAdd %5 %199 %200
+%203 = OpULessThan %74 %199 %201
+%204 = OpSelect %5 %203 %202 %77
+%205 = OpAccessChain %78 %40 %37 %204
+OpStore %205 %192
+%207 = OpIAdd %5 %204 %50
+%206 = OpAccessChain %78 %40 %37 %207
+OpStore %206 %193
+%209 = OpIAdd %5 %204 %57
+%208 = OpAccessChain %78 %40 %37 %209
+OpStore %208 %194
+%210 = OpShiftRightLogical %11 %89 %188
+%211 = OpShiftRightLogical %11 %90 %190
+%212 = OpShiftRightLogical %11 %91 %191
+%213 = OpBitwiseOr %5 %115 %214
+%215 = OpIMul %5 %38 %117
+%217 = OpIAdd %5 %215 %216
+%218 = OpCompositeExtract %5 %46 0
+%219 = OpCompositeExtract %5 %46 1
+%220 = OpIAdd %5 %217 %218
+%221 = OpULessThan %74 %217 %219
+%222 = OpSelect %5 %221 %220 %77
+%223 = OpAccessChain %78 %40 %37 %222
+OpStore %223 %210
+%225 = OpIAdd %5 %222 %50
+%224 = OpAccessChain %78 %40 %37 %225
+OpStore %224 %211
+%227 = OpIAdd %5 %222 %57
+%226 = OpAccessChain %78 %40 %37 %227
+OpStore %226 %212
+%228 = OpShiftRightArithmetic %11 %89 %188
+%229 = OpShiftRightArithmetic %11 %90 %190
+%230 = OpShiftRightArithmetic %11 %91 %191
+%231 = OpBitwiseOr %5 %115 %70
+%232 = OpIMul %5 %38 %117
+%234 = OpIAdd %5 %232 %233
+%235 = OpCompositeExtract %5 %46 0
+%236 = OpCompositeExtract %5 %46 1
+%237 = OpIAdd %5 %234 %235
+%238 = OpULessThan %74 %234 %236
+%239 = OpSelect %5 %238 %237 %77
+%240 = OpAccessChain %78 %40 %37 %239
+OpStore %240 %228
+%242 = OpIAdd %5 %239 %50
+%241 = OpAccessChain %78 %40 %37 %242
+OpStore %241 %229
+%244 = OpIAdd %5 %239 %57
+%243 = OpAccessChain %78 %40 %37 %244
+OpStore %243 %230
+%245 = OpBitwiseAnd %11 %109 %89
+%246 = OpBitwiseAnd %11 %110 %90
+%247 = OpBitwiseAnd %11 %111 %91
+%248 = OpBitwiseOr %5 %115 %249
+%250 = OpIMul %5 %38 %117
+%252 = OpIAdd %5 %250 %251
+%253 = OpCompositeExtract %5 %46 0
+%254 = OpCompositeExtract %5 %46 1
+%255 = OpIAdd %5 %252 %253
+%256 = OpULessThan %74 %252 %254
+%257 = OpSelect %5 %256 %255 %77
+%258 = OpAccessChain %78 %40 %37 %257
+OpStore %258 %245
+%260 = OpIAdd %5 %257 %50
+%259 = OpAccessChain %78 %40 %37 %260
+OpStore %259 %246
+%262 = OpIAdd %5 %257 %57
+%261 = OpAccessChain %78 %40 %37 %262
+OpStore %261 %247
+%263 = OpIMul %5 %38 %117
+%264 = OpIMul %5 %38 %42
+%274 = OpFunctionCall %5 %268 %264 %275
+%276 = OpCompositeExtract %5 %67 0
+%277 = OpCompositeExtract %5 %67 1
+%278 = OpIAdd %5 %274 %276
+%279 = OpULessThan %74 %274 %277
+%280 = OpSelect %5 %279 %278 %77
+%281 = OpAccessChain %78 %63 %37 %280
+%282 = OpLoad %11 %281
+%284 = OpIAdd %5 %280 %50
+%283 = OpAccessChain %78 %63 %37 %284
+%285 = OpLoad %11 %283
+%287 = OpCompositeConstruct %286 %282 %285
+%288 = OpCompositeExtract %11 %287 0
+%289 = OpCompositeExtract %11 %287 1
+%290 = OpFunctionCall %5 %268 %38 %275
+%291 = OpCompositeExtract %5 %61 0
+%292 = OpCompositeExtract %5 %61 1
+%293 = OpIAdd %5 %290 %291
+%294 = OpULessThan %74 %290 %292
+%295 = OpSelect %5 %294 %293 %77
+%296 = OpAccessChain %78 %56 %37 %295
+OpStore %296 %288
+%298 = OpIAdd %5 %295 %50
+%297 = OpAccessChain %78 %56 %37 %298
+OpStore %297 %289
+%300 = OpIAdd %5 %295 %57
+%299 = OpAccessChain %78 %56 %37 %300
+OpStore %299 %91
 OpReturn
 OpFunctionEnd
-%257 = OpFunction %5 None %254
-%255 = OpFunctionParameter %5
-%256 = OpFunctionParameter %5
-%258 = OpLabel
-%259 = OpUDiv %5 %260 %256
-%261 = OpBitwiseAnd %5 %255 %259
-OpReturnValue %261
+%268 = OpFunction %5 None %265
+%266 = OpFunctionParameter %5
+%267 = OpFunctionParameter %5
+%269 = OpLabel
+%270 = OpUDiv %5 %271 %267
+%272 = OpBitwiseAnd %5 %266 %270
+OpReturnValue %272
 OpFunctionEnd
 #endif


### PR DESCRIPTION
Well, as we found out, we actually need to implement DXBC behaviour here, whereas signed division by 0 is just UB even at the IR level. Doesn't change any generated code if the divisor is a literal scalar constant, which should hopefully keep changed shaders in check.

Haven't found a great way to emit helper functions so I just went with the "replace divisor" approach, which drivers should hopefully be able to optimize out given that the pattern is basically `b != 0 ? a / (b != 0 ? b : -1) : -1`.